### PR TITLE
Removing .txt extension from pyxis secret

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-artifact.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-artifact.yml
@@ -54,7 +54,7 @@ spec:
         fi
 
         if [[ "$(workspaces.pyxis-api-key.bound)" == "true" ]]; then
-          API_KEY_PATH=$(workspaces.pyxis-api-key.path)/pyxis_api_key.txt
+          API_KEY_PATH=$(workspaces.pyxis-api-key.path)/pyxis_api_key
           export PYXIS_API_KEY=$(cat $API_KEY_PATH)
         fi
 
@@ -95,7 +95,7 @@ spec:
         fi
 
         if [[ "$(workspaces.pyxis-api-key.bound)" == "true" ]]; then
-          API_KEY_PATH=$(workspaces.pyxis-api-key.path)/pyxis_api_key.txt
+          API_KEY_PATH=$(workspaces.pyxis-api-key.path)/pyxis_api_key
           export PYXIS_API_KEY=$(cat $API_KEY_PATH)
         fi
 
@@ -134,7 +134,7 @@ spec:
         fi
 
         if [[ "$(workspaces.pyxis-api-key.bound)" == "true" ]]; then
-          API_KEY_PATH=$(workspaces.pyxis-api-key.path)/pyxis_api_key.txt
+          API_KEY_PATH=$(workspaces.pyxis-api-key.path)/pyxis_api_key
           export PYXIS_API_KEY=$(cat $API_KEY_PATH)
         fi
 

--- a/docs/first-time-run.md
+++ b/docs/first-time-run.md
@@ -87,7 +87,7 @@ container API. This requires a partner's API key and the key needs to be created
 as a secret in openshift cluster before running a Tekton pipeline.
 
 ```bash
-oc create secret generic pyxis-api-secret --from-literal PYXIS_API_KEY=< API KEY >
+oc create secret generic pyxis-api-secret --from-literal pyxis_api_key=< API KEY >
 ```
 
 #### Kubeconfig


### PR DESCRIPTION
This is a nit, but we are setting the pyxis api secret with a .txt.  The docs suggest that the .txt shouldn't be there: 

`oc create secret generic pyxis-api-secret --from-literal PYXIS_API_KEY=< API KEY >`

I suggest we drop the extension and follow the pattern in the documentation. 
