### PR TITLE
Fix order for querying publishing checklist

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -642,23 +642,6 @@ spec:
         - name: pyxis-ssl-credentials
           workspace: pyxis-ssl-credentials
 
-    # Query Hydra API for status of the pre-certification checklist
-    - name: query-publishing-checklist
-      runAfter:
-        - upload-artifacts
-      taskRef:
-        name: query-publishing-checklist
-      params:
-        - name: pipeline_image
-          value: "$(params.pipeline_image)"
-        - name: cert_project_id
-          value: "$(tasks.certification-project-check.results.certification_project_id)"
-        - name: connect_url
-          value: "$(tasks.set-env.results.connect_url)"
-      workspaces:
-        - name: hydra-credentials
-          workspace: hydra-credentials
-
     - name: get-ci-results
       runAfter:
         - upload-artifacts
@@ -739,10 +722,28 @@ spec:
         - name: pyxis-ssl-credentials
           workspace: pyxis-ssl-credentials
 
+    # Query Hydra API for status of the pre-certification checklist
+    - name: query-publishing-checklist
+      runAfter:
+        - link-pull-request
+        - verify-ci-results
+      taskRef:
+        name: query-publishing-checklist
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: cert_project_id
+          value: "$(tasks.certification-project-check.results.certification_project_id)"
+        - name: connect_url
+          value: "$(tasks.set-env.results.connect_url)"
+      workspaces:
+        - name: hydra-credentials
+          workspace: hydra-credentials
+
     # merge PR
     - name: merge-pr
       runAfter:
-        - verify-ci-results
+        - query-publishing-checklist
       taskRef:
         name: merge-pr
       params:


### PR DESCRIPTION
The checklist depends on the execution of link-pull-request.