### PR TITLE
Necessary permissions for pipeline Service Account

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,11 @@ The release pipeline can be triggered using the tkn CLI like so:
 
 
 tkn pipeline start operator-release-pipeline \
-  --param git_repo_url=https://github.com:redhat-openshift-ecosystem/operator-pipelines-test.git \
+  --param git_repo_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
   --param bundle_path=operators/kogito-operator/1.6.0-ok \
+  --param git_commit=3ffff387caac0a5b475f44c4a54fb45eebb8dd8e \
   --param is_latest=true \
   --workspace name=repository,volumeClaimTemplateFile=templates/workspace-template.yml \
   --workspace name=pyxis-ssl-credentials,secret=operator-pipeline-api-certs \
+  --workspace name=github-bot-token,secret=github-bot-token \
   --showlog

--- a/ansible/init.sh
+++ b/ansible/init.sh
@@ -60,16 +60,12 @@ main() {
     for env in $environments;
     do
         execute_playbook $env $passwd_file
-    done
 
-    # Grant the pipeline service account permissions to create projects
-    # -it cannot be done in Playbook, as ansible SA has no permissions to create
-    # cluster-scoped resources- and this command creates ClusterRoleBinding
-    for env in $environments;
-    do
+        # Grant the pipeline service account permissions to create projects
+        # -it cannot be done in Playbook, as ansible SA has no permissions to create
+        # cluster-scoped resources- and this command creates ClusterRoleBinding
         oc adm policy add-cluster-role-to-user self-provisioner -z pipeline -n operator-pipeline-$env
     done
-
 
     # Asks if the script should update the secret-vars.yml files
     read -p "Service accounts configured for ($environments). Update secret-vars with tokens? [y/N] " -n 1 -r

--- a/ansible/init.sh
+++ b/ansible/init.sh
@@ -62,6 +62,15 @@ main() {
         execute_playbook $env $passwd_file
     done
 
+    # Grant the pipeline service account permissions to create projects
+    # -it cannot be done in Playbook, as ansible SA has no permissions to create
+    # cluster-scoped resources- and this command creates ClusterRoleBinding
+    for env in $environments;
+    do
+        oc adm policy add-cluster-role-to-user self-provisioner -z pipeline -n operator-pipeline-$env
+    done
+
+
     # Asks if the script should update the secret-vars.yml files
     read -p "Service accounts configured for ($environments). Update secret-vars with tokens? [y/N] " -n 1 -r
     echo

--- a/docs/first-time-run.md
+++ b/docs/first-time-run.md
@@ -118,3 +118,16 @@ when using this method, secret containing bot token should be created.
 ```bash
 oc create secret generic github-bot-token --from-literal github_bot_token.txt=< BOT TOKEN >
 ```
+
+### Only Hosted pipeline:
+#### Service account permissions
+
+Openshift Pipelines are using self- created service account named Pipeline. 
+To grant permissions to create new namespaces, run:
+```bash
+oc secret link pipeline registry-dockerconfig-secret
+```
+To grant permissions to pull images from specified registries by service account, run
+```bash
+oc adm policy add-cluster-role-to-user self-provisioner -z pipeline -n <YOUR_NAMESPACE> 
+```


### PR DESCRIPTION
Service Account `pipeline` used by openshift pipelines needs permissions for project creation. They are used in task imagestream-manipulation. 