### PR TITLE
Set hosted pipeline timeout to 2 hours

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/webhook-hosted-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/webhook-hosted-pipeline-trigger.yml
@@ -81,6 +81,8 @@
                 metadata:
                   generateName: operator-hosted-pipeline-run
                 spec:
+                  timeouts:
+                    pipeline: "2h0m0s"
                   pipelineRef:
                     name: operator-hosted-pipeline
                   params:


### PR DESCRIPTION
Some older versions of OpenShift takes 45-60 min to spin up in DPTP,
so the pipeline will fail with the default timeout (1 hour).

Jira: CLOUDWF-6863