### PR TITLE
Use ssh credentials in Git pull step

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,27 @@ it in ocp environment. After an operator is installed a pre-flight tests are exe
 that validates that operator meets minimum requirements for Red Hat OpenShift Certification.
 If tests pass a CI pipeline submits a PR for full operator certification workflow.
 
-To trigger a CI pipeline follow steps bellow:
 
+Since CI pipeline needs to make some changes in git repository (for example digest pinning)
+the pipeline requires a write access to provided git repository. Before running a pipeline
+user needs to upload ssh secret key to a cluster where the pipeline will run.
+
+To create a required secret run following command:
+```bash
+cat << EOF > ssh-secret.yml
+kind: Secret
+apiVersion: v1
+metadata:
+  name: my-ssh-credentials
+data:
+  id_rsa: |
+    < PRIVATE SSH KEY >
+EOF
+
+oc create -f ssh-secret.yml
+```
+
+To trigger a CI pipeline follow steps bellow:
 ```bash
 oc apply -R -f pipelines
 oc apply -R -f tasks
@@ -20,5 +39,6 @@ tkn pipeline start operator-ci-pipeline \
   --param git_revision=master \
   --param bundle_path=operators/kogito-operator/1.6.0 \
   --workspace name=pipeline,volumeClaimTemplateFile=test/workspace-template.yml \
+  --workspace name=ssh-dir,secret=my-ssh-credentials \
   --showlog
 ```

--- a/pipelines/operator-ci-pipeline.yml
+++ b/pipelines/operator-ci-pipeline.yml
@@ -13,6 +13,7 @@ spec:
       default: default-route-openshift-image-registry.apps-crc.testing
   workspaces:
     - name: pipeline
+    - name: ssh-dir
   tasks:
     - name: checkout
       taskRef:
@@ -27,6 +28,8 @@ spec:
         - name: output
           workspace: pipeline
           subPath: src
+        - name: ssh-directory
+          workspace: ssh-dir
 
     - name: digest-pinning
       runAfter:


### PR DESCRIPTION
SSH credentials are used when pulling private repository with a write
access. User needs to upload ssh before running the CI pipeline.

JIRA: ISV-847
Signed-off-by: Ales Raszka <araszka@redhat.com>