### PR TITLE
Compute md5sum of submitted bundle

### DIFF
--- a/pipelines/operator-ci-pipeline.yml
+++ b/pipelines/operator-ci-pipeline.yml
@@ -83,10 +83,23 @@ spec:
           workspace: pipeline
           subPath: src
 
-    - name: dockerfile-creation
+    - name: content-hash
       runAfter:
         - validation
         - yaml-lint
+      taskRef:
+        name: content-hash
+      params:
+        - name: bundle_path
+          value: "$(params.bundle_path)"
+      workspaces:
+        - name: source
+          workspace: pipeline
+          subPath: src
+
+    - name: dockerfile-creation
+      runAfter:
+        - content-hash
       taskRef:
         name: dockerfile-creation
       params:

--- a/tasks/content-hash.yml
+++ b/tasks/content-hash.yml
@@ -1,0 +1,30 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: content-hash
+spec:
+  params:
+    - name: bundle_path
+  results:
+    - name: md5sum
+  workspaces:
+    - name: source
+  steps:
+    - name: compute-md5sum
+      image: quay.io/redhat-isv/operator-pipelines-images:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        #! /usr/bin/env bash
+        set -xe
+        echo "Compute md5hash of bundle content..."
+
+        find $(params.bundle_path) -not -name "Dockerfile" -type f -printf '%f\t%p\n' | \
+          sort -V -k1 | \
+          cut -d$'\t' -f2 | \
+          tr '\n' '\0' | \
+          xargs -r0 -I {} md5sum "{}" >> hashes.txt
+
+        cat hashes.txt
+
+        md5sum hashes.txt | awk '{ print $1 }' | tee $(results.md5sum.path)


### PR DESCRIPTION
Content of all files related to operator bundle is hashed using mf5sum.
The sum is used to identity if content is still the same as was
submitted together with artifacts and test results.

JIRA: ISV-905