### PR TITLE
Fix some release pipeline bugs

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/webhook-release-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/webhook-release-pipeline-trigger.yml
@@ -23,11 +23,13 @@
               - name: git_repo_url
                 value: $(body.pull_request.base.repo.clone_url)
               - name: git_commit
-                value: $(body.pull_request.head.sha)
+                value: $(body.pull_request.merge_commit_sha)
               - name: git_pr_title
                 value: $(body.pull_request.title)
               - name: git_pr_url
                 value: $(body.pull_request.html_url)
+              - name: git_base_branch
+                value: $(body.pull_request.base.ref)
               - name: env
                 value: "{{ env }}"
               - name: pipeline_image
@@ -51,6 +53,7 @@
               - name: git_commit
               - name: git_pr_title
               - name: git_pr_url
+              - name: git_base_branch
               - name: is_latest
               - name: env
               - name: pipeline_image
@@ -71,6 +74,8 @@
                       value: $(tt.params.git_pr_title)
                     - name: git_pr_url
                       value: $(tt.params.git_pr_url)
+                    - name: git_base_branch
+                      value: $(tt.params.git_base_branch)
                     - name: is_latest
                       value: "true"
                     - name: env

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -7,8 +7,8 @@ spec:
   params:
     - name: git_repo_url
       description: ssh address of GitHub repository
-    - name: git_revision
-      description: git revision used to check out project
+    - name: git_base_branch
+      description: Name of the base branch in the pull request. e.g. "main"
       default: "main"
     - name: git_commit
       description: Git repository HEAD commit
@@ -41,7 +41,7 @@ spec:
       default: ibm-webhook-token
     - name: ibm_webhook_token_secret_key
       description: The key within the Kubernetes Secret that contains the IBM webhook token.
-      default: ibm-webhook-token
+      default: token
   workspaces:
     - name: repository
     - name: results
@@ -100,7 +100,7 @@ spec:
         - name: url
           value: $(params.git_repo_url)
         - name: revision
-          value: $(params.git_revision)
+          value: $(params.git_base_branch)
         - name: gitInitImage
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
       workspaces:

--- a/docs/first-time-run.md
+++ b/docs/first-time-run.md
@@ -189,5 +189,5 @@ The Release pipeline needs to call an IBM webhook to trigger marketplace replica
 authenticate with the webhook, a token is needed.
 
 ```bash
-oc create secret generic ibm-webhook-token --from-literal ibm-webhook-token=< TOKEN >
+oc create secret generic ibm-webhook-token --from-literal token=< TOKEN >
 ```


### PR DESCRIPTION
The merged commit and base branch are now used to pull the source and
set the github status. This also fixes a discrepency with the default IBM
webhook token key name vs what's is deployed in the ansible playbooks.