### PR TITLE
Fix bug in RHM flow of Release Pipeline

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-ocp-registry.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-ocp-registry.yml
@@ -87,7 +87,7 @@ spec:
           oc create rolebinding $ROLE_NAME --role=$ROLE_NAME \
             --serviceaccount connect:rhmp-sa \
             --serviceaccount connect:bpmsa
-        else:
+        else
           echo "Error: wrong distribution method ${DIST_METHOD}"
           exit 1
         fi


### PR DESCRIPTION
There was a stray colon in the if else statement of a bash script which caused an error when that part of the code was executed.  The code is only executed when running a Red Hat Marketplace operator through the Release Pipeline. 