### PR TITLE
Update pin manifest digest step

### DIFF
--- a/pipelines/operator-ci-pipeline.yml
+++ b/pipelines/operator-ci-pipeline.yml
@@ -13,6 +13,11 @@ spec:
       default: default-route-openshift-image-registry.apps-crc.testing
     - name: image_stream
       default: $(context.pipelineRun.namespace)
+    - name: test_mode
+      description: The test mode flag skips certain steps to make a pipeline
+        faster for rapid operator development. The flag needs to be set to false
+        for a full CI pipeline run and certification pull-request submission.
+      default: "false"
   workspaces:
     - name: pipeline
     - name: ssh-dir
@@ -42,6 +47,8 @@ spec:
       params:
         - name: bundle_path
           value: "$(params.bundle_path)"
+        - name: skip
+          value: "$(params.test_mode)"
       workspaces:
         - name: source
           workspace: pipeline

--- a/tasks/digest-pinning.yml
+++ b/tasks/digest-pinning.yml
@@ -6,6 +6,7 @@ metadata:
 spec:
   params:
     - name: bundle_path
+    - name: skip
   results:
     - name: dirty_flag
   workspaces:
@@ -18,8 +19,20 @@ spec:
         #! /usr/bin/env bash
         set -xe
 
+        if [ "$(params.skip)" == "true" ]; then
+          echo "Skip flag is set. Skipping digest pinning..."
+          echo "false" | tee $(results.dirty_flag.path)
+          exit 0
+        fi
+
         BUNDLE_PATH=$(realpath $(params.bundle_path))
         ls -l $BUNDLE_PATH
         operator-manifest pin $BUNDLE_PATH
 
-        echo "true" | tee $(results.dirty_flag.path)
+        if [[ $(git diff --stat) != '' ]]; then
+          echo "Manifests were not pinned."
+          echo "true" | tee $(results.dirty_flag.path)
+        else
+          echo "Manifests are pinned."
+          echo "false" | tee $(results.dirty_flag.path)
+        fi


### PR DESCRIPTION
The pinning step returns a dirty flag based on if there are any changes
in manifest references. The pinning step can be also skipped by setting
pipeline test_mode parameter.

JIRA: ISV-849