### PR TITLE
Unify prod env naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ tkn pipeline start operator-ci-pipeline \
   --param git_repo_url=git@github.com:redhat-openshift-ecosystem/operator-pipelines-test.git \
   --param git_branch=main \
   --param bundle_path=operators/kogito-operator/1.6.0-ok \
-  --param env=production \
+  --param env=prod \
   --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
   --workspace name=kubeconfig,secret=kubeconfig \
   --workspace name=ssh-dir,secret=github-ssh-credentials \
@@ -49,7 +49,7 @@ tkn pipeline start operator-ci-pipeline \
   --param git_repo_url=git@github.com:redhat-openshift-ecosystem/operator-pipelines-test.git \
   --param git_branch=main \
   --param bundle_path=operators/kogito-operator/1.6.0-ok \
-  --param env=production \
+  --param env=prod \
   --param registry=quay.io \
   --param image_namespace=redhat-isv \
   --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
@@ -98,7 +98,7 @@ tkn pipeline start operator-hosted-pipeline \
   --param git_commit=0aeff5f71e4fc2d4990474780b56d9312554da5a \
   --param git_base_branch=main \
   --param pr_head_label=MarcinGinszt:test-PR-ok \
-  --param env=production \
+  --param env=prod \
   --param preflight_min_version=0.0.0 \
   --param ci_min_version=0.0.0 \
   --workspace name=repository,volumeClaimTemplateFile=templates/workspace-template-small.yml \

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline-serial.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline-serial.yml
@@ -19,8 +19,8 @@ spec:
     - name: registry
       default: image-registry.openshift-image-registry.svc:5000
     - name: env
-      description: Which environment to run in. Can be one of [dev, qa, stage, production]
-      default: "production"
+      description: Which environment to run in. Can be one of [dev, qa, stage, prod]
+      default: "prod"
     - name: image_namespace
       default: $(context.pipelineRun.namespace)
       description: The namespace/organization all built images will be pushed to.

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -19,8 +19,8 @@ spec:
     - name: registry
       default: image-registry.openshift-image-registry.svc:5000
     - name: env
-      description: Which environment to run in. Can be one of [dev, qa, stage, production]
-      default: "production"
+      description: Which environment to run in. Can be one of [dev, qa, stage, prod]
+      default: "prod"
     - name: image_namespace
       default: $(context.pipelineRun.namespace)
       description: The namespace/organization all built images will be pushed to.

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -18,8 +18,8 @@ spec:
       description: Name of the base branch. e.g. "main"
     - name: pr_head_label
     - name: env
-      description: Which environment to run in. Can be one of [dev, qa, stage, production]
-      default: "production"
+      description: Which environment to run in. Can be one of [dev, qa, stage, prod]
+      default: "prod"
     - name: preflight_min_version
     - name: ci_min_version
     - name: registry

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -25,8 +25,8 @@ spec:
       description: The namespace/organization where images from Hosted pipeline are stored.
       default: $(context.pipelineRun.namespace)
     - name: env
-      description: Which environment to run in. Can be one of [dev, qa, stage, production]
-      default: "production"
+      description: Which environment to run in. Can be one of [dev, qa, stage, prod]
+      default: "prod"
     - name: pipeline_image
       description: An image of operator-pipeline-images.
       default: "quay.io/redhat-isv/operator-pipelines-images:latest"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-bundle.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-bundle.yml
@@ -20,7 +20,7 @@ spec:
       description: Operator distribution method. Can be one of [connect, marketplace]
     - name: environment
       description: |
-        Which environment the pipeline is running in. Can be one of [dev, qa, stage, production]
+        Which environment the pipeline is running in. Can be one of [dev, qa, stage, prod]
   results:
     - name: status
       description: Indicates a status of publishing a bundle to an index
@@ -51,7 +51,7 @@ spec:
         # select the correct index
 
         case "$(params.environment)" in
-            production)
+            prod)
                 case $DIST_METHOD in
                     connect)
                       FROM_INDEX="quay.io/redhat/redhat----certified-operator-index"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-resources.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-resources.yml
@@ -16,7 +16,7 @@ spec:
     - name: pyxis_key_path
       default: ""
     - name: environment
-      default: production
+      default: prod
       description: Environment where the pipeline runs
     - name: pyxis_url
       default: https://pyxis.engineering.redhat.com

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   params:
     - name: env
-      description: Environment. One of [dev, qa, stage, production]
+      description: Environment. One of [dev, qa, stage, prod]
     - name: access_type
       description: Pyxis access type. One of [internal, external]
   results:
@@ -34,7 +34,7 @@ spec:
         fi
 
         case $ENV in
-            production)
+            prod)
                 case $ACCESS_TYPE in
                     internal)
                     PYXIS_URL="https://pyxis.engineering.redhat.com"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/show-support-link.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/show-support-link.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: env
-      description: Enviroment. One of [dev, qa, stage, production]
+      description: Enviroment. One of [dev, qa, stage, prod]
     - name: type
       description: Connect case type.
       default: "CERT"
@@ -35,7 +35,7 @@ spec:
 
         # select the correct connect instance
         URL_ENV="connect"
-        if [[ $LINK_ENV != "production" ]]; then
+        if [[ $LINK_ENV != "prod" ]]; then
             URL_ENV="$URL_ENV.$LINK_ENV"
         fi
 


### PR DESCRIPTION
Ansible inventory uses 'prod' as a name of production environment and a
pipelines use 'production'. This is causing a failures when running a
pipeline in prod environment. Since we can't change inventory variable
because it determines ocp namespaces and few other things we have to
rename a 'production' -> 'prod' in a pipelines.