### PR TITLE
fixing file perms on result.json

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -89,6 +89,7 @@ spec:
         preflight check operator $(params.bundle_image)
 
         mv $PFLT_ARTIFACTS/results.json results.json
+        chmod +r results.json
         echo -n $PFLT_LOGFILE | tee $(results.log_output_file.path)
         echo -n results.json | tee $(results.result_output_file.path)
         echo -n $PFLT_ARTIFACTS | tee $(results.artifacts_output_dir.path)


### PR DESCRIPTION
While testing on an AWS cluster installed with IPI, I hit an error where the results.json file couldn't be read during the `preflight verify-results` step.  This was because the `preflight check-operator` step runs as root and writes the results.json as root.  Then the `preflight verify-results` runs as user and tries to read results.json owned by root.  