### PR TITLE
Fixing issue with manual pinning

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
@@ -57,8 +57,16 @@ spec:
         BUNDLE_PATH=$(realpath $(params.bundle_path))
         ls -l $BUNDLE_PATH
         operator-manifest pin $BUNDLE_PATH
+    - name: verify-pinning
+      image: "$(params.pipeline_image)"
+      workingDir: $(workspaces.source.path)
+      script: |
+        #! /usr/bin/env bash
+        set -xe
+        cat replacements.json
+        REPLACEMENT_COUNT=$(jq length replacements.json)
 
-        if [[ $(git diff --stat) != '' ]]; then
+        if [[ $REPLACEMENT_COUNT -gt 0 ]]; then
           echo "Manifests were not pinned."
           echo -n "true" | tee $(results.dirty_flag.path)
         else


### PR DESCRIPTION
In our current implementation only output from the `manifest-pinning` tool is accepted. Partners who wanted to manually pin their images were unsuccessful unless the were able to duplicate the output of the pinning tool manually.  This caused us to fail CSVs that were in fact pinned but maybe listed in. a different order or using a different naming scheme than what was produced by the pinning tool. In this implementation we use the output of the pinning tool's `replacements.json` instead of `git diff` which requires a perfect line for line match to the pining tool. Any unpinned images will be captured in `replacements.json` therefore we use `jq` to determine the length of that json object.  If the object length is 0 then all images are pinned according to the `manifest-pinning` tool. 