### PR TITLE
Change the URL for preflight.tar.gz.asc

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
@@ -92,7 +92,7 @@ spec:
 
         PROWJOB_ID=${PROWJOB_URL##*/}
 
-        ARTIFACTS_TARBALL_URI="${BASE_URL}periodic-ci-redhat-openshift-ecosystem-preflight-ocp-$(params.ocp_version)-preflight-common-claim/${PROWJOB_ID}/artifacts/preflight-common-claim/operator-pipelines-preflight-common-crypt/artifacts/preflight.tar.gz.asc"
+        ARTIFACTS_TARBALL_URI="${BASE_URL}periodic-ci-redhat-openshift-ecosystem-preflight-ocp-$(params.ocp_version)-preflight-common-claim/${PROWJOB_ID}/artifacts/preflight-common-claim/operator-pipelines-preflight-common-encrypt/artifacts/preflight.tar.gz.asc"
 
         curl -sLO "${ARTIFACTS_TARBALL_URI}"
 
@@ -107,8 +107,6 @@ spec:
         }'|tr -d '[:space:]'`":6: | gpg --import-ownertrust 1> /dev/null
 
         gpg -d preflight.tar.gz.asc | tar -xzf -
-
-        ls -lha
 
         mv artifacts/results.json .
 


### PR DESCRIPTION
Our need to potentially provide a docker config json required changing
our crypt step to encrypt and decrypt steps in the openshift-ci step
registry.

As a result of this change the job URL no longer has the word crypt but
instead encrypt. We build this URL dynamically however some parts of it
are hardcoded; this is one of those hardcoded parts.

Signed-off-by: Melvin Hillsman <mhillsma@redhat.com>