### PR TITLE
fixing jsonpath to get clusterversion

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/check-ocp-cluster-version.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/check-ocp-cluster-version.yml
@@ -18,7 +18,7 @@ spec:
         set -xe
 
         KUBECONFIG=$(workspaces.kubeconfig.path)/kubeconfig
-        CLUSTER_VERSION=$(oc get clusterversion -o jsonpath="{.items[0].spec.desiredUpdate.version}" --kubeconfig $KUBECONFIG)
+        CLUSTER_VERSION=$(oc get clusterversion -o jsonpath="{.items[0].status.desired.version}" --kubeconfig $KUBECONFIG)
         # Grab only the major and minor version for comparison
         CLUSTER_VERSION=$(echo $CLUSTER_VERSION | cut -d. -f1,2)
         # parse indices into a list of strings with OCP versions


### PR DESCRIPTION
When testing this on an AWS cluster installed with IPI,  I received an error.  The jsonpath was invalid. 

```STEP-CHECK-OCP-CLUSTER-VERSION

+ KUBECONFIG=/workspace/kubeconfig/kubeconfig
++ oc get clusterversion -o 'jsonpath={.items[0].spec.desiredUpdate.version}' --kubeconfig /workspace/kubeconfig/kubeconfig
+ CLUSTER_VERSION=
++ echo
++ cut -d. -f1,2
+ CLUSTER_VERSION=
++ echo '[  "4.8",  "4.7",  "4.6"]'
++ jq -r '.[]'
+ SUPPORTED_VERSIONS='4.8
4.7
4.6'
+ for version in $SUPPORTED_VERSIONS
+ '[' 4.8 == '' ']'
+ for version in $SUPPORTED_VERSIONS
+ '[' 4.7 == '' ']'
+ for version in $SUPPORTED_VERSIONS
+ '[' 4.6 == '' ']'
+ echo ' is not a supported OCP version'
 is not a supported OCP version
+ exit 1```