### PR TITLE
Simplify the content hash check

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/content-hash.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/content-hash.yml
@@ -19,11 +19,10 @@ spec:
         set -xe
         echo "Compute md5hash of bundle content..."
 
-        find $(params.bundle_path) -not -name "Dockerfile" -type f -printf '%f\t%p\n' | \
-          sort -V -k1 | \
-          cut -d$'\t' -f2 | \
+        find $(params.bundle_path) -not -name "Dockerfile" -type f | \
           tr '\n' '\0' | \
-          xargs -r0 -I {} md5sum "{}" >> hashes.txt
+          xargs -r0 -I {} md5sum "{}" | \
+          sort >> hashes.txt
 
         cat hashes.txt
 


### PR DESCRIPTION
The content hash currently has a somewhat complicated string of commands
so that the generation of it is predictable. This same command is being
used in preflight. I'd like to propose this new method, that instead of
sorting on the filenames themselves, this just saves the sort for the end
and sorts by the hashes.

Preflight would then be able to use a simpler set of code that is actual
golang instead of shelling out to a complicated command that is not very
testable on the preflight side.

Signed-off-by: Brad P. Crochet <brad@redhat.com>