### PR TITLE
Always include the original set of registry credentials when merging

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-registry-credentials.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-registry-credentials.yml
@@ -55,5 +55,6 @@ spec:
           echo "Tokens successfully merged"
         else
           echo "No partner's registry token has been provided."
-          echo "{}" > "$(workspaces.registry-credentials-all.path)/.dockerconfigjson"
+          cp "$(workspaces.registry-credentials.path)/.dockerconfigjson" \
+             "$(workspaces.registry-credentials-all.path)/.dockerconfigjson"
         fi


### PR DESCRIPTION
Noticed and tested this fix in the stage environment.