### PR TITLE
Allowing the ci.yaml to be modified

### DIFF
--- a/operator-pipeline-images/operatorcert/__init__.py
+++ b/operator-pipeline-images/operatorcert/__init__.py
@@ -218,24 +218,30 @@ def get_files_added_in_pr(
     rsp = requests.get(compare_changes_url)
     rsp.raise_for_status()
 
-    added_files_names = []
+    added_files = []
     modified_files = []
+    allowed_files = []
     for file in rsp.json().get("files", []):
         if file["status"] == "added":
-            added_files_names.append(file["filename"])
+            added_files.append(file["filename"])
         else:
             # To prevent the modifications to previously merged bundles,
             # we allow only changed with status "added"
             modified_files.append(file)
 
+    allowed_files.extend(added_files)
+
     if modified_files:
         for modified_file in modified_files:
-            logging.error(
-                f"Change not permitted: file: {modified_file['filename']}, status: {modified_file['status']}"
-            )
-        raise RuntimeError("There are changes done to previously merged files")
+            if not modified_file["filename"].endswith("ci.yaml"):
+                logging.error(
+                    f"Change not permitted: file: {modified_file['filename']}, status: {modified_file['status']}"
+                )
+                raise RuntimeError("There are changes done to previously merged files")
+            else:
+                allowed_files.append(modified_file["filename"])
 
-    return added_files_names
+    return allowed_files
 
 
 def verify_changed_files_location(

--- a/operator-pipeline-images/tests/test_operatorcert.py
+++ b/operator-pipeline-images/tests/test_operatorcert.py
@@ -174,6 +174,27 @@ def test_get_files_added_in_pr_changed_files(mock_get: MagicMock):
     )
 
 
+@patch("requests.get")
+def test_get_files_added_in_pr_changed_ci_yaml(mock_get: MagicMock):
+    mock_rsp = MagicMock()
+    mock_rsp.json.return_value = {
+        "irrelevant_key": "abc",
+        "files": [
+            {"filename": "ci.yaml", "status": "changed"},
+        ],
+    }
+    mock_get.return_value = mock_rsp
+    files = operatorcert.get_files_added_in_pr(
+        "rh", "operator-repo", "main", "user:fixup"
+    )
+
+    mock_get.assert_called_with(
+        "https://api.github.com/repos/rh/operator-repo/compare/main...user:fixup"
+    )
+
+    assert files == ["ci.yaml"]
+
+
 @pytest.mark.parametrize(
     "wrong_change",
     [


### PR DESCRIPTION
Currenty, STEP-VERIFY-CHANGED-DIRECTORIES will fail if a PR includes changes to the `ci.yaml` file. The current implementation rejects any files in a PR that do not have a status of `added` therefore all `modified` files are rejected. This patch adds a single exception to that rule for the `ci.yaml` file.  This will allow users to set `merge:false` in `ci.yaml` and covers a few edge cases where a `cert_projet_id` may need to be modified. 