### PR TITLE
Upload pipeline logs in hosted pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,18 @@ container API. This requires a partner's API key and the key needs to be created
 as a secret in openshift cluster before running a Tekton pipeline.
 
 ```bash
-oc create secret generic pyxis-api-secret --from-literal PYXIS_API_KEY=< API KEY >
+oc create secret generic pyxis-api-secret --from-literal pyxis_api_key.txt=< API KEY >
 ```
+
+The hosted pipeline communicates with internal Container API that requires cert + key.
+The corresponding secret needs to be created before running the pipeline.
+
+```bash
+oc create secret generic operator-pipeline-api-certs \
+  --from-file operator-pipeline.pem \
+  --from-file operator-pipeline.key
+```
+
 ### Installation
 ```bash
 oc apply -R -f pipelines/operator-ci-pipeline.yml
@@ -122,6 +132,7 @@ tkn pipeline start operator-ci-pipeline \
   --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
   --workspace name=ssh-dir,secret=my-ssh-credentials \
   --workspace name=registry-credentials,secret=my-registry-secret \
+  --workspace name=pyxis-api-key,secret=pyxis-api-secret \
   --showlog
 ```
 
@@ -163,5 +174,6 @@ tkn pipeline start operator-hosted-pipeline \
   --workspace name=results,volumeClaimTemplateFile=templates/workspace-template.yml \
   --workspace name=ssh-dir,secret=my-ssh-credentials \
   --workspace name=registry-credentials,secret=my-registry-secret \
+  --workspace name=pyxis-ssl-credentials,secret=operator-pipeline-api-certs \
   --showlog
 ```

--- a/ansible/roles/operator-pipeline/tasks/main.yml
+++ b/ansible/roles/operator-pipeline/tasks/main.yml
@@ -40,7 +40,7 @@
       kind: Secret
       type: Opaque
       metadata:
-        name: operator-pipeline-certs-{{ suffix }}
+        name: operator-pipeline-api-certs
         labels:
           app: operator-pipeline
           suffix: "{{ suffix }}"
@@ -48,6 +48,7 @@
       data:
         operator-pipeline.key: "{{ lookup('file', operator_pipeline_private_key_local_path, rstrip=False) | b64encode }}"
         operator-pipeline.pem: "{{ lookup('file', operator_pipeline_private_cert_local_path, rstrip=False) | b64encode }}"
+
 
 - name: Create Operator pipeline quay token secret
   no_log: yes

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -28,6 +28,7 @@ spec:
     - name: ssh-dir
     - name: registry-credentials
       optional: true
+    - name: pyxis-api-key
   tasks:
     - name: checkout
       taskRef:
@@ -246,6 +247,8 @@ spec:
         - name: source
           workspace: pipeline
           subPath: src
+        - name: pyxis-api-key
+          workspace: pyxis-api-key
 
     - name: open-pr
       runAfter:
@@ -272,6 +275,9 @@ spec:
     - name: upload-pipeline-logs
       taskRef:
         name: upload-pipeline-logs
+      workspaces:
+        - name: pyxis-api-key
+          workspace: pyxis-api-key
       params:
         - name: md5sum
           value: "$(tasks.content-hash.results.md5sum)"

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -27,6 +27,7 @@ spec:
     - name: results
     - name: ssh-dir
     - name: registry-credentials
+    - name: pyxis-ssl-credentials
   tasks:
     # Git clone
     - name: checkout
@@ -204,7 +205,7 @@ spec:
         - dockerfile-creation
       taskRef:
         name: buildah
-        kind: ClusterTask
+        kind: Task
       params:
         - name: IMAGE
           value: &bundleImage "$(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name):$(tasks.operator-validation.results.bundle_version)"
@@ -241,7 +242,7 @@ spec:
         - generate-index
       taskRef:
         name: buildah
-        kind: ClusterTask
+        kind: Task
       params:
         - name: IMAGE
           value: &bundleIndexImage "$(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name)-index:$(tasks.operator-validation.results.bundle_version)"
@@ -333,17 +334,23 @@ spec:
         - name: md5sum
           value: "$(tasks.content-hash.results.md5sum)"
         - name: cert_project_id
-          value: "$(tasks.operator-validation.results.certification_project_id)"
+          value: "$(tasks.certification-project-check.results.certification_project_id)"
         - name: bundle_version
           value: "$(tasks.operator-validation.results.bundle_version)"
         - name: package_name
           value: "$(tasks.operator-validation.results.package_name)"
         - name: pyxis_url
           value: "$(params.pyxis_url)"
+        - name: pyxis_cert_path
+          value: /workspace/pyxis-ssl-credentials/operator-pipeline.pem
+        - name: pyxis_key_path
+          value: /workspace/pyxis-ssl-credentials/operator-pipeline.key
       workspaces:
         - name: source
           workspace: repository
           subPath: src
+        - name: pyxis-ssl-credentials
+          workspace: pyxis-ssl-credentials
 
     - name: ocp-environment-cleanup
       runAfter:
@@ -418,3 +425,26 @@ spec:
     - name: cleanup
       taskRef:
         name: cleanup
+    - name: upload-pipeline-logs
+      taskRef:
+        name: upload-pipeline-logs
+      workspaces:
+        - name: pyxis-ssl-credentials
+          workspace: pyxis-ssl-credentials
+      params:
+        - name: md5sum
+          value: "$(tasks.content-hash.results.md5sum)"
+        - name: cert_project_id
+          value: "$(tasks.certification-project-check.results.certification_project_id)"
+        - name: bundle_version
+          value: "$(tasks.operator-validation.results.bundle_version)"
+        - name: package_name
+          value: "$(tasks.operator-validation.results.package_name)"
+        - name: pyxis_url
+          value: "$(params.pyxis_url)"
+        - name: pipeline_name
+          value: "$(context.pipelineRun.name)"
+        - name: pyxis_cert_path
+          value: /workspace/pyxis-ssl-credentials/operator-pipeline.pem
+        - name: pyxis_key_path
+          value: /workspace/pyxis-ssl-credentials/operator-pipeline.key

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-artifact.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-artifact.yml
@@ -7,6 +7,13 @@ spec:
   params:
     - name: pyxis_api_key_secret
       default: pyxis-api-secret
+      description: OpenShift secret name that contains Pyxis API key. Valid only when external Pyxis is used.
+    - name: pyxis_cert_path
+      default: ""
+      description: Path to Pyxis certificates. Valid only when internal Pyxis is used.
+    - name: pyxis_key_path
+      default: ""
+      description: Path to Pyxis key. Valid only when internal Pyxis is used.
     - name: pyxis_url
       default: https://catalog.redhat.com/api/containers/
     - name: log_file
@@ -23,16 +30,20 @@ spec:
     - name: result_url
   workspaces:
     - name: source
+    - name: pyxis-ssl-credentials
+      optional: true
+    - name: pyxis-api-key
+      optional: true
   steps:
     - name: upload-test-logs
       image: quay.io/redhat-isv/operator-pipelines-images:latest
       workingDir: $(workspaces.source.path)
       env:
-        - name: PYXIS_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: $(params.pyxis_api_key_secret)
-              key: PYXIS_API_KEY
+        - name: PYXIS_CERT_PATH
+          value: $(params.pyxis_cert_path)
+        - name: PYXIS_KEY_PATH
+          value: $(params.pyxis_key_path)
+
       script: |
         #! /usr/bin/env bash
         PREFLIGHT_RESULTS_EXISTS="$(params.preflight_results_exists)"
@@ -40,6 +51,11 @@ spec:
           echo "Preflight logs already exists - skipping"
           echo "none" | tee $(results.log_url.path)
           exit 0
+        fi
+
+        if [[ "$(workspaces.pyxis-api-key.bound)" == "true" ]]; then
+          API_KEY_PATH=$(workspaces.pyxis-api-key.path)/pyxis_api_key.txt
+          export PYXIS_API_KEY=$(cat $API_KEY_PATH)
         fi
 
         echo "Uploading test log"
@@ -65,11 +81,10 @@ spec:
       image: quay.io/redhat-isv/operator-pipelines-images:latest
       workingDir: $(workspaces.source.path)
       env:
-        - name: PYXIS_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: $(params.pyxis_api_key_secret)
-              key: PYXIS_API_KEY
+        - name: PYXIS_CERT_PATH
+          value: $(params.pyxis_cert_path)
+        - name: PYXIS_KEY_PATH
+          value: $(params.pyxis_key_path)
       script: |
         #! /usr/bin/env bash
         PREFLIGHT_RESULTS_EXISTS="$(params.preflight_results_exists)"
@@ -77,6 +92,11 @@ spec:
           echo "Preflight results already exists - skipping"
           echo "none" | tee $(results.result_url.path)
           exit 0
+        fi
+
+        if [[ "$(workspaces.pyxis-api-key.bound)" == "true" ]]; then
+          API_KEY_PATH=$(workspaces.pyxis-api-key.path)/pyxis_api_key.txt
+          export PYXIS_API_KEY=$(cat $API_KEY_PATH)
         fi
 
         echo "Uploading test results"
@@ -102,16 +122,20 @@ spec:
       image: quay.io/redhat-isv/operator-pipelines-images:latest
       workingDir: $(workspaces.source.path)
       env:
-        - name: PYXIS_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: $(params.pyxis_api_key_secret)
-              key: PYXIS_API_KEY
+        - name: PYXIS_CERT_PATH
+          value: $(params.pyxis_cert_path)
+        - name: PYXIS_KEY_PATH
+          value: $(params.pyxis_key_path)
       script: |
         #! /usr/bin/env bash
         PREFLIGHT_RESULTS_EXISTS="$(params.preflight_results_exists)"
         if [ $PREFLIGHT_RESULTS_EXISTS == "true" ]; then
           exit 0
+        fi
+
+        if [[ "$(workspaces.pyxis-api-key.bound)" == "true" ]]; then
+          API_KEY_PATH=$(workspaces.pyxis-api-key.path)/pyxis_api_key.txt
+          export PYXIS_API_KEY=$(cat $API_KEY_PATH)
         fi
 
         echo "Uploading test artifacts"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
@@ -7,7 +7,12 @@ spec:
   params:
     - name: pyxis_api_key_secret
       default: pyxis-api-secret
-      description: Secret name that contains container API key
+      description: OpenShift secret name that contains Pyxis API key. Valid only when external Pyxis is used.
+    - name: pyxis_cert_path
+      default: ""
+      description: Path to Pyxis certificates. Valid only when internal Pyxis is used.
+    - name: pyxis_key_path
+      default: ""
     - name: pyxis_url
       default: https://catalog.redhat.com/api/containers/
       description: Red Hat's container API URL
@@ -23,6 +28,11 @@ spec:
       description: Tekton pipeline run name where logs will be gathered from
   results:
     - name: pipeline_log_url
+  workspaces:
+    - name: pyxis-ssl-credentials
+      optional: true
+    - name: pyxis-api-key
+      optional: true
   steps:
     - name: get-pipeline-logs
       image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8:0.19.0-2
@@ -37,15 +47,19 @@ spec:
     - name: upload-pipeline-logs
       image: quay.io/redhat-isv/operator-pipelines-images:latest
       env:
-        - name: PYXIS_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: $(params.pyxis_api_key_secret)
-              key: PYXIS_API_KEY
+        - name: PYXIS_CERT_PATH
+          value: $(params.pyxis_cert_path)
+        - name: PYXIS_KEY_PATH
+          value: $(params.pyxis_key_path)
       script: |
         #! /usr/bin/env bash
         echo "Uploading pipeline logs"
         set -xe
+
+        if [[ "$(workspaces.pyxis-api-key.bound)" == "true" ]]; then
+          API_KEY_PATH=$(workspaces.pyxis-api-key.path)/pyxis_api_key.txt
+          export PYXIS_API_KEY=$(cat $API_KEY_PATH)
+        fi
 
         upload-artifacts \
           --cert-project-id "$(params.cert_project_id)" \


### PR DESCRIPTION
The hosted pipeline uploads its logs using Pyxis API. The commit also
enables uploading script to use a cert-based auth.

JIRA: ISV-974, ISV-928