### PR TITLE
fixing the dockerfile context

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -511,8 +511,6 @@ spec:
       params:
         - name: IMAGE
           value: &bundleIndexImage "$(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name)-index:$(tasks.operator-validation.results.bundle_version)"
-        - name: CONTEXT
-          value: "$(tasks.get-bundle-path.results.bundle_path)"
         - name: DOCKERFILE
           value: "$(tasks.generate-index.results.index_dockerfile)"
       workspaces:


### PR DESCRIPTION
Fixing up the Dockerfile context for the Index image so it uses the default context and no longer points to the bundle image context. 