### PR TITLE
Allow private registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ To trigger a CI pipeline follow steps below:
 oc apply -R -f pipelines/operator-ci-pipeline.yml
 oc apply -R -f tasks
 
-# Install external yaml-lint task
+# Install external dependencies
 curl https://raw.githubusercontent.com/tektoncd/catalog/main/task/yaml-lint/0.1/yaml-lint.yaml | oc apply -f -
+curl https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.4/git-clone.yaml | oc apply -f -
 
 
 tkn pipeline start operator-ci-pipeline \
@@ -83,8 +84,9 @@ To trigger a Hosted pipeline follow steps below:
 oc apply -R -f pipelines/operator-hosted-pipeline.yml
 oc apply -R -f tasks
 
-# Install external yaml-lint task
+# Install external dependencies
 curl https://raw.githubusercontent.com/tektoncd/catalog/main/task/yaml-lint/0.1/yaml-lint.yaml | oc apply -f -
+curl https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.4/git-clone.yaml | oc apply -f -
 
 tkn pipeline start operator-hosted-pipeline \
   --param git_pr_branch=main \

--- a/pipelines/operator-ci-pipeline.yml
+++ b/pipelines/operator-ci-pipeline.yml
@@ -21,7 +21,7 @@ spec:
     - name: checkout
       taskRef:
         name: git-clone
-        kind: ClusterTask
+        kind: Task
       params:
         - name: url
           value: $(params.git_repo_url)

--- a/pipelines/operator-ci-pipeline.yml
+++ b/pipelines/operator-ci-pipeline.yml
@@ -16,6 +16,7 @@ spec:
   workspaces:
     - name: pipeline
     - name: ssh-dir
+    - name: registry-credentials
   tasks:
     - name: checkout
       taskRef:
@@ -120,8 +121,10 @@ spec:
       runAfter:
         - dockerfile-creation
       taskRef:
+        # custom task that supports auth
+        # TODO: try push auth changes to upstream
         name: buildah
-        kind: ClusterTask
+        kind: Task
       params:
         - name: IMAGE
           value: &bundleImage "$(params.registry)/$(params.image_stream)/$(tasks.operator-validation.results.package_name):$(tasks.operator-validation.results.bundle_version)"
@@ -131,6 +134,8 @@ spec:
         - name: source
           workspace: pipeline
           subPath: src
+        - name: credentials
+          workspace: registry-credentials
 
     # Index image contains a record of bundle images from which
     # manifests could be extract in order to install an operator.
@@ -152,7 +157,7 @@ spec:
         - generate-index
       taskRef:
         name: buildah
-        kind: ClusterTask
+        kind: Task
       params:
         - name: IMAGE
           value: &bundleIndexImage "$(params.registry)/$(params.image_stream)/$(tasks.operator-validation.results.package_name)-index:$(tasks.operator-validation.results.bundle_version)"
@@ -164,6 +169,8 @@ spec:
         - name: source
           workspace: pipeline
           subPath: src
+        - name: credentials
+          workspace: registry-credentials
 
     - name: ocp-environment-preparation
       runAfter:

--- a/pipelines/operator-hosted-pipeline.yml
+++ b/pipelines/operator-hosted-pipeline.yml
@@ -26,7 +26,7 @@ spec:
     - name: checkout
       taskRef:
         name: git-clone
-        kind: ClusterTask
+        kind: Task
       params:
         - name: url
           value: $(params.git_repo_url)

--- a/tasks/buildah.yml
+++ b/tasks/buildah.yml
@@ -1,0 +1,86 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: buildah
+spec:
+  description: |-
+    Buildah task builds source into a container image and then pushes it to a container registry.
+    Buildah Task builds source into a container image using Project Atomic's Buildah build tool.It uses Buildah's support for building from Dockerfiles, using its buildah bud command.This command executes the directives in the Dockerfile to assemble a container image, then pushes that image to a container registry.
+  params:
+    - description: Reference of the image buildah will produce.
+      name: IMAGE
+      type: string
+    - default: registry.redhat.io/rhel8/buildah@sha256:6a68ece207bc5fd8db2dd5cc2d0b53136236fb5178eb5b71eebe5d07a3c33d13
+      description: The location of the buildah builder image.
+      name: BUILDER_IMAGE
+      type: string
+    - default: vfs
+      description: Set buildah storage driver
+      name: STORAGE_DRIVER
+      type: string
+    - default: ./Dockerfile
+      description: Path to the Dockerfile to build.
+      name: DOCKERFILE
+      type: string
+    - default: .
+      description: Path to the directory to use as context.
+      name: CONTEXT
+      type: string
+    - default: "true"
+      description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+        registry)
+      name: TLSVERIFY
+      type: string
+    - default: oci
+      description: The format of the built container, oci or docker
+      name: FORMAT
+      type: string
+    - default: ""
+      description: Extra parameters passed for the build command when building images.
+      name: BUILD_EXTRA_ARGS
+      type: string
+    - default: ""
+      description: Extra parameters passed for the push command when pushing images.
+      name: PUSH_EXTRA_ARGS
+      type: string
+  results:
+    - description: Digest of the image just built.
+      name: IMAGE_DIGEST
+  steps:
+    - image: $(params.BUILDER_IMAGE)
+      name: build
+      resources: {}
+      script: |
+        buildah --storage-driver=$(params.STORAGE_DRIVER) bud \
+          $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
+          --tls-verify=$(params.TLSVERIFY) --no-cache \
+          -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+      workingDir: $(workspaces.source.path)
+    - image: $(params.BUILDER_IMAGE)
+      name: push
+      resources: {}
+      # Added authfile argument to support private registries
+      script: |
+        buildah --storage-driver=$(params.STORAGE_DRIVER) push \
+          $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
+          --authfile $(workspaces.credentials.path)/.dockerconfigjson \
+          --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+          docker://$(params.IMAGE)
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+      workingDir: $(workspaces.source.path)
+    - image: $(params.BUILDER_IMAGE)
+      name: digest-to-results
+      resources: {}
+      script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+  volumes:
+    - emptyDir: {}
+      name: varlibcontainers
+  workspaces:
+    - name: source
+    - name: credentials


### PR DESCRIPTION
The CI pipeline is not capable to push to a private registry using
provided credentials.

The original buildah task doesn't support a custom registry credentials
stored as "dockerconfigjson" so this commit adds a custom temporary
buildah task that use a secret workspace with token.
    
JIRA: ISV-855

This PR also replace git-clone ClusterTask with a Task.