### PR TITLE
Fix for broken index images

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -513,8 +513,8 @@ spec:
           value: &bundleIndexImage "$(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name)-index:$(tasks.operator-validation.results.bundle_version)"
         - name: CONTEXT
           value: "$(tasks.get-bundle-path.results.bundle_path)"
-        # - name: DOCKERFILE
-        #   value: "Dockerfile.index"
+        - name: DOCKERFILE
+          value: "$(tasks.generate-index.results.index_dockerfile)"
       workspaces:
         - name: source
           workspace: repository


### PR DESCRIPTION
In the hosted pipeline we were not passing in a DOCKERFILE param to the `build-index` task. As a result the task was using the default ./Dockerfile which is the same one used by the Bundle image.   The Bundle image DOCKERFILE uses a FROM scratch setting.  As a result the Index Images were being created with FROM scratch and they didn't contain an `entrypoint` nor a `cmd` setting.  We ended up with index images that could not be executed and therefore bundles could not be served from our index.  This results in DeployableByOLM failures in Preflight when using the Hosted pipeline. This fix makes Hosted use the same pattern that we use in the CI.