### PR TITLE
Set GitHub status when operator is published

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,4 +140,5 @@ tkn pipeline start operator-release-pipeline \
   --param is_latest=true \
   --workspace name=repository,volumeClaimTemplateFile=templates/workspace-template.yml \
   --workspace name=pyxis-ssl-credentials,secret=operator-pipeline-api-certs \
+  --workspace name=github-bot-token,secret=github-bot-token \
   --showlog

--- a/ansible/roles/operator-pipeline/tasks/main.yml
+++ b/ansible/roles/operator-pipeline/tasks/main.yml
@@ -100,7 +100,7 @@
           suffix: "{{ suffix }}"
           env: "{{ env }}"
       data:
-        github_bot_token.txt: "{{ lookup('file', operator_pipeline_github_bot_token, rstrip=False) | b64encode }}"
+        github_bot_token: "{{ lookup('file', operator_pipeline_github_bot_token, rstrip=False) | b64encode }}"
 
 - name: Create Operator pipeline github webhook secret
   no_log: yes

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -10,6 +10,8 @@ spec:
     - name: git_revision
       description: git revision used to check out project
       default: "main"
+    - name: git_commit
+      description: Git repository HEAD commit
     - name: bundle_path
       description: path indicating the location of the certified bundle within the repository
     - name: is_latest
@@ -28,6 +30,7 @@ spec:
     - name: ssh-dir
       optional: true
     - name: pyxis-ssl-credentials
+    - name: github-bot-token
   tasks:
     # Set environment
     - name: set-env
@@ -224,3 +227,24 @@ spec:
           value: "$(tasks.get-supported-versions.results.indices)"
         - name: container_digest
           value: "$(tasks.publish-to-ocp-registry.results.container_digest)"
+
+    - name: set-github-status-published
+      runAfter:
+        - publish-bundle
+      taskRef:
+        name: set-github-status
+      params:
+        - name: git_repo_url
+          value: $(params.git_repo_url)
+        - name: commit_sha
+          value: $(params.git_commit)
+        - name: description
+          value: "Operator $(tasks.operator-validation.results.package_name):$(tasks.operator-validation.results.bundle_version) has
+            been published."
+        - name: state
+          value: "$(tasks.publish-bundle.results.status)"
+        - name: context
+          value: "$(tasks.operator-validation.results.package_name):$(tasks.operator-validation.results.bundle_version)"
+      workspaces:
+        - name: github-bot-token
+          workspace: github-bot-token

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
@@ -38,7 +38,7 @@ spec:
           exit 0
         fi
 
-        GITHUB_BOT_TOKEN_PATH=$(workspaces.github-bot-token.path)/github_bot_token.txt
+        GITHUB_BOT_TOKEN_PATH=$(workspaces.github-bot-token.path)/github_bot_token
         export GITHUB_BOT_TOKEN=$(cat $GITHUB_BOT_TOKEN_PATH)
 
         # get the PR number and the repository name from the original PR url-

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-bundle.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-bundle.yml
@@ -11,6 +11,9 @@ spec:
       description: imagestream container_digest
     - name: bundle_versions
       description: All known supported OCP indices
+  results:
+    - name: status
+      description: Indicates a status of publishing a bundle to an index
   steps:
     - name: publish-bundle
       image: registry.access.redhat.com/ubi8-minimal
@@ -21,4 +24,4 @@ spec:
         echo "Calling the IIB"
         echo "Got result- updating GitHub status"
 
-        echo "ok"
+        echo "success" | tee "$(results.status.path)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/set-github-status.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/set-github-status.yml
@@ -24,7 +24,7 @@ spec:
       image: quay.io/redhat-isv/operator-pipelines-images:latest
       env:
         - name: GITHUB_BOT_TOKEN_PATH
-          value: $(workspaces.github-bot-token.path)/github_bot_token.txt
+          value: $(workspaces.github-bot-token.path)/github_bot_token
       script: |
         #! /usr/bin/env bash
         # Don't use set -x to avoid exposing github token

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
@@ -57,7 +57,7 @@ spec:
         set -xe
 
         if [[ "$(workspaces.pyxis-api-key.bound)" == "true" ]]; then
-          API_KEY_PATH=$(workspaces.pyxis-api-key.path)/pyxis_api_key.txt
+          API_KEY_PATH=$(workspaces.pyxis-api-key.path)/pyxis_api_key
           export PYXIS_API_KEY=$(cat $API_KEY_PATH)
         fi
 

--- a/docs/first-time-run.md
+++ b/docs/first-time-run.md
@@ -116,5 +116,5 @@ To automatically merge the PR, Hosted pipeline uses GitHub API. To authenticate
 when using this method, secret containing bot token should be created.
 
 ```bash
-oc create secret generic github-bot-token --from-literal github_bot_token.txt=< BOT TOKEN >
+oc create secret generic github-bot-token --from-literal github_bot_token=< BOT TOKEN >
 ```


### PR DESCRIPTION
Github commit status is set when the release pipeline publishes operator
using IIB.

JIRA: ISV-994
