### PR TITLE
Generate connect_url based on env and use in github status

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -454,6 +454,8 @@ spec:
           value: "$(tasks.operator-validation.results.package_name)"
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
+        - name: connect_url
+          value: "$(tasks.set-env.results.connect_url)"
         - name: pyxis_cert_path
           value: /workspace/pyxis-ssl-credentials/operator-pipeline.pem
         - name: pyxis_key_path
@@ -541,7 +543,7 @@ spec:
           value: $(params.git_commit)
         - name: description
           value: "Operator test for $(tasks.submission-validation.results.operator_name)
-            complete. Test result URL: $(tasks.upload-artifacts.results.result_url)"
+            complete. Test result URL: $(tasks.upload-artifacts.results.result_spa_url)"
         - name: state
           value: "$(tasks.verify-ci-results.results.test_result)"
         - name: context

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env.yml
@@ -14,6 +14,8 @@ spec:
       description: Container API URL based for selected environment
     - name: target_branch
       description: Target branch for submitted PR in upstream repository
+    - name: connect_url
+      description: Connect SPA URL based on selected environment
   steps:
     - name: set-env
       image: registry.access.redhat.com/ubi8-minimal
@@ -40,6 +42,7 @@ spec:
                     ;;
                 esac
                 TARGET_BRANCH="main"
+                CONNECT_URL="https://connect.redhat.com"
             ;;
             stage)
                 case $ACCESS_TYPE in
@@ -51,6 +54,7 @@ spec:
                     ;;
                 esac
                 TARGET_BRANCH="stage"
+                CONNECT_URL="https://connect.stage.redhat.com"
             ;;
             qa)
                 case $ACCESS_TYPE in
@@ -62,6 +66,7 @@ spec:
                     ;;
                 esac
                 TARGET_BRANCH="qa"
+                CONNECT_URL="https://connect.qa.redhat.com"
             ;;
             dev)
                 case $ACCESS_TYPE in
@@ -73,6 +78,7 @@ spec:
                     ;;
                 esac
                 TARGET_BRANCH="dev"
+                CONNECT_URL="https://connect.dev.redhat.com"
             ;;
             *)
                 echo "Unknown environment."
@@ -82,3 +88,4 @@ spec:
 
         echo -n $PYXIS_URL | tee $(results.pyxis_url.path)
         echo -n $TARGET_BRANCH | tee $(results.target_branch.path)
+        echo -n $CONNECT_URL | tee $(results.connect_url.path)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-artifact.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-artifact.yml
@@ -16,6 +16,8 @@ spec:
       description: Path to Pyxis key. Valid only when internal Pyxis is used.
     - name: pyxis_url
       default: https://catalog.redhat.com/api/containers/
+    - name: connect_url
+      default: https://connect.redhat.com
     - name: log_file
     - name: result_file
     - name: artifacts_dir
@@ -28,6 +30,9 @@ spec:
   results:
     - name: log_url
     - name: result_url
+      description: URL to the Pyxis test results endpoint
+    - name: result_spa_url
+      description: URL to the Connect SPA test results page
   workspaces:
     - name: source
     - name: pyxis-ssl-credentials
@@ -116,6 +121,11 @@ spec:
 
         echo "Test result URL: "
         echo -n $RESULT_URL | tee $(results.result_url.path)
+
+        RESULT_SPA_URL="$(params.connect_url)/projects/$(params.cert_project_id)/test-results"
+
+        echo "Test result SPA URL: "
+        echo -n $RESULT_SPA_URL | tee $(results.result_spa_url.path)
 
     - name: upload-test-artifacts
       image: quay.io/redhat-isv/operator-pipelines-images:latest


### PR DESCRIPTION
Github status need to use the external facing SPA url for partners
to access test results