### PR TITLE
Remove dependency variables from set-status

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -826,8 +826,6 @@ spec:
           value: $(params.git_commit)
         - name: description
           value: "Failed to certify the Operator bundle."
-        - name: target_url
-          value: "$(tasks.set-env.results.connect_url)/projects/$(tasks.certification-project-check.results.certification_project_id)/test-results"
         - name: state
           value: failure
         - name: context

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/set-github-status.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/set-github-status.yml
@@ -15,7 +15,6 @@ spec:
       description: The github status to set for the given commit.
     - name: context
       description: Context attached to the github status.
-    # TODO - https://issues.redhat.com/browse/ISV-1219
     - name: target_url
       description: URL to more details about the status.
       default: ""


### PR DESCRIPTION
When pipeline fails we always want to set github failed status. This
removal allows to set status always no matter when a pipeline fails.

JIRA: ISV-1269