### PR TITLE
Non-permissive additive index generation

### DIFF
--- a/pipelines/operator-ci-pipeline.yml
+++ b/pipelines/operator-ci-pipeline.yml
@@ -147,10 +147,14 @@ spec:
       params:
         - name: bundle_image
           value: *bundleImage
+        - name: from_index
+          value: "$(tasks.operator-validation.results.max_supported_index)"
       workspaces:
-        - name: source
+        - name: output
           workspace: pipeline
-          subPath: src
+          subPath: index
+        - name: credentials
+          workspace: registry-credentials
 
     - name: build-index
       runAfter:
@@ -161,14 +165,12 @@ spec:
       params:
         - name: IMAGE
           value: &bundleIndexImage "$(params.registry)/$(params.image_stream)/$(tasks.operator-validation.results.package_name)-index:$(tasks.operator-validation.results.bundle_version)"
-        - name: CONTEXT
-          value: "$(params.bundle_path)"
-        # - name: DOCKERFILE
-        #   value: "Dockerfile.index"
+        - name: DOCKERFILE
+          value: "$(tasks.generate-index.results.index_dockerfile)"
       workspaces:
         - name: source
           workspace: pipeline
-          subPath: src
+          subPath: index
         - name: credentials
           workspace: registry-credentials
 

--- a/pipelines/operator-hosted-pipeline.yml
+++ b/pipelines/operator-hosted-pipeline.yml
@@ -21,6 +21,7 @@ spec:
   workspaces:
     - name: repository
     - name: results
+    - name: registry-credentials
   tasks:
     # Git clone
     - name: checkout
@@ -198,10 +199,14 @@ spec:
       params:
         - name: bundle_image
           value: *bundleImage
+        - name: from_index
+          value: "$(tasks.operator-validation.results.max_supported_index)"
       workspaces:
-        - name: source
+        - name: output
           workspace: repository
-          subPath: src
+          subPath: index
+        - name: credentials
+          workspace: registry-credentials
 
     - name: build-index
       runAfter:

--- a/tasks/generate-index.yml
+++ b/tasks/generate-index.yml
@@ -6,29 +6,36 @@ metadata:
 spec:
   params:
     - name: bundle_image
+      description: Pull spec of a bundle image
+    - name: from_index
+      description: Parent index image the bundle will be added to
   results:
     - name: index_dockerfile
+      description: Path to the generated index Dockerfile
   workspaces:
-    - name: source
+    - name: output
+    - name: credentials
+      description: Docker config for retrieving the parent index image and bundle image
   steps:
     - name: generate
-      image: quay.io/amisstea/operator-pipeline-tools:latest
-      workingDir: $(workspaces.source.path)
+      image: quay.io/redhat-isv/operator-pipelines-images:latest
+      workingDir: $(workspaces.output.path)
       script: |
         #! /usr/bin/env bash
         set -xe
 
-        # TODO should --from-index be specified?
-        # --permissive is used to overcome errors about the missing bundles
-        # this one replaces.
+        # OPM needs the standard docker config directory structure
+        export DOCKER_CONFIG=/tmp/.docker
+        mkdir $DOCKER_CONFIG
+        cp $(workspaces.credentials.path)/.dockerconfigjson $DOCKER_CONFIG/config.json
+
         opm index add \
-          --bundles $(params.bundle_image) \
+          --from-index "$(params.from_index)" \
+          --bundles "$(params.bundle_image)" \
           --container-tool none \
           --out-dockerfile Dockerfile.index \
-          --generate \
-          --skip-tls \
-          --permissive
+          --generate
 
-        ls -l
+        ls -lh
         cat Dockerfile.index
-        echo Dockerfile.index | tee $(results.index_dockerfile.path)
+        echo -n Dockerfile.index | tee $(results.index_dockerfile.path)

--- a/tasks/operator-validation.yml
+++ b/tasks/operator-validation.yml
@@ -37,8 +37,14 @@ spec:
 
         VERSION_INFO=$(ocp-version-info $(params.bundle_path))
         echo $VERSION_INFO | jq
-        echo $VERSION_INFO | jq -r '.max_version_index.ocp_version' | tee $(results.max_supported_ocp_version.path)
-        echo $VERSION_INFO | jq -r '.max_version_index.path' | tee $(results.max_supported_index.path)
+        echo $VERSION_INFO \
+          | jq -r '.max_version_index.ocp_version' \
+          | tr -d '\n\r' \
+          | tee $(results.max_supported_ocp_version.path)
+        echo $VERSION_INFO \
+          | jq -r '.max_version_index.path' \
+          | tr -d '\n\r' \
+          | tee $(results.max_supported_index.path)
 
     - name: certification-project-check
       image: quay.io/redhat-isv/operator-pipelines-images:latest

--- a/templates/workspace-template.yml
+++ b/templates/workspace-template.yml
@@ -4,4 +4,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: 5Gi


### PR DESCRIPTION
The index generation task needs creds to pull from all private registries.
This requires the user to provide the terms-based registry creds
themselves rather than using the cluster-scoped secret because they
aren't accessible to OPM inside the container.