### PR TITLE
Update preflight params and change results location

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -24,10 +24,10 @@ spec:
       default: "default"
     - name: namespace
       description: The namespace for the preflight config
-      default: "$(context.taskRun.namespace)"
+      default: "default"
     - name: log_level
       description: Preflight logging level
-      default: info
+      default: trace
 
   results:
     - name: log_output_file
@@ -96,6 +96,7 @@ spec:
 
         preflight check operator $(params.bundle_image)
 
+        mv $PFLT_ARTIFACTS/results.json results.json
         echo -n $PFLT_LOGFILE | tee $(results.log_output_file.path)
         echo -n results.json | tee $(results.result_output_file.path)
         echo -n $PFLT_ARTIFACTS | tee $(results.artifacts_output_dir.path)


### PR DESCRIPTION
In our testing with preflight in the pipeline, we changed a few things. 

- The loglevel of info is pretty quiet. Preflight may need to make some adjustments as to what goes into which log level, but the `trace` level gives you the most information re: what broke if something breaks.
- The `preflight_namespace` needs to refer to a namespace that exists in the test cluster, not the tekton cluster. I'm thinking it makes more sense to use `default` and change it dynamically as needed.
- The results.json file is being included in the artifacts directory. I updated the path reference that gets passed to the task's outputs, but I'm not sure if this is what you want, given that a the upload-artifacts task seems to target the artifacts directory in its entirety for one of the steps. I'm thinking that having results exist there might be a problem for the upload. Happy to change this however you think is best.

Let me know what I can do to help.

Signed-off-by: Jose R. Gonzalez <josegonzalez89@gmail.com>