### PR TITLE
Make digest pinning explicit in the CI pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ If tests pass a CI pipeline submits a PR for full operator certification workflo
 ### Prerequisites
 
 #### Git SSH Secret
-Since CI pipeline needs to make some changes in git repository (for example digest pinning)
-the pipeline requires a write access to provided git repository. Before running a pipeline
-user needs to upload ssh secret key to a cluster where the pipeline will run.
+The CI pipeline requires git SSH credentials with write access to the repository if automatic
+digest pinning is enabled using the `pin_digests` param. This is disabled by default. Before
+executing the pipeline the user must create a secret in the same namespace as the pipeline.
 
-To create a required secret run following command:
+To create the secret run the following commands (substituting your key):
 ```bash
 cat << EOF > ssh-secret.yml
 kind: Secret
@@ -107,7 +107,6 @@ tkn pipeline start operator-ci-pipeline \
   --param git_revision=main \
   --param bundle_path=operators/kogito-operator/1.6.0-ok \
   --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
-  --workspace name=ssh-dir,secret=my-ssh-credentials \
   --showlog
 ```
 If using an external registry, the CI pipeline can be triggered using the tkn CLI like so:
@@ -120,9 +119,15 @@ tkn pipeline start operator-ci-pipeline \
   --param registry=quay.io \
   --param image_namespace=redhat-isv \
   --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
-  --workspace name=ssh-dir,secret=my-ssh-credentials \
   --workspace name=registry-credentials,secret=my-registry-secret \
   --showlog
+```
+
+To enable digest pinning, pass the following arguments:
+
+```bash
+  --param pin_digests=true \
+  --workspace name=ssh-dir,secret=my-ssh-credentials
 ```
 
 ## Operator Hosted pipeline

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -15,14 +15,15 @@ spec:
     - name: image_namespace
       default: $(context.pipelineRun.namespace)
       description: The namespace/organization all built images will be pushed to.
-    - name: test_mode
-      description: The test mode flag skips certain steps to make a pipeline
-        faster for rapid operator development. The flag needs to be set to false
-        for a full CI pipeline run and certification pull-request submission.
+    - name: pin_digests
+      description: Set to "true" to automatically generate the relatedImages
+        section of the ClusterServiceVersion for you. If changes are made, the
+        result will be committed to GitHub.
       default: "false"
   workspaces:
     - name: pipeline
     - name: ssh-dir
+      optional: true
     - name: registry-credentials
       optional: true
   tasks:
@@ -50,8 +51,8 @@ spec:
       params:
         - name: bundle_path
           value: "$(params.bundle_path)"
-        - name: skip
-          value: "$(params.test_mode)"
+        - name: enabled
+          value: "$(params.pin_digests)"
       workspaces:
         - name: source
           workspace: pipeline

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
@@ -6,8 +6,8 @@ metadata:
 spec:
   params:
     - name: bundle_path
-    - name: skip
-      default: "false"
+    - name: enabled
+      default: "true"
   results:
     - name: dirty_flag
   workspaces:
@@ -20,8 +20,8 @@ spec:
         #! /usr/bin/env bash
         set -xe
 
-        if [ "$(params.skip)" == "true" ]; then
-          echo "Skip flag is set. Skipping digest pinning..."
+        if [ "$(params.enabled)" != "true" ]; then
+          echo "Digest pinning is not enabled"
           echo -n "false" | tee $(results.dirty_flag.path)
           exit 0
         fi


### PR DESCRIPTION
The test_mode flag is no longer necessary since it was only controlling
the behavior around pinning anyway. The ssh-dir workspace can also be
optional because it's only needed if digest pinning is enabled. This
also helps lower the barrier for getting started.