### PR TITLE
Support dynamically setting ocp_version for preflight

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -580,6 +580,8 @@ spec:
         kind: Task
         name: preflight-trigger
       params:
+        - name: ocp_version
+          value: "$(tasks.get-supported-versions.results.max_supported_ocp_version)"
         - name: asset_type
           value: operator
         - name: bundle_index_image

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
@@ -4,7 +4,7 @@ metadata:
   name: preflight-trigger
 spec:
   params:
-    - default: '4.8'
+    - default: '4.9'
       name: ocp_version
       type: string
     - default: trace


### PR DESCRIPTION
The preflight-trigger task has a parameter for setting the version of
OpenShift to request from DPTP. Currently this is hardcoded to 4.8. We
are updating this to 4.9 as the default and passing in the parameter
value dynamically from task get-supported-versions.

Signed-off-by: Melvin Hillsman <mhillsma@redhat.com>