### PR TITLE
Reduce the chances of the hosted pipeline not uploading logs

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -81,9 +81,25 @@ spec:
         - name: ssh-directory
           workspace: ssh-dir
 
-    - name: digest-pinning
+    # Verify the bundle path exists
+    - name: bundle-path-validation
       runAfter:
         - checkout
+      taskRef:
+        name: bundle-path-validation
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: bundle_path
+          value: "$(params.bundle_path)"
+      workspaces:
+        - name: source
+          workspace: pipeline
+          subPath: src
+
+    - name: digest-pinning
+      runAfter:
+        - bundle-path-validation
       taskRef:
         name: digest-pinning
       params:
@@ -136,26 +152,9 @@ spec:
           workspace: pipeline
           subPath: src
 
-    - name: operator-validation
-      runAfter:
-        - commit-pinned-digest
-      taskRef:
-        name: operator-validation
-      params:
-        - name: pipeline_image
-          value: "$(params.pipeline_image)"
-        - name: bundle_path
-          value: "$(params.bundle_path)"
-        - name: pyxis_url
-          value: "$(tasks.set-env.results.pyxis_url)"
-      workspaces:
-        - name: source
-          workspace: pipeline
-          subPath: src
-
     - name: annotations-validation
       runAfter:
-        - operator-validation
+        - commit-pinned-digest
       taskRef:
         name: annotations-validation
       params:
@@ -164,7 +163,7 @@ spec:
         - name: bundle_path
           value: "$(params.bundle_path)"
         - name: package_name
-          value: "$(tasks.operator-validation.results.package_name)"
+          value: "$(tasks.bundle-path-validation.results.package_name)"
       workspaces:
         - name: source
           workspace: pipeline
@@ -231,7 +230,7 @@ spec:
 
     - name: dockerfile-creation
       runAfter:
-        - operator-validation
+        - annotations-validation
         - yaml-lint
         - certification-project-check
       taskRef:
@@ -259,7 +258,7 @@ spec:
         kind: Task
       params:
         - name: IMAGE
-          value: &bundleImage "$(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name):$(tasks.operator-validation.results.bundle_version)"
+          value: &bundleImage "$(params.registry)/$(params.image_namespace)/$(tasks.bundle-path-validation.results.package_name):$(tasks.bundle-path-validation.results.bundle_version)"
         - name: CONTEXT
           value: "$(params.bundle_path)"
       workspaces:
@@ -299,7 +298,7 @@ spec:
         kind: Task
       params:
         - name: IMAGE
-          value: &bundleIndexImage "$(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name)-index:$(tasks.operator-validation.results.bundle_version)"
+          value: &bundleIndexImage "$(params.registry)/$(params.image_namespace)/$(tasks.bundle-path-validation.results.package_name)-index:$(tasks.bundle-path-validation.results.bundle_version)"
         - name: DOCKERFILE
           value: "$(tasks.generate-index.results.index_dockerfile)"
       workspaces:
@@ -318,9 +317,9 @@ spec:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
         - name: bundle_version
-          value: "$(tasks.operator-validation.results.bundle_version)"
+          value: "$(tasks.bundle-path-validation.results.bundle_version)"
         - name: package_name
-          value: "$(tasks.operator-validation.results.package_name)"
+          value: "$(tasks.bundle-path-validation.results.package_name)"
         - name: bundle_index_image
           value: *bundleIndexImage
         - name: bundle_image
@@ -365,9 +364,9 @@ spec:
         - name: cert_project_id
           value: "$(tasks.certification-project-check.results.certification_project_id)"
         - name: bundle_version
-          value: "$(tasks.operator-validation.results.bundle_version)"
+          value: "$(tasks.bundle-path-validation.results.bundle_version)"
         - name: package_name
-          value: "$(tasks.operator-validation.results.package_name)"
+          value: "$(tasks.bundle-path-validation.results.package_name)"
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
       workspaces:
@@ -400,9 +399,9 @@ spec:
         - name: test_result_url
           value: "$(tasks.upload-artifacts.results.result_url)"
         - name: package_name
-          value: "$(tasks.operator-validation.results.package_name)"
+          value: "$(tasks.bundle-path-validation.results.package_name)"
         - name: bundle_version
-          value: "$(tasks.operator-validation.results.bundle_version)"
+          value: "$(tasks.bundle-path-validation.results.bundle_version)"
         - name: certification_project_id
           value: "$(tasks.certification-project-check.results.certification_project_id)"
       workspaces:
@@ -430,9 +429,9 @@ spec:
         - name: cert_project_id
           value: "$(tasks.certification-project-check.results.certification_project_id)"
         - name: bundle_version
-          value: "$(tasks.operator-validation.results.bundle_version)"
+          value: "$(tasks.bundle-path-validation.results.bundle_version)"
         - name: package_name
-          value: "$(tasks.operator-validation.results.package_name)"
+          value: "$(tasks.bundle-path-validation.results.package_name)"
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: pipeline_name

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -135,10 +135,26 @@ spec:
         - name: git_pr_title
           value: $(params.git_pr_title)
 
+    # Verify the bundle path exists
+    - name: bundle-path-validation
+      runAfter:
+        - get-bundle-path
+      taskRef:
+        name: bundle-path-validation
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: bundle_path
+          value: "$(tasks.get-bundle-path.results.bundle_path)"
+      workspaces:
+        - name: source
+          workspace: repository
+          subPath: src
+
     # Get cert project id
     - name: certification-project-check
       runAfter:
-        - get-bundle-path
+        - bundle-path-validation
       taskRef:
         name: certification-project-check
       params:
@@ -153,7 +169,6 @@ spec:
 
     - name: create-support-link-for-pr
       runAfter:
-        - set-env
         - certification-project-check
       taskRef:
         name: create-support-link-for-pr
@@ -293,27 +308,9 @@ spec:
         - name: pyxis_key_path
           value: $(workspaces.pyxis-ssl-credentials.path)/operator-pipeline.key
 
-    # additional checks
-    - name: operator-validation
-      runAfter:
-        - reserve-operator-name
-      taskRef:
-        name: operator-validation
-      params:
-        - name: pipeline_image
-          value: "$(params.pipeline_image)"
-        - name: bundle_path
-          value: "$(tasks.get-bundle-path.results.bundle_path)"
-        - name: pyxis_url
-          value: "$(tasks.set-env.results.pyxis_url)"
-      workspaces:
-        - name: source
-          workspace: repository
-          subPath: src
-
     - name: annotations-validation
       runAfter:
-        - operator-validation
+        - reserve-operator-name
       taskRef:
         name: annotations-validation
       params:
@@ -322,7 +319,7 @@ spec:
         - name: bundle_path
           value: "$(tasks.get-bundle-path.results.bundle_path)"
         - name: package_name
-          value: "$(tasks.operator-validation.results.package_name)"
+          value: "$(tasks.validate-pr-title.results.operator_name)"
       workspaces:
         - name: source
           workspace: repository
@@ -387,7 +384,7 @@ spec:
 
     - name: content-hash
       runAfter:
-        - get-bundle-path
+        - bundle-path-validation
       taskRef:
         name: content-hash
       params:
@@ -423,7 +420,6 @@ spec:
     # Those steps are also a part of the CI pipeline.
     - name: dockerfile-creation
       runAfter:
-        - operator-validation
         - annotations-validation
         - get-supported-versions
         - yaml-lint
@@ -452,7 +448,7 @@ spec:
         kind: Task
       params:
         - name: IMAGE
-          value: &bundleImage "$(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name):$(tasks.operator-validation.results.bundle_version)"
+          value: &bundleImage "$(params.registry)/$(params.image_namespace)/$(tasks.validate-pr-title.results.operator_name):$(tasks.validate-pr-title.results.bundle_version)"
         - name: CONTEXT
           value: "$(tasks.get-bundle-path.results.bundle_path)"
       workspaces:
@@ -472,7 +468,7 @@ spec:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
         - name: repository
-          value: "$(params.image_namespace)/$(tasks.operator-validation.results.package_name)"
+          value: "$(params.image_namespace)/$(tasks.validate-pr-title.results.operator_name)"
         - name: visibility
           value: public
         - name: oauth_secret_name
@@ -510,7 +506,7 @@ spec:
         kind: Task
       params:
         - name: IMAGE
-          value: &bundleIndexImage "$(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name)-index:$(tasks.operator-validation.results.bundle_version)"
+          value: &bundleIndexImage "$(params.registry)/$(params.image_namespace)/$(tasks.validate-pr-title.results.operator_name)-index:$(tasks.validate-pr-title.results.bundle_version)"
         - name: DOCKERFILE
           value: "$(tasks.generate-index.results.index_dockerfile)"
       workspaces:
@@ -530,7 +526,7 @@ spec:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
         - name: repository
-          value: "$(params.image_namespace)/$(tasks.operator-validation.results.package_name)-index"
+          value: "$(params.image_namespace)/$(tasks.validate-pr-title.results.operator_name)-index"
         - name: visibility
           value: public
         - name: oauth_secret_name
@@ -586,10 +582,10 @@ spec:
           value: operator
         - name: bundle_index_image
           value: >-
-            $(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name)-index:$(tasks.operator-validation.results.bundle_version)
+            $(params.registry)/$(params.image_namespace)/$(tasks.validate-pr-title.results.operator_name)-index:$(tasks.validate-pr-title.results.bundle_version)
         - name: bundle_image
           value: >-
-            $(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name):$(tasks.operator-validation.results.bundle_version)
+            $(params.registry)/$(params.image_namespace)/$(tasks.validate-pr-title.results.operator_name):$(tasks.validate-pr-title.results.bundle_version)
         - name: skip
           value: "$(tasks.get-ci-results-attempt.results.preflight_results_exists)"
       workspaces:
@@ -624,9 +620,9 @@ spec:
         - name: cert_project_id
           value: "$(tasks.certification-project-check.results.certification_project_id)"
         - name: bundle_version
-          value: "$(tasks.operator-validation.results.bundle_version)"
+          value: "$(tasks.validate-pr-title.results.bundle_version)"
         - name: package_name
-          value: "$(tasks.operator-validation.results.package_name)"
+          value: "$(tasks.validate-pr-title.results.operator_name)"
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: connect_url
@@ -665,7 +661,7 @@ spec:
         - name: bundle_version
           value: "$(tasks.validate-pr-title.results.bundle_version)"
         - name: operator_name
-          value: "$(tasks.operator-validation.results.package_name)"
+          value: "$(tasks.validate-pr-title.results.operator_name)"
         - name: pyxis_cert_path
           value: $(workspaces.pyxis-ssl-credentials.path)/operator-pipeline.pem
         - name: pyxis_key_path
@@ -764,7 +760,9 @@ spec:
 
   finally:
 
-    # Upload the logs of this pipeline
+    # Upload the logs of this pipeline.
+    # Dependencies on other task results should be minimized. If any
+    # of those tasks fail, it'll prevent this task from executing.
     - name: upload-pipeline-logs
       taskRef:
         name: upload-pipeline-logs
@@ -779,9 +777,9 @@ spec:
         - name: cert_project_id
           value: "$(tasks.certification-project-check.results.certification_project_id)"
         - name: bundle_version
-          value: "$(tasks.operator-validation.results.bundle_version)"
+          value: "$(tasks.validate-pr-title.results.bundle_version)"
         - name: package_name
-          value: "$(tasks.operator-validation.results.package_name)"
+          value: "$(tasks.validate-pr-title.results.operator_name)"
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: pipeline_name

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -120,10 +120,26 @@ spec:
         - name: git_pr_title
           value: $(params.git_pr_title)
 
+    # Verify the bundle path exists
+    - name: bundle-path-validation
+      runAfter:
+        - get-bundle-path
+      taskRef:
+        name: bundle-path-validation
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: bundle_path
+          value: "$(tasks.get-bundle-path.results.bundle_path)"
+      workspaces:
+        - name: source
+          workspace: repository
+          subPath: src
+
     # Compute a hash of the content so pipeline logs can be uploaded with it
     - name: content-hash
       runAfter:
-        - get-bundle-path
+        - bundle-path-validation
       taskRef:
         name: content-hash
       params:
@@ -139,7 +155,7 @@ spec:
     # Get cert project id
     - name: certification-project-check
       runAfter:
-        - get-bundle-path
+        - bundle-path-validation
       taskRef:
         name: certification-project-check
       params:
@@ -154,7 +170,6 @@ spec:
 
     - name: create-support-link-for-pr
       runAfter:
-        - set-env
         - certification-project-check
       taskRef:
         name: create-support-link-for-pr
@@ -171,7 +186,7 @@ spec:
     # Get the bundle versions to build index
     - name: get-supported-versions
       runAfter:
-        - get-bundle-path
+        - bundle-path-validation
       taskRef:
         name: get-supported-versions
       params:
@@ -179,26 +194,6 @@ spec:
           value: "$(params.pipeline_image)"
         - name: bundle_path
           value: "$(tasks.get-bundle-path.results.bundle_path)"
-      workspaces:
-        - name: source
-          workspace: repository
-          subPath: src
-
-    # This task is needed only because of it's second step, which
-    # parses the bundle path and returns the package_name and bundle_version.
-    # TODO: split this task
-    - name: operator-validation
-      runAfter:
-        - get-bundle-path
-      taskRef:
-        name: operator-validation
-      params:
-        - name: pipeline_image
-          value: "$(params.pipeline_image)"
-        - name: bundle_path
-          value: "$(tasks.get-bundle-path.results.bundle_path)"
-        - name: pyxis_url
-          value: "$(tasks.set-env.results.pyxis_url)"
       workspaces:
         - name: source
           workspace: repository
@@ -252,13 +247,13 @@ spec:
 
     - name: inspect-image
       runAfter:
-        - operator-validation
+        - bundle-path-validation
       taskRef:
         name: inspect-image
         kind: Task
       params:
         - name: image
-          value: &bundleImage "$(params.registry)/$(params.image_namespace)/$(tasks.operator-validation.results.package_name):$(tasks.operator-validation.results.bundle_version)"
+          value: &bundleImage "$(params.registry)/$(params.image_namespace)/$(tasks.bundle-path-validation.results.package_name):$(tasks.bundle-path-validation.results.bundle_version)"
         - name: registry
           value: $(params.registry)
       workspaces:
@@ -287,7 +282,7 @@ spec:
         - name: is_latest
           value: "$(params.is_latest)"
         - name: bundle_version
-          value: "$(tasks.operator-validation.results.bundle_version)"
+          value: "$(tasks.bundle-path-validation.results.bundle_version)"
         - name: connect_registry
           value: "$(tasks.set-env.results.connect_registry)"
       workspaces:
@@ -299,7 +294,7 @@ spec:
       runAfter:
         - publish-to-ocp-registry
         - get-supported-versions
-        - operator-validation
+        - bundle-path-validation
       taskRef:
         name: trigger-marketplace-replication
       params:
@@ -310,7 +305,7 @@ spec:
         - name: ibm_webhook_token_secret_key
           value: "$(params.ibm_webhook_token_secret_key)"
         - name: package
-          value: "$(tasks.operator-validation.results.package_name)"
+          value: "$(tasks.bundle-path-validation.results.package_name)"
         - name: pipeline_image
           value: "$(params.pipeline_image)"
         - name: ocp_version
@@ -318,7 +313,7 @@ spec:
         - name: organization
           value: "$(tasks.get-cert-project-related-data.results.organization)"
         - name: version
-          value: "$(tasks.operator-validation.results.bundle_version)"
+          value: "$(tasks.bundle-path-validation.results.bundle_version)"
       workspaces:
         - name: source
           workspace: repository
@@ -347,7 +342,7 @@ spec:
         - name: pyxis_key_path
           value: $(workspaces.pyxis-ssl-credentials.path)/operator-pipeline.key
         - name: bundle_version
-          value: "$(tasks.operator-validation.results.bundle_version)"
+          value: "$(tasks.bundle-path-validation.results.bundle_version)"
         - name: is_latest
           value: "$(params.is_latest)"
       workspaces:
@@ -407,7 +402,9 @@ spec:
 
   finally:
 
-    # Upload the logs of this pipeline
+    # Upload the logs of this pipeline.
+    # Dependencies on other task results should be minimized. If any
+    # of those tasks fail, it'll prevent this task from executing.
     - name: upload-pipeline-logs
       taskRef:
         name: upload-pipeline-logs
@@ -422,9 +419,9 @@ spec:
         - name: cert_project_id
           value: "$(tasks.certification-project-check.results.certification_project_id)"
         - name: bundle_version
-          value: "$(tasks.operator-validation.results.bundle_version)"
+          value: "$(tasks.bundle-path-validation.results.bundle_version)"
         - name: package_name
-          value: "$(tasks.operator-validation.results.package_name)"
+          value: "$(tasks.bundle-path-validation.results.package_name)"
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: pipeline_name

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/bundle-path-validation.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/bundle-path-validation.yml
@@ -2,15 +2,12 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: operator-validation
+  name: bundle-path-validation
 spec:
   params:
     - name: pipeline_image
     - name: bundle_path
-      description: path indicating the location of the certified bundle within the repository
-    - name: pyxis_url
-      description: URL of the Pyxis- API for accessing container metadata.
-      default: https://catalog.redhat.com/api/containers/
+      description: path indicating the location of the Operator bundle within the repository
   results:
     - name: package_name
       description: Operator package name


### PR DESCRIPTION
The operator-validation task was renamed to bundle-path-validation to
better reflect what it verifies. When uploading logs from the hosted and
release pipelines, the package name and bundle version are taken from
verify-pr-title because it's the earliest moment these values are known.
Hence increasing the odds that logs will be available to the partner.