### PR TITLE
Change timeouts config in the hosted pipelien trigger to timeout

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/webhook-hosted-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/webhook-hosted-pipeline-trigger.yml
@@ -81,8 +81,7 @@
                 metadata:
                   generateName: operator-hosted-pipeline-run
                 spec:
-                  timeouts:
-                    pipeline: "2h0m0s"
+                  timeout: "2h"
                   pipelineRef:
                     name: operator-hosted-pipeline
                   params:


### PR DESCRIPTION
The timeouts.pipeline config is not available in the version of
Tekton pipeline that we use, have to use timeout which is older.