### PR TITLE
fixing a bug preflight trigger skipping

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
@@ -80,7 +80,7 @@ spec:
       script: |
           #!/usr/bin/env sh
 
-          if [ "$(params.skip)" ]; then
+          if [ "$(params.skip)" == "true" ]; then
               echo "Preflight testing has been skipped"
               exit 0
           fi


### PR DESCRIPTION
Fixing a small issue found while testing the non-ci flow of the hosted pipeline.  Had an if statement that was treating a string like a boolean and causing prow to be skipped. 