### PR TITLE
Add pipeline summary GitHub comments

### DIFF
--- a/ansible/inventory/group_vars/operator-pipeline-dev.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-dev.yml
@@ -4,7 +4,7 @@ branch: "{{ env }}"
 operator_pipeline_webhook_secret: ../../vaults/common/github-webhook-secret-preprod.txt
 kerberos_keytab: ../../vaults/common/nonprod-operatorpipelines.keytab
 
-operator_pipeline_image_tag: "v1.0.5"
+operator_pipeline_image_tag: "v1.0.6"
 
 # how many of newest pipelineruns should be preserved on cleanup?
 preserve_after_cleanup: "5"

--- a/ansible/inventory/group_vars/operator-pipeline-prod.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-prod.yml
@@ -4,7 +4,7 @@ branch: main
 operator_pipeline_webhook_secret: ../../vaults/prod/github-webhook-secret-prod.txt
 kerberos_keytab: ../../vaults/prod/operatorpipelines.keytab
 
-operator_pipeline_image_tag: "v1.0.5"
+operator_pipeline_image_tag: "v1.0.6"
 
 # how many of newest pipelineruns should be preserved on cleanup?
 preserve_after_cleanup: "10"

--- a/ansible/inventory/group_vars/operator-pipeline-qa.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-qa.yml
@@ -4,7 +4,7 @@ branch: "{{ env }}"
 operator_pipeline_webhook_secret: ../../vaults/common/github-webhook-secret-preprod.txt
 kerberos_keytab: ../../vaults/common/nonprod-operatorpipelines.keytab
 
-operator_pipeline_image_tag: "v1.0.5"
+operator_pipeline_image_tag: "v1.0.6"
 
 # how many of newest pipelineruns should be preserved on cleanup?
 preserve_after_cleanup: "5"

--- a/ansible/inventory/group_vars/operator-pipeline-stage.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-stage.yml
@@ -4,7 +4,7 @@ branch: "{{ env }}"
 operator_pipeline_webhook_secret: ../../vaults/common/github-webhook-secret-preprod.txt
 kerberos_keytab: ../../vaults/common/nonprod-operatorpipelines.keytab
 
-operator_pipeline_image_tag: "v1.0.5"
+operator_pipeline_image_tag: "v1.0.6"
 
 # how many of newest pipelineruns should be preserved on cleanup?
 preserve_after_cleanup: "5"

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -40,7 +40,7 @@ spec:
       default: "false"
     - name: pipeline_image
       description: An image of operator-pipeline-images.
-      default: "quay.io/redhat-isv/operator-pipelines-images:v1.0.5"
+      default: "quay.io/redhat-isv/operator-pipelines-images:v1.0.6"
   workspaces:
     - name: pipeline
     - name: kubeconfig

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -30,7 +30,7 @@ spec:
       description: The namespace/organization all built images will be pushed to.
     - name: pipeline_image
       description: An image of operator-pipeline-images.
-      default: "quay.io/redhat-isv/operator-pipelines-images:v1.0.5"
+      default: "quay.io/redhat-isv/operator-pipelines-images:v1.0.6"
     - name: github_token_secret_name
       description: The name of the Kubernetes Secret that contains the GitHub token.
       default: github-bot-token

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -57,7 +57,7 @@ spec:
     - name: gpg-key
       description: GPG private key that decrypts secrets partner's data
   tasks:
-    # Set a pending GitHub status check first to provide the user with immeditate feedback.
+    # Set a pending GitHub status check first to provide the user with immediate feedback.
     - name: set-github-status-pending
       taskRef:
         name: set-github-status
@@ -790,7 +790,7 @@ spec:
           value: $(workspaces.pyxis-ssl-credentials.path)/operator-pipeline.key
 
     # In the event of a failure, comment with the support link on the github PR
-    - name: github-add-comment
+    - name: github-add-support-comment
       when:
         - input: $(tasks.status)
           operator: notin
@@ -903,3 +903,29 @@ spec:
           value: "$(params.github_token_secret_name)"
         - name: github_token_secret_key
           value: "$(params.github_token_secret_key)"
+
+    # Comment with a pipeline summary
+    - name: github-add-summary-comment
+      taskRef:
+        name: github-pipelinerun-summary
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: request_url
+          value: "$(params.git_pr_url)"
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
+        - name: pipelinerun
+          value: "$(context.pipelineRun.name)"
+        - name: comment_suffix
+          value: |
+
+            ## Troubleshooting
+
+            Please refer to the [troubleshooting guide](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md).
+      workspaces:
+        - name: output
+          workspace: results
+          subPath: summary

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -29,7 +29,7 @@ spec:
       default: "prod"
     - name: pipeline_image
       description: An image of operator-pipeline-images.
-      default: "quay.io/redhat-isv/operator-pipelines-images:v1.0.5"
+      default: "quay.io/redhat-isv/operator-pipelines-images:v1.0.6"
     - name: github_token_secret_name
       description: The name of the Kubernetes Secret that contains the GitHub token.
       default: github-bot-token

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -432,7 +432,7 @@ spec:
           value: $(workspaces.pyxis-ssl-credentials.path)/operator-pipeline.key
 
     # In the event of a failure, comment with the support link on the github PR
-    - name: github-add-comment
+    - name: github-add-support-comment
       when:
         - input: $(tasks.status)
           operator: notin
@@ -572,3 +572,23 @@ spec:
           value: "$(params.github_token_secret_name)"
         - name: github_token_secret_key
           value: "$(params.github_token_secret_key)"
+
+    # Comment with a pipeline summary
+    - name: github-add-summary-comment
+      taskRef:
+        name: github-pipelinerun-summary
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: request_url
+          value: "$(params.git_pr_url)"
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
+        - name: pipelinerun
+          value: "$(context.pipelineRun.name)"
+      workspaces:
+        - name: output
+          workspace: results
+          subPath: summary

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/github-add-comment.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/github-add-comment.yml
@@ -89,6 +89,8 @@ spec:
               key: $(params.GITHUB_TOKEN_SECRET_KEY)
 
       image: registry.access.redhat.com/ubi8/ubi-minimal:8.2
+      # TODO: Store this script elsewhere
+      # https://issues.redhat.com/browse/ISV-1386
       script: |
         #!/usr/libexec/platform-python
         import json

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
@@ -1,0 +1,139 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: github-pipelinerun-summary
+spec:
+  description: >-
+    This task adds a PipelineRun summary comment to a GitHub pull request.
+  workspaces:
+    - name: output
+      description: Scratch space and storage for the comment
+
+  params:
+    - name: github_host_url
+      description: |
+        The GitHub host, adjust this if you run a GitHub enteprise.
+      default: "api.github.com"
+
+    - name: api_path_prefix
+      description: |
+        The API path prefix, GitHub Enterprise has a prefix e.g. /api/v3
+      default: ""
+
+    - name: request_url
+      description: |
+        The GitHub issue or pull request URL where we want to add a new
+        comment.
+
+    - name: github_token_secret_name
+      description: |
+        The name of the Kubernetes Secret that contains the GitHub token.
+      default: github
+
+    - name: github_token_secret_key
+      description: |
+        The key within the Kubernetes Secret that contains the GitHub token.
+      default: token
+
+    - name: pipelinerun
+      description: The name of the PipelineRun to summarize.
+
+    - name: pipeline_image
+      description: The common pipeline image.
+
+    - name: comment_suffix
+      description: A comment to append to the end of the summary
+      default: ""
+
+  steps:
+    - name: gather-info
+      workingDir: $(workspaces.output.path)
+      image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:cc8bbdb079578605a66447529d7de76f32882dc2ada571e39ff18e483cdbdf49
+      script: |
+        #! /usr/bin/env bash
+        set -xe
+
+        PR_NAME="$(params.pipelinerun)"
+        mkdir $PR_NAME
+
+        echo "Getting PipelineRun details"
+        tkn pipelinerun describe $PR_NAME -o json > $PR_NAME/pipelinerun.json
+
+        echo "Getting TaskRun details"
+        tkn taskrun list \
+          --label 'tekton.dev/pipelineRun'=="$PR_NAME" \
+          -o jsonpath='{.items}' \
+          > $PR_NAME/taskruns.json
+
+        chmod -R 777 $PR_NAME
+
+    - name: build-comment
+      workingDir: $(workspaces.output.path)
+      image: "$(params.pipeline_image)"
+      script: |
+        #! /usr/bin/env bash
+        set -xe
+
+        PR_NAME="$(params.pipelinerun)"
+
+        pipelinerun-summary $PR_NAME/pipelinerun.json $PR_NAME/taskruns.json \
+          > $PR_NAME/comment.md
+
+        if [ ! -z "$(params.comment_suffix)" ]; then
+          echo "$(params.comment_suffix)" >> $PR_NAME/comment.md
+        fi
+
+    - name: post-comment
+      workingDir: $(workspaces.output.path)
+      env:
+        - name: GITHUBTOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.github_token_secret_name)
+              key: $(params.github_token_secret_key)
+      image: registry.access.redhat.com/ubi8/ubi-minimal:8.2
+      # TODO: Store this script elsewhere
+      # https://issues.redhat.com/browse/ISV-1386
+      script: |
+        #!/usr/libexec/platform-python
+        import json
+        import os
+        import sys
+        import http.client
+        import urllib.parse
+
+        split_url = urllib.parse.urlparse(
+            "$(params.request_url)").path.split("/")
+
+        # This will convert https://github.com/foo/bar/pull/202 to
+        # api url path /repos/foo/issues/
+        api_url = "{base}/repos/{package}/issues/{id}".format(
+          base="", package="/".join(split_url[1:3]), id=split_url[-1])
+
+        with open("$(params.pipelinerun)/comment.md") as fh:
+          data = {"body": fh.read()}
+
+        conn = http.client.HTTPSConnection("$(params.github_host_url)")
+
+        method = "POST"
+        target_url = api_url + "/comments"
+
+        print("Sending this data to GitHub with {}: ".format(method))
+        print(data)
+        r = conn.request(
+            method,
+            target_url,
+            body=json.dumps(data),
+            headers={
+                "User-Agent": "TektonCD, the peaceful cat",
+                "Authorization": "Bearer " + os.environ["GITHUBTOKEN"],
+            })
+        resp = conn.getresponse()
+
+        if not str(resp.status).startswith("2"):
+            print("Error: %d" % (resp.status))
+            print(resp.read())
+            sys.exit(1)
+        else:
+            print("A GitHub comment has been added to $(params.request_url)")


### PR DESCRIPTION
It's not possible to chain these pipeline tasks together with the github-add-comment task because Tekton runs everything in `finally` in parallel.

There is some code duplication so I filed a [jira issue](https://issues.redhat.com/browse/ISV-1386) to reduce this later.

I'm also placing this on hold until #157 and https://github.com/redhat-openshift-ecosystem/operator-pipelines-images/pull/45 are merged in their new home. The `pipeline_image` param default will need to be updated as well.