### PR TITLE
Make use of imagestreams to pull index images

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ oc create -f registry-secret.yml
 
 The pipelines must pull the parent index images through the internal OpenShift
 registry to take advantage of the built-in credentials for Red Hat's terms-based
-registry (registry.redhat.io). The saves the user from needing to provide such
+registry (registry.redhat.io). This saves the user from needing to provide such
 credentials. The index generation task will always pull published index images
 through imagestreams of the same name in the current namespace. As a result,
 there is a one time configuration for each desired distribution catalog.
@@ -99,7 +99,18 @@ curl https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.4/
 ```
 
 ### Execution
-The CI pipeline can be triggered using the tkn CLI like so:
+If using the default internal registry, the CI pipeline can be triggered using the tkn CLI like so:
+
+```bash
+tkn pipeline start operator-ci-pipeline \
+  --param git_repo_url=git@github.com:redhat-openshift-ecosystem/operator-pipelines-test.git \
+  --param git_revision=main \
+  --param bundle_path=operators/kogito-operator/1.6.0-ok \
+  --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
+  --workspace name=ssh-dir,secret=my-ssh-credentials \
+  --showlog
+```
+If using an external registry, the CI pipeline can be triggered using the tkn CLI like so:
 
 ```bash
 tkn pipeline start operator-ci-pipeline \
@@ -107,7 +118,7 @@ tkn pipeline start operator-ci-pipeline \
   --param git_revision=main \
   --param bundle_path=operators/kogito-operator/1.6.0-ok \
   --param registry=quay.io \
-  --param image_stream=redhat-isv \
+  --param image_namespace=redhat-isv \
   --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
   --workspace name=ssh-dir,secret=my-ssh-credentials \
   --workspace name=registry-credentials,secret=my-registry-secret \

--- a/pipelines/operator-ci-pipeline.yml
+++ b/pipelines/operator-ci-pipeline.yml
@@ -9,7 +9,7 @@ spec:
     - name: git_revision
     - name: bundle_path
     - name: registry
-      default: default-route-openshift-image-registry.apps-crc.testing
+      default: image-registry.openshift-image-registry.svc:5000
     - name: pyxis_url
       default: https://catalog.redhat.com/api/containers/
     - name: image_stream
@@ -23,6 +23,7 @@ spec:
     - name: pipeline
     - name: ssh-dir
     - name: registry-credentials
+      optional: true
   tasks:
     - name: checkout
       taskRef:

--- a/pipelines/operator-ci-pipeline.yml
+++ b/pipelines/operator-ci-pipeline.yml
@@ -12,8 +12,9 @@ spec:
       default: image-registry.openshift-image-registry.svc:5000
     - name: pyxis_url
       default: https://catalog.redhat.com/api/containers/
-    - name: image_stream
+    - name: image_namespace
       default: $(context.pipelineRun.namespace)
+      description: The namespace/organization all built images will be pushed to.
     - name: test_mode
       description: The test mode flag skips certain steps to make a pipeline
         faster for rapid operator development. The flag needs to be set to false
@@ -153,7 +154,7 @@ spec:
         kind: Task
       params:
         - name: IMAGE
-          value: &bundleImage "$(params.registry)/$(params.image_stream)/$(tasks.operator-validation.results.package_name):$(tasks.operator-validation.results.bundle_version)"
+          value: &bundleImage "$(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name):$(tasks.operator-validation.results.bundle_version)"
         - name: CONTEXT
           value: "$(params.bundle_path)"
       workspaces:
@@ -190,7 +191,7 @@ spec:
         kind: Task
       params:
         - name: IMAGE
-          value: &bundleIndexImage "$(params.registry)/$(params.image_stream)/$(tasks.operator-validation.results.package_name)-index:$(tasks.operator-validation.results.bundle_version)"
+          value: &bundleIndexImage "$(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name)-index:$(tasks.operator-validation.results.bundle_version)"
         - name: DOCKERFILE
           value: "$(tasks.generate-index.results.index_dockerfile)"
       workspaces:

--- a/pipelines/operator-hosted-pipeline.yml
+++ b/pipelines/operator-hosted-pipeline.yml
@@ -19,8 +19,9 @@ spec:
     - name: ci_min_version
     - name: registry
       default: quay.io
-    - name: image_stream
+    - name: image_namespace
       default: $(context.pipelineRun.namespace)
+      description: The namespace/organization all built images will be pushed to.
   workspaces:
     - name: repository
     - name: results
@@ -206,7 +207,7 @@ spec:
         kind: ClusterTask
       params:
         - name: IMAGE
-          value: &bundleImage "$(params.registry)/$(params.image_stream)/$(tasks.operator-validation.results.package_name):$(tasks.operator-validation.results.bundle_version)"
+          value: &bundleImage "$(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name):$(tasks.operator-validation.results.bundle_version)"
         - name: CONTEXT
           value: "$(params.bundle_path)"
       workspaces:
@@ -243,7 +244,7 @@ spec:
         kind: ClusterTask
       params:
         - name: IMAGE
-          value: &bundleIndexImage "$(params.registry)/$(params.image_stream)/$(tasks.operator-validation.results.package_name)-index:$(tasks.operator-validation.results.bundle_version)"
+          value: &bundleIndexImage "$(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name)-index:$(tasks.operator-validation.results.bundle_version)"
         - name: CONTEXT
           value: "$(params.bundle_path)"
         # - name: DOCKERFILE

--- a/tasks/buildah.yml
+++ b/tasks/buildah.yml
@@ -65,9 +65,13 @@ spec:
       resources: {}
       # Added authfile argument to support private registries
       script: |
+        EXTRA_ARGS=""
+        if [[ "$(workspaces.credentials.bound)" == "true" ]]; then
+          EXTRA_ARGS+=" --authfile $(workspaces.credentials.path)/.dockerconfigjson"
+        fi
+
         buildah --storage-driver=$(params.STORAGE_DRIVER) push \
-          $(params.PUSH_EXTRA_ARGS) --tls-verify=$(params.TLSVERIFY) \
-          --authfile $(workspaces.credentials.path)/.dockerconfigjson \
+          $(params.PUSH_EXTRA_ARGS) $EXTRA_ARGS --tls-verify=$(params.TLSVERIFY) \
           --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
           docker://$(params.IMAGE)
       volumeMounts:
@@ -84,3 +88,4 @@ spec:
   workspaces:
     - name: source
     - name: credentials
+      optional: true

--- a/tasks/generate-index.yml
+++ b/tasks/generate-index.yml
@@ -9,13 +9,17 @@ spec:
       description: Pull spec of a bundle image
     - name: from_index
       description: Parent index image the bundle will be added to
+    - name: internal_registry
+      description: Host for the internal OpenShift registry
+      default: image-registry.openshift-image-registry.svc:5000
   results:
     - name: index_dockerfile
       description: Path to the generated index Dockerfile
   workspaces:
     - name: output
     - name: credentials
-      description: Docker config for retrieving the parent index image and bundle image
+      description: Docker config for retrieving the bundle image
+      optional: true
   steps:
     - name: generate
       image: quay.io/redhat-isv/operator-pipelines-images:latest
@@ -24,13 +28,23 @@ spec:
         #! /usr/bin/env bash
         set -xe
 
-        # OPM needs the standard docker config directory structure
-        export DOCKER_CONFIG=/tmp/.docker
-        mkdir $DOCKER_CONFIG
-        cp $(workspaces.credentials.path)/.dockerconfigjson $DOCKER_CONFIG/config.json
+        if [[ "$(workspaces.credentials.bound)" == "true" ]]; then
+          # Setup registry credentials for OPM. Combine the default credentials
+          # with those found in the workspace to maintain access to the internal
+          # registry.
+          export DOCKER_CONFIG=/tmp/.docker
+          mkdir $DOCKER_CONFIG
+          jq -s '.[0] * .[1]' \
+            $(workspaces.credentials.path)/.dockerconfigjson \
+            $HOME/.docker/config.json \
+            > $DOCKER_CONFIG/config.json
+        fi
+
+        INDEX_IMG_STREAM=$(echo $(params.from_index) | rev | cut -f1 -d/ | rev)
+        FROM_INDEX="$(params.internal_registry)/$(context.taskRun.namespace)/$INDEX_IMG_STREAM"
 
         opm index add \
-          --from-index "$(params.from_index)" \
+          --from-index $FROM_INDEX \
           --bundles "$(params.bundle_image)" \
           --container-tool none \
           --out-dockerfile Dockerfile.index \


### PR DESCRIPTION
This reduces the complexity for the user to get started because they no
longer need to specify credentials for the internal registry or
terms-based registry. The trade-off is the addition of two one-time
configuration commands.