### PR TITLE
Upload pipeline logs in CI pipeline

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -290,3 +290,21 @@ spec:
         - name: source
           workspace: pipeline
           subPath: src
+
+  finally:
+    - name: upload-pipeline-logs
+      taskRef:
+        name: upload-pipeline-logs
+      params:
+        - name: md5sum
+          value: "$(tasks.content-hash.results.md5sum)"
+        - name: cert_project_id
+          value: "$(tasks.certification-project-check.results.certification_project_id)"
+        - name: bundle_version
+          value: "$(tasks.operator-validation.results.bundle_version)"
+        - name: package_name
+          value: "$(tasks.operator-validation.results.package_name)"
+        - name: pyxis_url
+          value: "$(params.pyxis_url)"
+        - name: pipeline_name
+          value: "$(context.pipelineRun.name)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-artifact.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-artifact.yml
@@ -24,7 +24,7 @@ spec:
   workspaces:
     - name: source
   steps:
-    - name: upload-test-artifacts-and-logs
+    - name: upload-test-logs
       image: quay.io/redhat-isv/operator-pipelines-images:latest
       workingDir: $(workspaces.source.path)
       env:
@@ -37,12 +37,12 @@ spec:
         #! /usr/bin/env bash
         PREFLIGHT_RESULTS_EXISTS="$(params.preflight_results_exists)"
         if [ $PREFLIGHT_RESULTS_EXISTS == "true" ]; then
-          echo "Preflight results already exists- skipping"
+          echo "Preflight logs already exists - skipping"
           echo "none" | tee $(results.log_url.path)
           exit 0
         fi
 
-        echo "Uploading test results and artifacts"
+        echo "Uploading test log"
 
         upload-artifacts \
           --cert-project-id "$(params.cert_project_id)" \
@@ -50,22 +50,79 @@ spec:
           --operator-package-name "$(params.package_name)" \
           --certification-hash "$(params.md5sum)" \
           --pyxis-url "$(params.pyxis_url)" \
-          --artifacts-dir "$(params.artifacts_dir)" \
-          --log-file "$(params.log_file)" \
-          --result-file "$(params.result_file)" \
+          --path "$(params.log_file)" \
+          --type preflight-logs \
+          --output preflight-logs.json \
           --verbose
 
-        cat output.json | jq
+        LOG_ID=$(cat preflight-logs.json | jq -r "._id")
+        LOG_URL="$(params.pyxis_url)v1/projects/certification/artifacts/id/$LOG_ID"
 
-        LOG_ID=$(cat output.json | jq -r ".logs._id")
-        RESULTS_ID=$(cat output.json| jq -r ".test_results._id")
-
-        LOG_URL="$(params.pyxis_url)v1/projects/certification/id/$(params.cert_project_id)/artifacts/$LOG_ID"
-        RESULT_URL="$(params.pyxis_url)v1/projects/certification/id/$(params.cert_project_id)/test-results/$RESULTS_ID"
-
-        echo "Test results URL:"
-        echo -n $RESULT_URL | tee $(results.result_url.path)
-
-        echo ""
         echo "Logs URL: "
         echo -n $LOG_URL | tee $(results.log_url.path)
+
+    - name: upload-test-results
+      image: quay.io/redhat-isv/operator-pipelines-images:latest
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: PYXIS_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pyxis_api_key_secret)
+              key: PYXIS_API_KEY
+      script: |
+        #! /usr/bin/env bash
+        PREFLIGHT_RESULTS_EXISTS="$(params.preflight_results_exists)"
+        if [ $PREFLIGHT_RESULTS_EXISTS == "true" ]; then
+          echo "Preflight results already exists - skipping"
+          echo "none" | tee $(results.result_url.path)
+          exit 0
+        fi
+
+        echo "Uploading test results"
+
+        upload-artifacts \
+          --cert-project-id "$(params.cert_project_id)" \
+          --operator-version "$(params.bundle_version)" \
+          --operator-package-name "$(params.package_name)" \
+          --certification-hash "$(params.md5sum)" \
+          --pyxis-url "$(params.pyxis_url)" \
+          --path "$(params.result_file)" \
+          --type preflight-results \
+          --output preflight-results.json \
+          --verbose
+
+        RESULTS_ID=$(cat preflight-results.json| jq -r "._id")
+        RESULT_URL="$(params.pyxis_url)v1/projects/certification/id/$(params.cert_project_id)/test-results/$RESULTS_ID"
+
+        echo "Test result URL: "
+        echo -n $RESULT_URL | tee $(results.result_url.path)
+
+    - name: upload-test-artifacts
+      image: quay.io/redhat-isv/operator-pipelines-images:latest
+      workingDir: $(workspaces.source.path)
+      env:
+        - name: PYXIS_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pyxis_api_key_secret)
+              key: PYXIS_API_KEY
+      script: |
+        #! /usr/bin/env bash
+        PREFLIGHT_RESULTS_EXISTS="$(params.preflight_results_exists)"
+        if [ $PREFLIGHT_RESULTS_EXISTS == "true" ]; then
+          exit 0
+        fi
+
+        echo "Uploading test artifacts"
+
+        upload-artifacts \
+          --cert-project-id "$(params.cert_project_id)" \
+          --operator-version "$(params.bundle_version)" \
+          --operator-package-name "$(params.package_name)" \
+          --certification-hash "$(params.md5sum)" \
+          --pyxis-url "$(params.pyxis_url)" \
+          --path "$(params.artifacts_dir)" \
+          --type preflight-artifacts \
+          --output preflight-artifacts.json \
+          --verbose

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
@@ -1,0 +1,66 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: upload-pipeline-logs
+spec:
+  params:
+    - name: pyxis_api_key_secret
+      default: pyxis-api-secret
+      description: Secret name that contains container API key
+    - name: pyxis_url
+      default: https://catalog.redhat.com/api/containers/
+      description: Red Hat's container API URL
+    - name: md5sum
+      description: Operator content md5 hash
+    - name: cert_project_id
+      description: Certification project identifier
+    - name: bundle_version
+      description: Operator bundle version
+    - name: package_name
+      description: Operator package name
+    - name: pipeline_name
+      description: Tekton pipeline run name where logs will be gathered from
+  results:
+    - name: pipeline_log_url
+  steps:
+    - name: get-pipeline-logs
+      image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8:0.19.0-2
+      script: |
+        #! /usr/bin/env bash
+        set -xe
+
+        echo "Getting pipeline logs"
+
+        tkn pipelinerun logs "$(params.pipeline_name)" > pipeline.logs
+
+    - name: upload-pipeline-logs
+      image: quay.io/redhat-isv/operator-pipelines-images:latest
+      env:
+        - name: PYXIS_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pyxis_api_key_secret)
+              key: PYXIS_API_KEY
+      script: |
+        #! /usr/bin/env bash
+        echo "Uploading pipeline logs"
+        set -xe
+
+        upload-artifacts \
+          --cert-project-id "$(params.cert_project_id)" \
+          --operator-version "$(params.bundle_version)" \
+          --operator-package-name "$(params.package_name)" \
+          --certification-hash "$(params.md5sum)" \
+          --pyxis-url "$(params.pyxis_url)" \
+          --path pipeline.logs \
+          --type pipeline-logs \
+          --output pipeline-logs-artifact.json \
+          --verbose
+
+        LOG_ID=$(cat pipeline-logs-artifact.json | jq -r "._id")
+
+        LOG_URL="$(params.pyxis_url)v1/projects/certification/artifacts/id/$LOG_ID"
+
+        echo "Pipeline logs URL: "
+        echo -n $LOG_URL | tee $(results.pipeline_log_url.path)


### PR DESCRIPTION
CI pipeline uploads pipeline logs using a upload script + Pyxis API. The
upload step is defined in finally block so it is always executer no
matter if previous steps passed or failed.

JIRA: ISV-927