### PR TITLE
Upload preflight test artifacts and results

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ EOF
 oc create -f my-registry-secret.yml
 ```
 
+#### Container API access
+CI pipelines automatically upload a test results, logs and artifacts using Red Hat
+container API. This requires a partner's API key and the key needs to be created
+as a secret in openshift cluster before running a Tekton pipeline.
+
+```bash
+oc create secret generic pyxis-api-secret --from-literal PYXIS_API_KEY=< API KEY >
+```
 ### Installation
 ```bash
 oc apply -R -f pipelines/operator-ci-pipeline.yml
@@ -114,7 +122,7 @@ tkn pipeline start operator-hosted-pipeline \
   --param git_username=test_user \
   --param pr_head_label=MarcinGinszt:test-PR-ok \
   --param bundle_path=operators/kogito-operator/1.6.1-ok \
-  --param pyxis_url=https://catalog.redhat.com/api/containers \
+  --param pyxis_url=https://catalog.redhat.com/api/containers/ \
   --param preflight_min_version=1.0.0 \
   --param ci_min_version=1.0.0 \
   --workspace name=repository,volumeClaimTemplateFile=templates/workspace-template.yml \

--- a/pipelines/operator-ci-pipeline.yml
+++ b/pipelines/operator-ci-pipeline.yml
@@ -10,6 +10,8 @@ spec:
     - name: bundle_path
     - name: registry
       default: default-route-openshift-image-registry.apps-crc.testing
+    - name: pyxis_url
+      default: https://catalog.redhat.com/api/containers/
     - name: image_stream
       default: $(context.pipelineRun.namespace)
     - name: test_mode
@@ -87,6 +89,8 @@ spec:
       params:
         - name: bundle_path
           value: "$(params.bundle_path)"
+        - name: pyxis_url
+          value: "$(params.pyxis_url)"
       workspaces:
         - name: source
           workspace: pipeline
@@ -212,14 +216,22 @@ spec:
       taskRef:
         name: upload-artifacts
       params:
-        - name: pyxis_api_key
-          value: foo
         - name: log_file
           value: "$(tasks.preflight.results.log_output_file)"
+        - name: artifacts_dir
+          value: "$(tasks.preflight.results.artifacts_output_dir)"
         - name: result_file
           value: "$(tasks.preflight.results.result_output_file)"
         - name: md5sum
           value: "$(tasks.content-hash.results.md5sum)"
+        - name: cert_project_id
+          value: "$(tasks.operator-validation.results.certification_project_id)"
+        - name: bundle_version
+          value: "$(tasks.operator-validation.results.bundle_version)"
+        - name: package_name
+          value: "$(tasks.operator-validation.results.package_name)"
+        - name: pyxis_url
+          value: "$(params.pyxis_url)"
       workspaces:
         - name: source
           workspace: pipeline

--- a/pipelines/operator-hosted-pipeline.yml
+++ b/pipelines/operator-hosted-pipeline.yml
@@ -80,6 +80,8 @@ spec:
       params:
         - name: bundle_path
           value: "$(params.bundle_path)"
+        - name: pyxis_url
+          value: "$(params.pyxis_url)"
       workspaces:
         - name: source
           workspace: repository
@@ -302,16 +304,24 @@ spec:
       taskRef:
         name: upload-artifacts
       params:
-        - name: pyxis_api_key
-          value: foo
-        - name: log_file
-          value: "$(tasks.preflight.results.log_output_file)"
-        - name: result_file
-          value: "$(tasks.preflight.results.result_output_file)"
         - name: preflight_results_exists
           value: "$(tasks.get-ci-results-attempt.results.preflight_results_exists)"
+        - name: log_file
+          value: "$(tasks.preflight.results.log_output_file)"
+        - name: artifacts_dir
+          value: "$(tasks.preflight.results.artifacts_output_dir)"
+        - name: result_file
+          value: "$(tasks.preflight.results.result_output_file)"
         - name: md5sum
           value: "$(tasks.content-hash.results.md5sum)"
+        - name: cert_project_id
+          value: "$(tasks.operator-validation.results.certification_project_id)"
+        - name: bundle_version
+          value: "$(tasks.operator-validation.results.bundle_version)"
+        - name: package_name
+          value: "$(tasks.operator-validation.results.package_name)"
+        - name: pyxis_url
+          value: "$(params.pyxis_url)"
       workspaces:
         - name: source
           workspace: repository

--- a/tasks/digest-pinning.yml
+++ b/tasks/digest-pinning.yml
@@ -22,7 +22,7 @@ spec:
 
         if [ "$(params.skip)" == "true" ]; then
           echo "Skip flag is set. Skipping digest pinning..."
-          echo "false" | tee $(results.dirty_flag.path)
+          echo -n "false" | tee $(results.dirty_flag.path)
           exit 0
         fi
 
@@ -32,8 +32,8 @@ spec:
 
         if [[ $(git diff --stat) != '' ]]; then
           echo "Manifests were not pinned."
-          echo "true" | tee $(results.dirty_flag.path)
+          echo -n "true" | tee $(results.dirty_flag.path)
         else
           echo "Manifests are pinned."
-          echo "false" | tee $(results.dirty_flag.path)
+          echo -n "false" | tee $(results.dirty_flag.path)
         fi

--- a/tasks/get-ci-results-attempt.yml
+++ b/tasks/get-ci-results-attempt.yml
@@ -21,4 +21,4 @@ spec:
         #! /usr/bin/env bash
         # Curl Pyxis results endpoint
         # If results exists, store them in the workspace
-        echo "true" | tee $(results.preflight_results_exists.path)
+        echo -n "true" | tee $(results.preflight_results_exists.path)

--- a/tasks/operator-validation.yml
+++ b/tasks/operator-validation.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: bundle_path
     - name: pyxis_url
-      default: https://catalog.redhat.com/api/containers
+      default: https://catalog.redhat.com/api/containers/
   results:
     - name: package_name
       description: Operator package name
@@ -64,7 +64,7 @@ spec:
           exit 1
         fi
 
-        echo $CERT_PROJECT_ID | tee $(results.certification_project_id.path)
+        echo -n $CERT_PROJECT_ID | tee $(results.certification_project_id.path)
 
     - name: bundle-parse
       image: quay.io/redhat-isv/operator-pipelines-images:latest

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -10,24 +10,31 @@ spec:
   results:
     - name: log_output_file
     - name: result_output_file
+    - name: artifacts_output_dir
   workspaces:
     - name: source
   steps:
     - name: preflight-tests
-      image: registry.access.redhat.com/ubi8-minimal
+      image: quay.io/redhat-isv/operator-pipelines-images:latest
       workingDir: $(workspaces.source.path)
       script: |
         #! /usr/bin/env bash
         PREFLIGHT_RESULTS_EXISTS="$(params.preflight_results_exists)"
         if [ $PREFLIGHT_RESULTS_EXISTS == "true" ]; then
           echo "Preflight results already exists- skipping"
-          echo "none" | tee $(results.log_output_file.path)
-          echo "none" | tee $(results.result_output_file.path)
+          echo -n "none" | tee $(results.log_output_file.path)
+          echo -n "none" | tee $(results.result_output_file.path)
           exit 0
         fi
 
         echo "Testing"
 
-        touch output.log results.json
-        echo output.log | tee $(results.log_output_file.path)
-        echo results.json | tee $(results.result_output_file.path)
+        # Temporary test data
+        ls -l
+        cp -r /home/user/tests/data/* .
+        ls -l
+
+
+        echo -n preflight.log | tee $(results.log_output_file.path)
+        echo -n results.json | tee $(results.result_output_file.path)
+        echo -n artifacts | tee $(results.artifacts_output_dir.path)

--- a/tasks/upload-artifact.yml
+++ b/tasks/upload-artifact.yml
@@ -5,23 +5,34 @@ metadata:
   name: upload-artifacts
 spec:
   params:
-    - name: pyxis_api_key
+    - name: pyxis_api_key_secret
+      default: pyxis-api-secret
     - name: pyxis_url
-      default: https://catalog.redhat.com/api/containers
+      default: https://catalog.redhat.com/api/containers/
     - name: log_file
     - name: result_file
+    - name: artifacts_dir
     - name: preflight_results_exists
       default: "false"
     - name: md5sum
+    - name: cert_project_id
+    - name: bundle_version
+    - name: package_name
   results:
     - name: log_url
     - name: result_url
   workspaces:
     - name: source
   steps:
-    - name: upload-test-logs
-      image: registry.access.redhat.com/ubi8-minimal
+    - name: upload-test-artifacts-and-logs
+      image: quay.io/redhat-isv/operator-pipelines-images:latest
       workingDir: $(workspaces.source.path)
+      env:
+        - name: PYXIS_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pyxis_api_key_secret)
+              key: PYXIS_API_KEY
       script: |
         #! /usr/bin/env bash
         PREFLIGHT_RESULTS_EXISTS="$(params.preflight_results_exists)"
@@ -31,22 +42,30 @@ spec:
           exit 0
         fi
 
-        echo "Uploading testing logs $(params.log_file)"
+        echo "Uploading test results and artifacts"
 
-        echo https://foo.com/logs/123 | tee $(results.log_url.path)
+        upload-artifacts \
+          --cert-project-id "$(params.cert_project_id)" \
+          --operator-version "$(params.bundle_version)" \
+          --operator-package-name "$(params.package_name)" \
+          --certification-hash "$(params.md5sum)" \
+          --pyxis-url "$(params.pyxis_url)" \
+          --artifacts-dir "$(params.artifacts_dir)" \
+          --log-file "$(params.log_file)" \
+          --result-file "$(params.result_file)" \
+          --verbose
 
-    - name: upload-test-results
-      image: registry.access.redhat.com/ubi8-minimal
-      workingDir: $(workspaces.source.path)
-      script: |
-        #! /usr/bin/env bash
-        PREFLIGHT_RESULTS_EXISTS="$(params.preflight_results_exists)"
-        if [ $PREFLIGHT_RESULTS_EXISTS == "true" ]; then
-          echo "Preflight results already exists- skipping"
-          echo "none" | tee $(results.result_url.path)
-          exit 0
-        fi
+        cat output.json | jq
 
-        echo "Uploading testing results $(params.result_file)"
+        LOG_ID=$(cat output.json | jq -r ".logs._id")
+        RESULTS_ID=$(cat output.json| jq -r ".test_results._id")
 
-        echo https://foo.com/results/123 | tee $(results.result_url.path)
+        LOG_URL="$(params.pyxis_url)v1/projects/certification/id/$(params.cert_project_id)/artifacts/$LOG_ID"
+        RESULT_URL="$(params.pyxis_url)v1/projects/certification/id/$(params.cert_project_id)/test-results/$RESULTS_ID"
+
+        echo "Test results URL:"
+        echo -n $RESULT_URL | tee $(results.result_url.path)
+
+        echo ""
+        echo "Logs URL: "
+        echo -n $LOG_URL | tee $(results.log_url.path)


### PR DESCRIPTION
The upload task reads a test results and artifacts and upload them using
Pyxis API to RH storage. This is later used by hosted pipeline to skip
preflight tests.

JIRA: ISV-883