### PR TITLE
fixed changing the cert project status from Started to In Progress

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -119,7 +119,7 @@ spec:
       when:
         - input: "$(tasks.get-cert-project-related-data.results.certification_status)"
           operator: in
-          values: [ "In Progress" ]
+          values: ["In Progress"]
       taskRef:
         name: update-cert-project-status
       params:

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -102,6 +102,8 @@ spec:
       params:
         - name: cert_project_id
           value: "$(tasks.certification-project-check.results.certification_project_id)"
+        - name: pyxis_url
+          value: "$(tasks.set-env.results.pyxis_url)"
         - name: pyxis_cert_path
           value: /workspace/pyxis-ssl-credentials/operator-pipeline.pem
         - name: pyxis_key_path
@@ -110,10 +112,14 @@ spec:
         - name: pyxis-ssl-credentials
           workspace: pyxis-ssl-credentials
 
-    # Update cert project related data
+    # Update cert project related data from "started" to "in progress"
     - name: update-cert-project-status
       runAfter:
         - get-cert-project-related-data
+      when:
+        - input: "$(tasks.get-cert-project-related-data.results.certification_status)"
+          operator: in
+          values: [ "In Progress" ]
       taskRef:
         name: update-cert-project-status
       params:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/get-cert-project-related-data.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/get-cert-project-related-data.yml
@@ -47,8 +47,13 @@ spec:
           --cert-project-id $(params.cert_project_id)
 
         CERTIFICATION_STATUS=$(cat cert_project | jq '.certification_status'| tr -d '"')
-        if [ $CERTIFICATION_STATUS == "Started" ]; then
+        if [ "$CERTIFICATION_STATUS" == "Started" ]; then
           echo -n "In Progress" | tee $(results.certification_status.path)
+        else
+          echo "Not going to update the certification status from "Started" \
+          to "In Progress". Current status:"
+          echo $CERTIFICATION_STATUS
+          echo -n "Don't Update" | tee $(results.certification_status.path)
         fi
 
         # `grep .` ensures, that pipe fail if jq returns no results

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/reserve-operator-name.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/reserve-operator-name.yml
@@ -29,12 +29,12 @@ spec:
           value: $(params.pyxis_cert_path)
         - name: PYXIS_KEY_PATH
           value: $(params.pyxis_key_path)
+        - name: ASSOCIATION
+          value: $(params.association)
       script: |
         #! /usr/bin/env bash
         set -xe
 
-        # Somehow, when not assigned to a var, this param has a trailing new line
-        ASSOCIATION=$(params.association)
         echo "Attempting to reserve operator name for assocation $ASSOCIATION"
 
         reserve-operator-name \


### PR DESCRIPTION
If status was other than "Started", "results.certification_status" did not exist. 