### PR TITLE
fixing build-index workspace subPath

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -518,7 +518,7 @@ spec:
       workspaces:
         - name: source
           workspace: repository
-          subPath: src
+          subPath: index
         - name: credentials
           # Do not use registry-credentials-all. Project creds may replace quay.io push creds.
           workspace: registry-credentials


### PR DESCRIPTION
The workspace subpath for the build-index task in the Hosted pipeline needs to match the workspace subpath of the generate-index task that runs before it. The generate-index workspace uses a subpath of `index`. This PR sets the build-index to use the same. 