### PR TITLE
Updating to use latest preflight with fixes

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -312,6 +312,8 @@ spec:
           value: "$(params.preflight_namespace)"
         - name: service_account
           value: "$(params.preflight_service_account)"
+        - name: cert_project_id
+          value: "$(tasks.certification-project-check.results.certification_project_id)"
       workspaces:
         - name: output
           workspace: pipeline

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:2c26d7d8835b75088b1c29fa764d453b2f47dd7af530eb87a986766045693d2a
+      default: quay.io/redhat-isv/preflight-test@sha256:32913b06f0e57eb7109371ad6d595dfdee6357f8a7b4b4fca7757658478159c2
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test
@@ -26,6 +26,8 @@ spec:
     - name: log_level
       description: Preflight logging level
       default: trace
+    - name: cert_project_id
+      description: Certification project id
 
   results:
     - name: log_output_file
@@ -78,6 +80,8 @@ spec:
           value: artifacts
         - name: PFLT_LOGLEVEL
           value: $(params.log_level)
+        - name: PFLT_CERTPROJECTID
+          value: $(params.cert_project_id)
         - name: PFLT_DOCKERCONFIG
           value: $(workspaces.output.path)/preflight-docker-config.json
         - name: KUBECONFIG


### PR DESCRIPTION
I found a few more issues with Preflight while testing.  This update passes in the certification project id to Preflight to be used during the `packageNameUniqueness` test.  Fixes a bug where a partner who already owned a package name was still failing this check.  Also updated the Preflight SHA to point to the image with the latest fixes. 