### PR TITLE
Fix relatedImages bug and improve err msg

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
@@ -99,10 +99,10 @@ spec:
         CSVFILE=$(find $BUNDLE_PATH -name "*clusterserviceversion.yaml" -o -name "*clusterserviceversion.yml")
         RELATED_IMAGE_COUNT=$(yq -e '.spec.relatedImages | length' $CSVFILE)
 
-        if [[ $REPLACEMENT_COUNT == $RELATED_IMAGE_COUNT ]]; then
+        if [[ $RELATED_IMAGE_COUNT >= $REFERENCE_COUNT ]]; then
           echo "Related images section exists."
           echo -n "true" | tee $(results.related_images_flag.path)
         else
-          echo "Related images section does not exist."
+          echo "The relatedImages section does not exist or is missing images."
           echo -n "false" | tee $(results.related_images_flag.path)
         fi


### PR DESCRIPTION
Missed a bug on this that was referencing the wrong variable. We were using `$REPLACEMENT_COUNT` instead of `$REFERENCE_COUNT` in the `verified_related_images` step. 

Fixing case were the digest tool places duplicate images in the `relatedImages `section.  Now we check that the number of images in the `relatedImages` section is greater than or equal to the `$REFERENCE_COUNT`

Also improved the error message. 