### PR TITLE
Adding an explicit check for relatedImages

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -381,6 +381,8 @@ spec:
       params:
         - name: dirty_flag
           value: "$(tasks.digest-pinning.results.dirty_flag)"
+        - name: related_images_flag
+          value: "$(tasks.digest-pinning.results.related_images_flag)"
 
     - name: content-hash
       runAfter:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
@@ -11,6 +11,7 @@ spec:
     - name: pipeline_image
   results:
     - name: dirty_flag
+    - name: related_images_flag
   workspaces:
     - name: source
     - name: registry-credentials
@@ -78,4 +79,30 @@ spec:
         else
           echo "Manifests are pinned."
           echo -n "false" | tee $(results.dirty_flag.path)
+        fi
+    - name: verify-related-images
+      image: "$(params.pipeline_image)"
+      workingDir: $(workspaces.source.path)
+      script: |
+        #! /usr/bin/env bash
+        set -xe
+
+        if [ "$(params.enabled)" != "true" ]; then
+          echo "Digest pinning is not enabled"
+          echo -n "true" | tee $(results.related_images_flag.path)
+          exit 0
+        fi
+
+        BUNDLE_PATH=$(realpath $(params.bundle_path))
+        cat references.json
+        REFERENCE_COUNT=$(jq length references.json)
+        CSVFILE=$(find $BUNDLE_PATH -name "*clusterserviceversion.yaml" -o -name "*clusterserviceversion.yml")
+        RELATED_IMAGE_COUNT=$(yq -e '.spec.relatedImages | length' $CSVFILE)
+
+        if [[ $REPLACEMENT_COUNT == $RELATED_IMAGE_COUNT ]]; then
+          echo "Related images section exists."
+          echo -n "true" | tee $(results.related_images_flag.path)
+        else
+          echo "Related images section does not exist."
+          echo -n "false" | tee $(results.related_images_flag.path)
         fi

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/verify-pinned-digest.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/verify-pinned-digest.yml
@@ -6,6 +6,7 @@ metadata:
 spec:
   params:
     - name: dirty_flag
+    - name: related_images_flag
   steps:
     - name: check-dirty-flag
       image: registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe
@@ -15,5 +16,15 @@ spec:
         echo $DIRTY_FLAG
         if [ $DIRTY_FLAG == "true" ]; then
           echo "There are unpinned images digests!"
+          exit 1
+        fi
+    - name: check-related-images
+      image: registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe
+      script: |
+        #! /usr/bin/env bash
+        RELATED_IMAGES_FLAG="$(params.related_images_flag)"
+        echo $RELATED_IMAGES_FLAG
+        if [ $RELATED_IMAGES_FLAG == "false" ]; then
+          echo "The relatedImages section is missing from the CSV"
           exit 1
         fi


### PR DESCRIPTION
With the resent modification to allow partners to manually pin their digest, we were not checking for relatedImages in that case.  RelatedImages are required for Marketplace.  This check uses the digest pinning tool to get the number of images in the CSV and make sure there is an equal number of images listed in the relatedImages.  In a future PR we can use a more robust check that does more than comparing image counts in the CSV to image counts in the relatedImages section. 