### PR TITLE
Trim trailing line-break from content hash

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/content-hash.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/content-hash.yml
@@ -27,4 +27,4 @@ spec:
 
         cat hashes.txt
 
-        md5sum hashes.txt | awk '{ print $1 }' | tee $(results.md5sum.path)
+        md5sum hashes.txt | awk '{ print $1 }' | tr -d $'\n' | tee $(results.md5sum.path)


### PR DESCRIPTION
The content hash is now without a trailing whitespace.

JIRA: ISV-1051