### PR TITLE
Tests for Hosted pipeline

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -136,28 +136,28 @@ jobs:
           bash init-custom-env.sh $OC_PROJECT stage vault-password
           popd
 
-      #- name: Run CI pipeline
-      #  run: |
-      #    tkn pipeline start operator-ci-pipeline \
-      #      --use-param-defaults \
-      #      --param git_repo_url=git@github.com:redhat-openshift-ecosystem/operator-pipelines-test.git \
-      #      --param git_branch=$SHORT_SHA \
-      #      --param bundle_path=operators/test-e2e-operator/0.0.7-$SHORT_SHA \
-      #      --param env=stage \
-      #      --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
-      #      --workspace name=kubeconfig,secret=kubeconfig \
-      #      --workspace name=ssh-dir,secret=github-ssh-credentials \
-      #      --workspace name=pyxis-api-key,secret=pyxis-api-secret \
-      #      --showlog
+      - name: Run CI pipeline
+        run: |
+          tkn pipeline start operator-ci-pipeline \
+            --use-param-defaults \
+            --param git_repo_url=git@github.com:redhat-openshift-ecosystem/operator-pipelines-test.git \
+            --param git_branch=$SHORT_SHA \
+            --param bundle_path=operators/test-e2e-operator/0.0.7-$SHORT_SHA \
+            --param env=stage \
+            --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
+            --workspace name=kubeconfig,secret=kubeconfig \
+            --workspace name=ssh-dir,secret=github-ssh-credentials \
+            --workspace name=pyxis-api-key,secret=pyxis-api-secret \
+            --showlog
 
-      #- name: Check if CI pipeline passed
-      #  run: |
-      #    PIPELINERUN_NAME=$(oc get pr -l tekton.dev/pipeline=operator-ci-pipeline --no-headers -o custom-columns=":metadata.name")
-      #    PIPELINERUN_SUCCEEDED=$(oc get pr $PIPELINERUN_NAME -o jsonpath={'.status.conditions[].status'})
-      #    if [[ "$PIPELINERUN_SUCCEEDED" != "True" ]]; then
-      #      oc get pr
-      #      exit 1
-      #    fi
+      - name: Check if CI pipeline passed
+        run: |
+          PIPELINERUN_NAME=$(oc get pr -l tekton.dev/pipeline=operator-ci-pipeline --no-headers -o custom-columns=":metadata.name")
+          PIPELINERUN_SUCCEEDED=$(oc get pr $PIPELINERUN_NAME -o jsonpath={'.status.conditions[].status'})
+          if [[ "$PIPELINERUN_SUCCEEDED" != "True" ]]; then
+            oc get pr
+            exit 1
+          fi
 
       - name: Run Hosted pipeline
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,6 +39,8 @@ jobs:
     env:
       SHORT_SHA: ${{needs.prepare-env-job.outputs.short_sha}}
       PR_BASE_BRANCH: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
+      # This env is needed for hub cli
+      GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
     steps:
       # Clone repository operator-pipelines-test on branch e2e-test-operator
       - uses: actions/checkout@v2
@@ -86,10 +88,9 @@ jobs:
       # Get the number of the created PR- it's used for cleanup
       - id: get_pr_number
         run: |
-          echo "test"
-          hub pr show --head ${PR_BASE_BRANCH} -f "%I"
+          hub pr show -f "%I"
           hub pr show --head ${PR_BASE_BRANCH} --url
-          PR_NUMBER=$(hub pr show --head ${PR_BASE_BRANCH} -f "%I")
+          PR_NUMBER=$(hub pr show -f "%I")
           echo "::set-output name=pr_number::${PR_NUMBER}"
 
   # Deploy and run the E2E tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Check if Hosted pipeline passed
         run: |
-          PIPELINERUN_NAME=$(oc get pr --no-headers -l tekton.dev/pipeline=operator-ci-pipeline -o custom-columns=":metadata.name")
+          PIPELINERUN_NAME=$(oc get pr --no-headers -l tekton.dev/pipeline=operator-hosted-pipeline -o custom-columns=":metadata.name")
           PIPELINERUN_SUCCEEDED=$(oc get pr $PIPELINERUN_NAME -o jsonpath={'.status.conditions[].status'})
           if [[ "$PIPELINERUN_SUCCEEDED" != "True" ]]; then
             oc get pr

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,7 @@
 ---
 name: E2E-CI
+# TODO: Document the secrets!
+# TODO: Document, how the partner can use this workflow!
 
 on:  # yamllint disable-line rule:truthy
   push:
@@ -9,6 +11,10 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
   workflow_dispatch:
 jobs:
+
+  # envs  for other jobs are prepared as outputs of this task. Outputs are a good way to
+  # concatenate strings and use them as values to keywords other than "run".
+  # For run, they can be used after redeclared in keyword "env".
   prepare-env-job:
      runs-on: ubuntu-latest
      outputs:
@@ -16,50 +22,70 @@ jobs:
        pr_title: ${{ steps.prepare.outputs.pr_title }}
        oc_project: ${{ steps.prepare.outputs.oc_project}}
      steps:
-       - uses: actions/checkout@v2
        - id: prepare
          run: |
-           SHORT_SHA=$(git rev-parse --short HEAD)
-           echo "::set-output name=short_sha::$SHORT_SHA"
+           echo "::set-output name=short_sha::${GITHUB_SHA::7}"
            echo "::set-output name=pr_title::operator test-e2e-operator (0.0.7-${SHORT_SHA})"
            echo "::set-output name=oc_project::test-e2e-${SHORT_SHA}"
+           echo "::set-output name=test_pr_base_branch::${SHORT_SHA}-base"
+
+  # Create a Pull Request with the fake version of fake operator in the repository operator-pipelines-test.
+  # Pipelines will run against this PR.
   prepare-test-data:
     runs-on: ubuntu-latest
     needs: prepare-env-job
     env:
       SHORT_SHA: ${{needs.prepare-env-job.outputs.short_sha}}
+      PR_BASE_BRANCH: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
     steps:
+      # Clone repository operator-pipelines-test on branch e2e-test-operator
       - uses: actions/checkout@v2
         with:
           repository: 'redhat-openshift-ecosystem/operator-pipelines-test'
           ref: 'e2e-test-operator'
+
+      # Create test branch as copy of main. This branch will be base for
+      # created test PR
+      - name: Create test branch
+        run: |
+          echo "Creating branch $SHORT_SHA-merge as copy of main"
+          git branch -c main ${PR_BASE_BRANCH}
+
+      # Create commit with changes used for E2E tests. This commit contains the `test-e2e-operator`
+      # from branch e2e-test-operator- just with the new version.
       - name: Create commit to create PR with test data
         run: |
-          git config user.name 'rh-operator-bundle-bot'
-          git config user.email 'exd-guild-isv+operators@redhat.com'
-
           cd operators/test-e2e-operator
           mv 0.0.7 0.0.7-$SHORT_SHA
           find ./ -type f -exec sed -i "s/0.0.7/0.0.7-$SHORT_SHA/g" {} \;
           git commit -am "new version of operator"
+
+      # Create PR.
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.BOT_TOKEN }}
           author: 'rh-operator-bundle-bot <exd-guild-isv+operators@redhat.com>'
           commit-message: 'Preparing the data for E2E tests'
+          base: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
           branch: ${{needs.prepare-env-job.outputs.short_sha}}
           title: ${{needs.prepare-env-job.outputs.pr_title}}
           delete-branch: true
           body: 'This is PR used for E2E tests of the operator pipelines'
+
+  # Deploy and run the E2E tests
   run-e2e:
     runs-on: ubuntu-latest
-    needs: prepare-env-job
+    needs:
+      - prepare-test-data
+      - prepare-env-job
     env:
       SHORT_SHA: ${{needs.prepare-env-job.outputs.short_sha}}
       OC_PROJECT: ${{needs.prepare-env-job.outputs.oc_project}}
     steps:
+      # Clone repo
       - uses: actions/checkout@v1
+
       - name: Prepare environment
         run: |
           # Install dependencies
@@ -79,6 +105,7 @@ jobs:
 
           # Prepare vault password
           echo ${{ secrets.VAULT_PASSWORD }} > ansible/vault-password
+
       - name: Deploy e2e environment
         # Default timeout is 2 min
         timeout-minutes: 5
@@ -87,6 +114,7 @@ jobs:
           pushd ansible
           bash init-custom-env.sh $OC_PROJECT stage vault-password
           popd
+
       - name: Run CI pipeline
         run: |
           tkn pipeline start operator-ci-pipeline \
@@ -100,6 +128,7 @@ jobs:
             --workspace name=ssh-dir,secret=github-ssh-credentials \
             --workspace name=pyxis-api-key,secret=pyxis-api-secret \
             --showlog
+
       - name: Check if pipeline passed
         run: |
           PIPELINERUN_NAME=$(oc get pr --no-headers -o custom-columns=":metadata.name")
@@ -108,7 +137,25 @@ jobs:
             oc get pr
             exit 1
           fi
-      - name: Cleanup
+
+  cleanup:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - run-e2e
+      - prepare-env-job
+    steps:
+      - name: Clean OC project
         if: always()
         run: |
           oc delete project $OC_PROJECT
+
+      - name: Clean test branches
+        if: always()
+        uses: dawidd6/action-delete-branch@v3
+        with:
+         github_token: ${{ secrets.BOT_TOKEN }}
+         owner: redhat-openshift-ecosystem
+         repository: operator-pipelines-test
+         branches: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
+         soft_fail: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,8 +78,7 @@ jobs:
           cp -r 0.0.7 0.0.7-$SHORT_SHA
           cd 0.0.7-$SHORT_SHA
           find ./ -type f -exec sed -i "s/0.0.7/0.0.7-$SHORT_SHA/g" {} \;
-          cd -
-          git commit -am "new version of operator"
+          git add --all && git commit -m "new version of operator"
 
       # Create PR.
       - name: Create Pull Request

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,8 +73,9 @@ jobs:
           # Head branch of the PR will be created by create-pull-request action
           git commit -am "new version of operator"
 
-
       - name: Create test PR base branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           git branch -c main ${PR_BASE_BRANCH}
           hub push --set-upstream origin ${PR_BASE_BRANCH}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,6 +63,7 @@ jobs:
       # from branch e2e-test-operator- just with the new version.
       - name: Create commit to create PR with test data
         run: |
+          set -x
           git config user.name 'rh-operator-bundle-bot'
           git config user.email 'exd-guild-isv+operators@redhat.com'
 
@@ -71,7 +72,7 @@ jobs:
 
           rm -rf 0.0.7-*
           # Add, commit and push, if anything was removed.
-          (git add --all && git commit -m "removing previously merged operator" && git push) || echo "No previously merged test operator to remove"
+          (git commit -am "removing previously merged operator" && git push) || echo "No previously merged test operator to remove"
 
           cd operators/test-e2e-operator
           cp -r 0.0.7 0.0.7-$SHORT_SHA

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,9 +55,6 @@ jobs:
       - name: Create test PR base branch
         run: |
           git branch -c main ${PR_BASE_BRANCH}
-          # must checkout to base branch before `create-pull-request` action, as current branch
-          # is used as base for PR
-          git checkout ${PR_BASE_BRANCH}
           git push --set-upstream origin ${PR_BASE_BRANCH}
 
       # Create commit with changes used for E2E tests. This commit contains the `test-e2e-operator`

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,6 +55,9 @@ jobs:
       # from branch e2e-test-operator- just with the new version.
       - name: Create commit to create PR with test data
         run: |
+          git config user.name 'rh-operator-bundle-bot'
+          git config user.email 'exd-guild-isv+operators@redhat.com'
+
           cd operators/test-e2e-operator
           mv 0.0.7 0.0.7-$SHORT_SHA
           find ./ -type f -exec sed -i "s/0.0.7/0.0.7-$SHORT_SHA/g" {} \;

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       short_sha: ${{ steps.prepare.outputs.short_sha }}
       pr_title: ${{ steps.prepare.outputs.pr_title }}
-      oc_project: ${{ steps.prepare.outputs.oc_project}}
+      oc_project: ${{ steps.prepare.outputs.oc_project }}
     steps:
       - id: prepare
         run: |
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare-env-job
     outputs:
-      test_pr_number: ${{ steps.prepare.get_pr_number.pr_number}}
+      test_pr_number: ${{ steps.get_pr_number.outputs.pr_number }}
     env:
       SHORT_SHA: ${{needs.prepare-env-job.outputs.short_sha}}
       PR_BASE_BRANCH: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,7 +86,9 @@ jobs:
       # Get the number of the created PR- it's used for cleanup
       - id: get_pr_number
         run: |
-          PR_NUMBER=$(hub pr show -f %I)
+          hub pr show --head ${PR_BASE_BRANCH} -f %I
+          hub pr show --head ${PR_BASE_BRANCH} --url
+          PR_NUMBER=$(hub pr show --head ${PR_BASE_BRANCH} -f %I)
           echo "::set-output name=pr_number::${PR_NUMBER}"
 
   # Deploy and run the E2E tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -172,6 +172,7 @@ jobs:
           tkn pipeline start operator-hosted-pipeline \
             --use-param-defaults \
             --param git_pr_branch=$SHORT_SHA \
+            --param image_namespace=operator-pipeline-stage \
             --param git_pr_title="${{needs.prepare-env-job.outputs.pr_title}}" \
             --param git_pr_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/${{needs.prepare-test-data.outputs.test_pr_number}} \
             --param git_fork_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,6 +36,9 @@ jobs:
     env:
       SHORT_SHA: ${{needs.prepare-env-job.outputs.short_sha}}
       PR_BASE_BRANCH: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
+    outputs:
+      test_pr_number: ${{ steps.create_pull_request.outputs.pr_number }}
+      test_pr_head_sha: ${{ steps.create_pull_request.outputs.pr_head_sha }}
     steps:
       # Clone repository operator-pipelines-test on branch e2e-test-operator
       - uses: actions/checkout@v2
@@ -167,11 +170,11 @@ jobs:
             --param git_pr_branch=$SHORT_SHA \
             --param image_namespace=operator-pipeline-stage \
             --param git_pr_title="${{needs.prepare-env-job.outputs.pr_title}}" \
-            --param git_pr_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/${{ steps.create_pull_request.outputs.pull-request-number }} \
+            --param git_pr_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/${{needs.prepare-test-data.outputs.test_pr_number}} \
             --param git_fork_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
             --param git_repo_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
             --param git_username=rh-operator-bundle-bot \
-            --param git_commit=${{ steps.create_pull_request.outputs.pull-request-head-sha }} \
+            --param git_commit=${{needs.prepare-test-data.outputs.test_pr_head_sha}} \
             --param git_base_branch=${{needs.prepare-env-job.outputs.test_pr_base_branch}} \
             --param pr_head_label=$SHORT_SHA \
             --param env=stage \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,7 +74,7 @@ jobs:
           git commit -am "removing previously merged operator" && git push || true
 
           cd operators/test-e2e-operator
-          cp 0.0.7 0.0.7-$SHORT_SHA
+          cp -r 0.0.7 0.0.7-$SHORT_SHA
           cd 0.0.7-$SHORT_SHA
           find ./ -type f -exec sed -i "s/0.0.7/0.0.7-$SHORT_SHA/g" {} \;
           git commit -am "new version of operator"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Create test PR base branch
         run: |
           git branch -c main ${PR_BASE_BRANCH}
-          hub push --set-upstream origin $SHORT_SHA
+          hub push --set-upstream origin ${PR_BASE_BRANCH}
 
       # Create PR.
       - name: Create Pull Request

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,8 +70,8 @@ jobs:
           # If something will go wrong with the test branch, backup is on branch e2e-test-operator-backup
 
           rm -rf 0.0.7-*
-          # Commit and push, if anything was removed.
-          git commit -am "removing previously merged operator" && git push || true
+          # Add, commit and push, if anything was removed.
+          git add --all && git commit -m "removing previously merged operator" && git push || true
 
           cd operators/test-e2e-operator
           cp -r 0.0.7 0.0.7-$SHORT_SHA

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,21 +63,22 @@ jobs:
       # from branch e2e-test-operator- just with the new version.
       - name: Create commit to create PR with test data
         run: |
-          set -x
           git config user.name 'rh-operator-bundle-bot'
           git config user.email 'exd-guild-isv+operators@redhat.com'
 
-          # Remove all of previously merged test operators, if there are any.
+          cd operators/test-e2e-operator
+
+          # Remove all of previously merged versions of test operator, if there are any.
           # If something will go wrong with the test branch, backup is on branch e2e-test-operator-backup
 
           rm -rf 0.0.7-*
-          # Add, commit and push, if anything was removed.
+          # Commit and push, if anything was removed.
           (git commit -am "removing previously merged operator" && git push) || echo "No previously merged test operator to remove"
 
-          cd operators/test-e2e-operator
           cp -r 0.0.7 0.0.7-$SHORT_SHA
           cd 0.0.7-$SHORT_SHA
           find ./ -type f -exec sed -i "s/0.0.7/0.0.7-$SHORT_SHA/g" {} \;
+          cd -
           git commit -am "new version of operator"
 
       # Create PR.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,18 +16,18 @@ jobs:
   # concatenate strings and use them as values to keywords other than "run".
   # For run, they can be used after redeclared in keyword "env".
   prepare-env-job:
-     runs-on: ubuntu-latest
-     outputs:
-       short_sha: ${{ steps.prepare.outputs.short_sha }}
-       pr_title: ${{ steps.prepare.outputs.pr_title }}
-       oc_project: ${{ steps.prepare.outputs.oc_project}}
-     steps:
-       - id: prepare
-         run: |
-           echo "::set-output name=short_sha::${GITHUB_SHA::7}"
-           echo "::set-output name=pr_title::operator test-e2e-operator (0.0.7-${GITHUB_SHA::7})"
-           echo "::set-output name=oc_project::test-e2e-${GITHUB_SHA::7}"
-           echo "::set-output name=test_pr_base_branch::${GITHUB_SHA::7}-base"
+    runs-on: ubuntu-latest
+    outputs:
+      short_sha: ${{ steps.prepare.outputs.short_sha }}
+      pr_title: ${{ steps.prepare.outputs.pr_title }}
+      oc_project: ${{ steps.prepare.outputs.oc_project}}
+    steps:
+      - id: prepare
+        run: |
+          echo "::set-output name=short_sha::${GITHUB_SHA::7}"
+          echo "::set-output name=pr_title::operator test-e2e-operator (0.0.7-${GITHUB_SHA::7})"
+          echo "::set-output name=oc_project::test-e2e-${GITHUB_SHA::7}"
+          echo "::set-output name=test_pr_base_branch::${GITHUB_SHA::7}-base"
 
   # Create a Pull Request with the fake version of fake operator in the repository operator-pipelines-test.
   # Pipelines will run against this PR.
@@ -166,11 +166,19 @@ jobs:
       - name: Clean OC project
         if: always()
         run: |
+
+          # Prepare Kubeconfig.
+          # Use GitHub secret which contains the Kubeconfig for SA with admin privilleges (same as in ansible vault)
+          # to create Kubernetes context.
+          mkdir $HOME/.kube
+          cat <<EOF > $HOME/.kube/config
+          ${{ secrets.KUBECONFIG }}
+          EOF
+
           oc delete project $OC_PROJECT
 
       - name: Clean opened PR
-        # run only on failure- on success PR is merged by pipeline
-        if: failure()
+        if: always()
         uses: peter-evans/close-pull@v1
         with:
           repository: 'redhat-openshift-ecosystem/operator-pipelines-test'
@@ -183,8 +191,8 @@ jobs:
         if: always()
         uses: dawidd6/action-delete-branch@v3
         with:
-         github_token: ${{ secrets.BOT_TOKEN }}
-         owner: redhat-openshift-ecosystem
-         repository: operator-pipelines-test
-         branches: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
-         soft_fail: true
+          github_token: ${{ secrets.BOT_TOKEN }}
+          owner: redhat-openshift-ecosystem
+          repository: operator-pipelines-test
+          branches: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
+          soft_fail: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,7 +81,7 @@ jobs:
           cp -r /tmp/test-e2e-operator operators/
 
           # Head branch of the PR will be created by create-pull-request action
-          git commit -am "new version of operator"
+          git add operators && git commit -m "new version of operator"
 
       - name: Create test PR base branch
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,8 +66,16 @@ jobs:
           git config user.name 'rh-operator-bundle-bot'
           git config user.email 'exd-guild-isv+operators@redhat.com'
 
+          # Remove all of previously merged test operators, if there are any.
+          # If something will go wrong with the test branch, backup is on branch e2e-test-operator-backup
+
+          rm -rf 0.0.7-*
+          # Commit and push, if anything was removed.
+          git commit -am "removing previously merged operator" && git push || true
+
           cd operators/test-e2e-operator
-          mv 0.0.7 0.0.7-$SHORT_SHA
+          cp 0.0.7 0.0.7-$SHORT_SHA
+          cd 0.0.7-$SHORT_SHA
           find ./ -type f -exec sed -i "s/0.0.7/0.0.7-$SHORT_SHA/g" {} \;
           git commit -am "new version of operator"
 
@@ -151,7 +159,7 @@ jobs:
 
       #- name: Check if CI pipeline passed
       #  run: |
-      #    PIPELINERUN_NAME=$(oc get pr --no-headers -o custom-columns=":metadata.name")
+      #    PIPELINERUN_NAME=$(oc get pr -l tekton.dev/pipeline=operator-ci-pipeline --no-headers -o custom-columns=":metadata.name")
       #    PIPELINERUN_SUCCEEDED=$(oc get pr $PIPELINERUN_NAME -o jsonpath={'.status.conditions[].status'})
       #    if [[ "$PIPELINERUN_SUCCEEDED" != "True" ]]; then
       #      oc get pr
@@ -185,10 +193,9 @@ jobs:
             --workspace name=gpg-key,secret=isv-gpg-key \
             --showlog
 
-      # TODO: now it can check the CI
       - name: Check if Hosted pipeline passed
         run: |
-          PIPELINERUN_NAME=$(oc get pr --no-headers -o custom-columns=":metadata.name")
+          PIPELINERUN_NAME=$(oc get pr --no-headers -l tekton.dev/pipeline=operator-ci-pipeline -o custom-columns=":metadata.name")
           PIPELINERUN_SUCCEEDED=$(oc get pr $PIPELINERUN_NAME -o jsonpath={'.status.conditions[].status'})
           if [[ "$PIPELINERUN_SUCCEEDED" != "True" ]]; then
             oc get pr
@@ -221,16 +228,7 @@ jobs:
 
           oc delete project $OC_PROJECT
 
-      - name: Clean opened PR
-        if: always()
-        uses: peter-evans/close-pull@v1
-        with:
-          repository: 'redhat-openshift-ecosystem/operator-pipelines-test'
-          pull-request-number: ${{needs.prepare-test-data.outputs.test_pr_number}}
-          comment: Auto-closing test pull request
-          delete-branch: true
-          token: ${{ secrets.BOT_TOKEN }}
-
+      # Deleting the branches associated with the PR will also close the PR- if it still exists
       - name: Clean test branches
         if: always()
         uses: dawidd6/action-delete-branch@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,8 +107,8 @@ jobs:
       # Get the number of the created PR- it's used for cleanup
       - id: get_pr_data
         run: |
-          PR_NUMBER=$(hub pr show --base ${PR_BASE_BRANCH} --format "%I")
-          PR_HEAD_SHA=$(hub pr show --base ${PR_BASE_BRANCH} --format "%sH")
+          PR_NUMBER=$(hub pr show -b ${PR_BASE_BRANCH} -f "%I")
+          PR_HEAD_SHA=$(hub pr show -b ${PR_BASE_BRANCH} -f "%sH")
           echo "::set-output name=pr_number::${PR_NUMBER}"
           echo "::set-output name=pr_head_sha::${PR_HEAD_SHA}"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -163,7 +163,7 @@ jobs:
           tkn pipeline start operator-hosted-pipeline \
             --use-param-defaults \
             --param git_pr_branch=$SHORT_SHA \
-            --param git_pr_title=${{needs.prepare-env-job.outputs.pr_title}} \
+            --param git_pr_title="${{needs.prepare-env-job.outputs.pr_title}}" \
             --param git_pr_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/${{needs.prepare-test-data.outputs.test_pr_number}} \
             --param git_fork_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
             --param git_repo_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -162,6 +162,9 @@ jobs:
     needs:
       - run-e2e
       - prepare-env-job
+      - prepare-test-data
+    env:
+      OC_PROJECT: ${{needs.prepare-env-job.outputs.oc_project}}
     steps:
       - name: Clean OC project
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,6 +63,7 @@ jobs:
 
           git config user.name 'rh-operator-bundle-bot'
           git config user.email 'exd-guild-isv+operators@redhat.com'
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/redhat-openshift-ecosystem/operator-pipelines-test
 
           cd operators/test-e2e-operator
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Create test branch
         run: |
           echo "Creating branch $PR_BASE_BRANCH as copy of main"
+          git fetch
           git branch -c main ${PR_BASE_BRANCH}
 
       # Create PR.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,14 +33,9 @@ jobs:
   prepare-test-data:
     runs-on: ubuntu-latest
     needs: prepare-env-job
-    outputs:
-      test_pr_number: ${{ steps.get_pr_data.outputs.pr_number }}
-      test_pr_head_sha: ${{ steps.get_pr_data.outputs.pr_head_sha }}
     env:
       SHORT_SHA: ${{needs.prepare-env-job.outputs.short_sha}}
       PR_BASE_BRANCH: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
-      # This env is needed for hub cli
-      GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
     steps:
       # Clone repository operator-pipelines-test on branch e2e-test-operator
       - uses: actions/checkout@v2
@@ -48,23 +43,27 @@ jobs:
           repository: 'redhat-openshift-ecosystem/operator-pipelines-test'
           token: ${{ secrets.BOT_TOKEN }}
 
-      - name: Prepare environment
+      - name: Configure Git
         run: |
-          # Install dependencies- GitHub client
-          sudo apt install -y hub
+          git config user.name 'rh-operator-bundle-bot'
+          git config user.email 'exd-guild-isv+operators@redhat.com'
+          git fetch
+
+      - name: Create test PR base branch
+        run: |
+          git branch -c main ${PR_BASE_BRANCH}
+          # must checkout to base branch before `create-pull-request` action, as current branch
+          # is used as base for PR
+          git checkout ${PR_BASE_BRANCH}
+          git push --set-upstream origin ${PR_BASE_BRANCH}
 
       # Create commit with changes used for E2E tests. This commit contains the `test-e2e-operator`
       # from branch e2e-test-operator- just with the new version.
-      - name: Create commit to create PR with test data
+      - name: Create commit to create PR with test data (PR head branch)
         run: |
-          git fetch
-
           # Start from the branch e2e-test-operator. This branch contains the base test operator.
           # If something would go wrong with the test branch, backup is on branch e2e-test-operator-backup
           git checkout e2e-test-operator
-
-          git config user.name 'rh-operator-bundle-bot'
-          git config user.email 'exd-guild-isv+operators@redhat.com'
 
           pushd operators/test-e2e-operator
 
@@ -83,16 +82,8 @@ jobs:
           # Head branch of the PR will be created by create-pull-request action
           git add operators && git commit -m "new version of operator"
 
-      - name: Create test PR base branch
-        run: |
-          git branch -c main ${PR_BASE_BRANCH}
-          # must checkout to base branch before `create-pull-request` action, as current branch
-          # is used as base for PR
-          git checkout ${PR_BASE_BRANCH}
-          git push --set-upstream origin ${PR_BASE_BRANCH}
-
       # Create PR.
-      - name: Create Pull Request
+      - id: create_pull_request
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.BOT_TOKEN }}
@@ -103,14 +94,6 @@ jobs:
           title: ${{needs.prepare-env-job.outputs.pr_title}}
           delete-branch: true
           body: 'This is PR used for E2E tests of the operator pipelines'
-
-      # Get the number of the created PR- it's used for cleanup
-      - id: get_pr_data
-        run: |
-          PR_NUMBER=$(hub pr show -h ${SHORT_SHA} -f "%I")
-          PR_HEAD_SHA=$(hub pr show -h ${SHORT_SHA} -f "%sH")
-          echo "::set-output name=pr_number::${PR_NUMBER}"
-          echo "::set-output name=pr_head_sha::${PR_HEAD_SHA}"
 
   # Deploy and run the E2E tests
   run-e2e:
@@ -184,11 +167,11 @@ jobs:
             --param git_pr_branch=$SHORT_SHA \
             --param image_namespace=operator-pipeline-stage \
             --param git_pr_title="${{needs.prepare-env-job.outputs.pr_title}}" \
-            --param git_pr_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/${{needs.prepare-test-data.outputs.test_pr_number}} \
+            --param git_pr_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/${{ steps.create_pull_request.outputs.pull-request-number }} \
             --param git_fork_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
             --param git_repo_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
             --param git_username=rh-operator-bundle-bot \
-            --param git_commit=${{needs.prepare-test-data.outputs.test_pr_head_sha}} \
+            --param git_commit=${{ steps.create_pull_request.outputs.pull-request-head-sha }} \
             --param git_base_branch=${{needs.prepare-env-job.outputs.test_pr_base_branch}} \
             --param pr_head_label=$SHORT_SHA \
             --param env=stage \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: 'redhat-openshift-ecosystem/operator-pipelines-test'
+          # If something go wrong with the test branch, backup is on branch e2e-test-operator-backup
           ref: 'e2e-test-operator'
 
       - name: Prepare environment
@@ -56,7 +57,7 @@ jobs:
       # created test PR
       - name: Create test branch
         run: |
-          echo "Creating branch $SHORT_SHA-merge as copy of main"
+          echo "Creating branch ${PR_BASE_BRANCH} as copy of main"
           git branch -c main ${PR_BASE_BRANCH}
 
       # Create commit with changes used for E2E tests. This commit contains the `test-e2e-operator`
@@ -69,7 +70,6 @@ jobs:
           cd operators/test-e2e-operator
 
           # Remove all of previously merged versions of test operator, if there are any.
-          # If something will go wrong with the test branch, backup is on branch e2e-test-operator-backup
 
           rm -rf 0.0.7-*
           # Commit and push, if anything was removed.
@@ -87,7 +87,9 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           author: 'rh-operator-bundle-bot <exd-guild-isv+operators@redhat.com>'
           commit-message: 'Preparing the data for E2E tests'
-          base: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
+          # base: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
+          # test
+          base: 377ca23
           branch: ${{needs.prepare-env-job.outputs.short_sha}}
           title: ${{needs.prepare-env-job.outputs.pr_title}}
           delete-branch: true
@@ -229,17 +231,6 @@ jobs:
           EOF
 
           oc delete project $OC_PROJECT
-
-      - name: Clean opened PR
-        # Do it on failure- on success Hosted pipeline will do it anyway
-        if: failure()
-        uses: peter-evans/close-pull@v1
-        with:
-          repository: 'redhat-openshift-ecosystem/operator-pipelines-test'
-          pull-request-number: ${{needs.prepare-test-data.outputs.test_pr_number}}
-          comment: Auto-closing test pull request
-          delete-branch: true
-          token: ${{ secrets.BOT_TOKEN }}
 
       # Deleting the branches associated with the PR will also close the PR- if it still exists
       - name: Clean test branches

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,6 +85,7 @@ jobs:
         with:
           github_token: ${{ secrets.BOT_TOKEN }}
           branch: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
+          repository: 'redhat-openshift-ecosystem/operator-pipelines-test'
 
       # Create PR.
       - name: Create Pull Request

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,9 +86,10 @@ jobs:
       # Get the number of the created PR- it's used for cleanup
       - id: get_pr_number
         run: |
-          hub pr show --head ${PR_BASE_BRANCH} -f %I
+          echo "test"
+          hub pr show --head ${PR_BASE_BRANCH} -f "%I"
           hub pr show --head ${PR_BASE_BRANCH} --url
-          PR_NUMBER=$(hub pr show --head ${PR_BASE_BRANCH} -f %I)
+          PR_NUMBER=$(hub pr show --head ${PR_BASE_BRANCH} -f "%I")
           echo "::set-output name=pr_number::${PR_NUMBER}"
 
   # Deploy and run the E2E tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,6 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-      - ISV-890
   workflow_dispatch:
 jobs:
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: 'redhat-openshift-ecosystem/operator-pipelines-test'
+          token: ${{ secrets.BOT_TOKEN }}
 
       - name: Prepare environment
         run: |
@@ -74,11 +75,9 @@ jobs:
           git commit -am "new version of operator"
 
       - name: Create test PR base branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: |
           git branch -c main ${PR_BASE_BRANCH}
-          hub push --set-upstream origin ${PR_BASE_BRANCH}
+          git push --set-upstream origin ${PR_BASE_BRANCH}
 
       # Create PR.
       - name: Create Pull Request

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,6 +38,7 @@ jobs:
       test_pr_head_sha: ${{ steps.get_pr_data.outputs.pr_head_sha }}
     env:
       SHORT_SHA: ${{needs.prepare-env-job.outputs.short_sha}}
+      PR_BASE_BRANCH: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
       # This env is needed for hub cli
       GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
     steps:
@@ -72,15 +73,18 @@ jobs:
           # Head branch of the PR will be created by create-pull-request action
           git commit -am "new version of operator"
 
+
+      - name: Create test PR base branch
+        run: |
+          git branch -c main ${PR_BASE_BRANCH}
+
       # Create test branch as copy of main. This branch will be base for
       # created test PR. It will be deleted later for cleanup.
-      - name: Push to built branch
-        uses: Automattic/action-commit-to-branch@master
+      - name: Push PR base branch
+        uses: ad-m/github-push-action@master
         with:
+          github_token: ${{ secrets.BOT_TOKEN }}
           branch: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
-          commit_message: 'Creating the base branch for test pull request'
-        env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
 
       # Create PR.
       - name: Create Pull Request

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,20 +1,17 @@
 ---
 name: E2E-CI
-# TODO: Document the secrets!
-# TODO: Document, how the partner can use this workflow!
 
 on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-      - ISV-1320
   pull_request:
   workflow_dispatch:
 jobs:
 
   # envs  for other jobs are prepared as outputs of this task. Outputs are a good way to
   # concatenate strings and use them as values to keywords other than "run".
-  # For run, they can be used after redeclared in keyword "env".
+  # For run, they can be used with keyword "env".
   prepare-env-job:
     runs-on: ubuntu-latest
     outputs:
@@ -169,6 +166,8 @@ jobs:
       - name: Clean OC project
         if: always()
         run: |
+
+          echo $OC_PROJECT
 
           # Prepare Kubeconfig.
           # Use GitHub secret which contains the Kubeconfig for SA with admin privilleges (same as in ansible vault)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,8 +37,8 @@ jobs:
       SHORT_SHA: ${{needs.prepare-env-job.outputs.short_sha}}
       PR_BASE_BRANCH: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
     outputs:
-      test_pr_number: ${{ steps.create_pull_request.outputs.pr_number }}
-      test_pr_head_sha: ${{ steps.create_pull_request.outputs.pr_head_sha }}
+      test_pr_number: ${{ steps.create_pull_request.outputs.pull-request-number }}
+      test_pr_head_sha: ${{ steps.create_pull_request.outputs.pull-request-head-sha }}
     steps:
       # Clone repository operator-pipelines-test on branch e2e-test-operator
       - uses: actions/checkout@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -230,6 +230,17 @@ jobs:
 
           oc delete project $OC_PROJECT
 
+      - name: Clean opened PR
+        # Do it on failure- on success Hosted pipeline will do it anyway
+        if: failure()
+        uses: peter-evans/close-pull@v1
+        with:
+          repository: 'redhat-openshift-ecosystem/operator-pipelines-test'
+          pull-request-number: ${{needs.prepare-test-data.outputs.test_pr_number}}
+          comment: Auto-closing test pull request
+          delete-branch: true
+          token: ${{ secrets.BOT_TOKEN }}
+
       # Deleting the branches associated with the PR will also close the PR- if it still exists
       - name: Clean test branches
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,6 +34,8 @@ jobs:
   prepare-test-data:
     runs-on: ubuntu-latest
     needs: prepare-env-job
+    outputs:
+      test_pr_number: ${{ steps.prepare.get_pr_number.pr_number}}
     env:
       SHORT_SHA: ${{needs.prepare-env-job.outputs.short_sha}}
       PR_BASE_BRANCH: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
@@ -43,6 +45,11 @@ jobs:
         with:
           repository: 'redhat-openshift-ecosystem/operator-pipelines-test'
           ref: 'e2e-test-operator'
+
+      - name: Prepare environment
+        run: |
+          # Install dependencies- GitHub client
+          sudo apt install -y hub
 
       # Create test branch as copy of main. This branch will be base for
       # created test PR
@@ -76,12 +83,18 @@ jobs:
           delete-branch: true
           body: 'This is PR used for E2E tests of the operator pipelines'
 
+      # Get the number of the created PR- it's used for cleanup
+      - id: get_pr_number
+        run: |
+          PR_NUMBER=$(hub pr show -f %I)
+          echo "::set-output name=pr_number::${PR_NUMBER}"
+
   # Deploy and run the E2E tests
   run-e2e:
     runs-on: ubuntu-latest
     needs:
-      - prepare-test-data
       - prepare-env-job
+      - prepare-test-data
     env:
       SHORT_SHA: ${{needs.prepare-env-job.outputs.short_sha}}
       OC_PROJECT: ${{needs.prepare-env-job.outputs.oc_project}}
@@ -152,6 +165,17 @@ jobs:
         if: always()
         run: |
           oc delete project $OC_PROJECT
+
+      - name: Clean opened PR
+        # run only on failure- on success PR is merged by pipeline
+        if: failure()
+        uses: peter-evans/close-pull@v1
+        with:
+          repository: 'redhat-openshift-ecosystem/operator-pipelines-test'
+          pull-request-number: ${{needs.prepare-test-data.outputs.test_pr_number}}
+          comment: Auto-closing test pull request
+          delete-branch: true
+          token: ${{ secrets.BOT_TOKEN }}
 
       - name: Clean test branches
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,6 +59,7 @@ jobs:
         run: |
           git fetch
 
+          # Start from the branch e2e-test-operator. This branch contains the base test operator.
           # If something would go wrong with the test branch, backup is on branch e2e-test-operator-backup
           git checkout e2e-test-operator
 
@@ -77,6 +78,7 @@ jobs:
       - name: Create test PR base branch
         run: |
           git branch -c main ${PR_BASE_BRANCH}
+          git checkout ${PR_BASE_BRANCH}
           git push --set-upstream origin ${PR_BASE_BRANCH}
 
       # Create PR.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,8 +107,8 @@ jobs:
       # Get the number of the created PR- it's used for cleanup
       - id: get_pr_data
         run: |
-          PR_NUMBER=$(hub pr show -b ${PR_BASE_BRANCH} -f "%I")
-          PR_HEAD_SHA=$(hub pr show -b ${PR_BASE_BRANCH} -f "%sH")
+          PR_NUMBER=$(hub pr show -h ${SHORT_SHA} -f "%I")
+          PR_HEAD_SHA=$(hub pr show -h ${SHORT_SHA} -f "%sH")
           echo "::set-output name=pr_number::${PR_NUMBER}"
           echo "::set-output name=pr_head_sha::${PR_HEAD_SHA}"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,7 +71,7 @@ jobs:
 
           rm -rf 0.0.7-*
           # Add, commit and push, if anything was removed.
-          git add --all && git commit -m "removing previously merged operator" && git push || true
+          (git add --all && git commit -m "removing previously merged operator" && git push) || echo "No previously merged test operator to remove"
 
           cd operators/test-e2e-operator
           cp -r 0.0.7 0.0.7-$SHORT_SHA

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
+      - ISV-890
   pull_request:
   workflow_dispatch:
 jobs:
@@ -32,7 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare-env-job
     outputs:
-      test_pr_number: ${{ steps.get_pr_number.outputs.pr_number }}
+      test_pr_number: ${{ steps.get_pr_data.outputs.pr_number }}
+      test_pr_head_sha: ${{ steps.get_pr_data.outputs.pr_head_sha }}
     env:
       SHORT_SHA: ${{needs.prepare-env-job.outputs.short_sha}}
       PR_BASE_BRANCH: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
@@ -83,13 +85,16 @@ jobs:
           body: 'This is PR used for E2E tests of the operator pipelines'
 
       # Get the number of the created PR- it's used for cleanup
-      - id: get_pr_number
+      - id: get_pr_data
         run: |
           PR_NUMBER=$(hub pr show -f "%I")
+          PR_HEAD_SHA=$(hub pr show -f "%sH")
           echo "::set-output name=pr_number::${PR_NUMBER}"
+          echo "::set-output name=pr_head_sha::${PR_HEAD_SHA}"
+
 
   # Deploy and run the E2E tests
-  run-e2e:
+  run-e2e-CI:
     runs-on: ubuntu-latest
     needs:
       - prepare-env-job
@@ -130,21 +135,58 @@ jobs:
           bash init-custom-env.sh $OC_PROJECT stage vault-password
           popd
 
-      - name: Run CI pipeline
+      #- name: Run CI pipeline
+      #  run: |
+      #    tkn pipeline start operator-ci-pipeline \
+      #      --use-param-defaults \
+      #      --param git_repo_url=git@github.com:redhat-openshift-ecosystem/operator-pipelines-test.git \
+      #      --param git_branch=$SHORT_SHA \
+      #      --param bundle_path=operators/test-e2e-operator/0.0.7-$SHORT_SHA \
+      #      --param env=stage \
+      #      --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
+      #      --workspace name=kubeconfig,secret=kubeconfig \
+      #      --workspace name=ssh-dir,secret=github-ssh-credentials \
+      #      --workspace name=pyxis-api-key,secret=pyxis-api-secret \
+      #      --showlog
+
+      #- name: Check if CI pipeline passed
+      #  run: |
+      #    PIPELINERUN_NAME=$(oc get pr --no-headers -o custom-columns=":metadata.name")
+      #    PIPELINERUN_SUCCEEDED=$(oc get pr $PIPELINERUN_NAME -o jsonpath={'.status.conditions[].status'})
+      #    if [[ "$PIPELINERUN_SUCCEEDED" != "True" ]]; then
+      #      oc get pr
+      #      exit 1
+      #    fi
+
+      - name: Run Hosted pipeline
         run: |
-          tkn pipeline start operator-ci-pipeline \
+          tkn pipeline start operator-hosted-pipeline \
             --use-param-defaults \
-            --param git_repo_url=git@github.com:redhat-openshift-ecosystem/operator-pipelines-test.git \
-            --param git_branch=$SHORT_SHA \
-            --param bundle_path=operators/test-e2e-operator/0.0.7-$SHORT_SHA \
+            --param git_pr_branch=$SHORT_SHA \
+            --param git_pr_title=${{needs.prepare-env-job.outputs.pr_title}} \
+            --param git_pr_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/${{needs.prepare-test-data.outputs.test_pr_number}} \
+            --param git_fork_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
+            --param git_repo_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
+            --param git_username=rh-operator-bundle-bot \
+            --param git_commit=${{needs.prepare-test-data.outputs.test_pr_head_sha}} \
+            --param git_base_branch=main \
+            --param pr_head_label=$SHORT_SHA \
             --param env=stage \
-            --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
-            --workspace name=kubeconfig,secret=kubeconfig \
-            --workspace name=ssh-dir,secret=github-ssh-credentials \
-            --workspace name=pyxis-api-key,secret=pyxis-api-secret \
+            --param preflight_min_version=0.0.0 \
+            --param ci_min_version=0.0.0 \
+            --workspace name=repository,volumeClaimTemplateFile=templates/workspace-template-small.yml \
+            --workspace name=results,volumeClaimTemplateFile=templates/workspace-template.yml \
+            --workspace name=registry-credentials-all,volumeClaimTemplateFile=templates/workspace-template-small.yml \
+            --workspace name=registry-credentials,secret=registry-dockerconfig-secret \
+            --workspace name=pyxis-ssl-credentials,secret=operator-pipeline-api-certs \
+            --workspace name=prow-kubeconfig,secret=prow-kubeconfig \
+            --workspace name=preflight-decryption-key,secret=preflight-decryption-key \
+            --workspace name=hydra-credentials,secret=hydra-credentials \
+            --workspace name=gpg-key,secret=isv-gpg-key \
             --showlog
 
-      - name: Check if pipeline passed
+      # TODO: now it can check the CI
+      - name: Check if Hosted pipeline passed
         run: |
           PIPELINERUN_NAME=$(oc get pr --no-headers -o custom-columns=":metadata.name")
           PIPELINERUN_SUCCEEDED=$(oc get pr $PIPELINERUN_NAME -o jsonpath={'.status.conditions[].status'})

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,7 +38,6 @@ jobs:
       test_pr_head_sha: ${{ steps.get_pr_data.outputs.pr_head_sha }}
     env:
       SHORT_SHA: ${{needs.prepare-env-job.outputs.short_sha}}
-      PR_BASE_BRANCH: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
       # This env is needed for hub cli
       GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
     steps:
@@ -75,11 +74,13 @@ jobs:
 
       # Create test branch as copy of main. This branch will be base for
       # created test PR. It will be deleted later for cleanup.
-      - name: Create test PR base branch
-        run: |
-          echo "Creating branch $PR_BASE_BRANCH as copy of main"
-          git branch -c main ${PR_BASE_BRANCH}
-          git push --set-upstream origin ${PR_BASE_BRANCH}
+      - name: Push to built branch
+        uses: Automattic/action-commit-to-branch@master
+        with:
+          branch: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
+          commit_message: 'Creating the base branch for test pull request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
 
       # Create PR.
       - name: Create Pull Request

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,15 +77,7 @@ jobs:
       - name: Create test PR base branch
         run: |
           git branch -c main ${PR_BASE_BRANCH}
-
-      # Create test branch as copy of main. This branch will be base for
-      # created test PR. It will be deleted later for cleanup.
-      - name: Push PR base branch
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.BOT_TOKEN }}
-          branch: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
-          repository: 'redhat-openshift-ecosystem/operator-pipelines-test'
+          hub push --set-upstream origin $SHORT_SHA
 
       # Create PR.
       - name: Create Pull Request

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,6 +73,7 @@ jobs:
           # Create HEAD branch of test PR
           git checkout -b $SHORT_SHA
           git commit -am "new version of operator"
+          git push --set-upstream origin $SHORT_SHA
 
       # Create test branch as copy of main. This branch will be base for
       # created test PR. It will be deleted later for cleanup.
@@ -80,6 +81,7 @@ jobs:
         run: |
           echo "Creating branch $PR_BASE_BRANCH as copy of main"
           git branch -c main ${PR_BASE_BRANCH}
+          git push --set-upstream origin ${PR_BASE_BRANCH}
 
       # Create PR.
       - name: Create Pull Request

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,13 +54,6 @@ jobs:
           # Install dependencies- GitHub client
           sudo apt install -y hub
 
-      # Create test branch as copy of main. This branch will be base for
-      # created test PR
-      - name: Create test branch
-        run: |
-          echo "Creating branch ${PR_BASE_BRANCH} as copy of main"
-          git branch -c main ${PR_BASE_BRANCH}
-
       # Create commit with changes used for E2E tests. This commit contains the `test-e2e-operator`
       # from branch e2e-test-operator- just with the new version.
       - name: Create commit to create PR with test data
@@ -73,6 +66,13 @@ jobs:
           mv 0.0.7 0.0.7-$SHORT_SHA
           find ./ -type f -exec sed -i "s/0.0.7/0.0.7-$SHORT_SHA/g" {} \;
           git commit -am "new version of operator"
+
+      # Create test branch as copy of main. This branch will be base for
+      # created test PR
+      - name: Create test branch
+        run: |
+          echo "Creating branch $PR_BASE_BRANCH as copy of main"
+          git branch -c main ${PR_BASE_BRANCH}
 
       # Create PR.
       - name: Create Pull Request
@@ -172,7 +172,7 @@ jobs:
             --param git_repo_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
             --param git_username=rh-operator-bundle-bot \
             --param git_commit=${{needs.prepare-test-data.outputs.test_pr_head_sha}} \
-            --param git_base_branch=main \
+            --param git_base_branch=${{needs.prepare-env-job.outputs.test_pr_base_branch}} \
             --param pr_head_label=$SHORT_SHA \
             --param env=stage \
             --param preflight_min_version=0.0.0 \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -94,7 +94,7 @@ jobs:
 
 
   # Deploy and run the E2E tests
-  run-e2e-CI:
+  run-e2e:
     runs-on: ubuntu-latest
     needs:
       - prepare-env-job

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,8 +107,8 @@ jobs:
       # Get the number of the created PR- it's used for cleanup
       - id: get_pr_data
         run: |
-          PR_NUMBER=$(hub pr show -f "%I")
-          PR_HEAD_SHA=$(hub pr show -f "%sH")
+          PR_NUMBER=$(hub pr show --base ${PR_BASE_BRANCH} --format "%I")
+          PR_HEAD_SHA=$(hub pr show --base ${PR_BASE_BRANCH} --format "%sH")
           echo "::set-output name=pr_number::${PR_NUMBER}"
           echo "::set-output name=pr_head_sha::${PR_HEAD_SHA}"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,7 +74,7 @@ jobs:
 
           popd
 
-          cp operators/test-e2e-operator /tmp
+          cp -r operators/test-e2e-operator /tmp
 
           # Start the feature branch (head) from main
           git checkout main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,6 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
       - ISV-890
-  pull_request:
   workflow_dispatch:
 jobs:
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,6 @@ jobs:
 
           git config user.name 'rh-operator-bundle-bot'
           git config user.email 'exd-guild-isv+operators@redhat.com'
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/redhat-openshift-ecosystem/operator-pipelines-test
 
           cd operators/test-e2e-operator
 
@@ -71,10 +70,8 @@ jobs:
           mv 0.0.7 0.0.7-$SHORT_SHA
           find ./ -type f -exec sed -i "s/0.0.7/0.0.7-$SHORT_SHA/g" {} \;
 
-          # Create HEAD branch of test PR
-          git checkout -b $SHORT_SHA
+          # Head branch of the PR will be created by create-pull-request action
           git commit -am "new version of operator"
-          git push --set-upstream origin $SHORT_SHA
 
       # Create test branch as copy of main. This branch will be base for
       # created test PR. It will be deleted later for cleanup.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,7 @@ jobs:
       short_sha: ${{ steps.prepare.outputs.short_sha }}
       pr_title: ${{ steps.prepare.outputs.pr_title }}
       oc_project: ${{ steps.prepare.outputs.oc_project }}
+      test_pr_base_branch: ${{ steps.prepare.outputs.test_pr_base_branch }}
     steps:
       - id: prepare
         run: |
@@ -69,16 +70,9 @@ jobs:
 
           cd operators/test-e2e-operator
 
-          # Remove all of previously merged versions of test operator, if there are any.
-
-          rm -rf 0.0.7-*
-          # Commit and push, if anything was removed.
-          (git commit -am "removing previously merged operator" && git push) || echo "No previously merged test operator to remove"
-
-          cp -r 0.0.7 0.0.7-$SHORT_SHA
-          cd 0.0.7-$SHORT_SHA
+          mv 0.0.7 0.0.7-$SHORT_SHA
           find ./ -type f -exec sed -i "s/0.0.7/0.0.7-$SHORT_SHA/g" {} \;
-          git add --all && git commit -m "new version of operator"
+          git commit -am "new version of operator"
 
       # Create PR.
       - name: Create Pull Request
@@ -87,9 +81,7 @@ jobs:
           token: ${{ secrets.BOT_TOKEN }}
           author: 'rh-operator-bundle-bot <exd-guild-isv+operators@redhat.com>'
           commit-message: 'Preparing the data for E2E tests'
-          # base: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
-          # test
-          base: 377ca23
+          base: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
           branch: ${{needs.prepare-env-job.outputs.short_sha}}
           title: ${{needs.prepare-env-job.outputs.pr_title}}
           delete-branch: true
@@ -102,7 +94,6 @@ jobs:
           PR_HEAD_SHA=$(hub pr show -f "%sH")
           echo "::set-output name=pr_number::${PR_NUMBER}"
           echo "::set-output name=pr_head_sha::${PR_HEAD_SHA}"
-
 
   # Deploy and run the E2E tests
   run-e2e:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,8 +88,6 @@ jobs:
       # Get the number of the created PR- it's used for cleanup
       - id: get_pr_number
         run: |
-          hub pr show -f "%I"
-          hub pr show --head ${PR_BASE_BRANCH} --url
           PR_NUMBER=$(hub pr show -f "%I")
           echo "::set-output name=pr_number::${PR_NUMBER}"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,11 +66,19 @@ jobs:
           git config user.name 'rh-operator-bundle-bot'
           git config user.email 'exd-guild-isv+operators@redhat.com'
 
-          cd operators/test-e2e-operator
+          pushd operators/test-e2e-operator
 
           # Modify the test operator version
           mv 0.0.7 0.0.7-$SHORT_SHA
           find ./ -type f -exec sed -i "s/0.0.7/0.0.7-$SHORT_SHA/g" {} \;
+
+          popd
+
+          cp operators/test-e2e-operator /tmp
+
+          # Start the feature branch (head) from main
+          git checkout main
+          cp /tmp/test-e2e-operator operators/
 
           # Head branch of the PR will be created by create-pull-request action
           git commit -am "new version of operator"
@@ -78,6 +86,8 @@ jobs:
       - name: Create test PR base branch
         run: |
           git branch -c main ${PR_BASE_BRANCH}
+          # must checkout to base branch before `create-pull-request` action, as current branch
+          # is used as base for PR
           git checkout ${PR_BASE_BRANCH}
           git push --set-upstream origin ${PR_BASE_BRANCH}
 
@@ -238,5 +248,5 @@ jobs:
           github_token: ${{ secrets.BOT_TOKEN }}
           owner: redhat-openshift-ecosystem
           repository: operator-pipelines-test
-          branches: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
+          branches: ${{needs.prepare-env-job.outputs.test_pr_base_branch}},${{needs.prepare-env-job.outputs.short_sha}}
           soft_fail: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,7 @@ jobs:
      outputs:
        short_sha: ${{ steps.prepare.outputs.short_sha }}
        pr_title: ${{ steps.prepare.outputs.pr_title }}
+       oc_project: ${{ steps.prepare.outputs.oc_project}}
      steps:
        - uses: actions/checkout@v2
        - id: prepare
@@ -21,6 +22,7 @@ jobs:
            SHORT_SHA=$(git rev-parse --short HEAD)
            echo "::set-output name=short_sha::$SHORT_SHA"
            echo "::set-output name=pr_title::operator test-e2e-operator (0.0.7-${SHORT_SHA})"
+           echo "::set-output name=oc_project::test-e2e-${SHORT_SHA}"
   prepare-test-data:
     runs-on: ubuntu-latest
     needs: prepare-env-job
@@ -52,12 +54,11 @@ jobs:
           body: 'This is PR used for E2E tests of the operator pipelines'
   run-e2e:
     runs-on: ubuntu-latest
+    needs: prepare-env-job
+    env:
+      SHORT_SHA: ${{needs.prepare-env-job.outputs.short_sha}}
+      OC_PROJECT: ${{needs.prepare-env-job.outputs.oc_project}}
     steps:
-      - name: Set environmental variables
-        run: |
-          echo "SHORT_SHA=`git rev-parse --short HEAD`" >> $GITHUB_ENV
-          echo 'PR_TITLE="operator test-e2e-operator (0.0.7-${SHORT_SHA})"'
-          echo "OC_PROJECT=test-e2e-${SHORT_SHA}" >> $GITHUB_ENV
       - uses: actions/checkout@v1
       - name: Prepare environment
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,7 +78,7 @@ jobs:
 
           # Start the feature branch (head) from main
           git checkout main
-          cp /tmp/test-e2e-operator operators/
+          cp -r /tmp/test-e2e-operator operators/
 
           # Head branch of the PR will be created by create-pull-request action
           git commit -am "new version of operator"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,8 +47,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config user.name 'rh-operator-bundle-bot'
-          git config user.email 'exd-guild-isv+operators@redhat.com'
+          git config user.name 'rh-operator-bundle-test-e2e'
+          git config user.email 'exd-guild-isv+operators-test-e2e@redhat.com'
           git fetch
 
       - name: Create test PR base branch
@@ -86,7 +86,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.BOT_TOKEN }}
-          author: 'rh-operator-bundle-bot <exd-guild-isv+operators@redhat.com>'
+          author: 'rh-operator-bundle-test-e2e <exd-guild-isv+operators-test-e2e@redhat.com>'
           commit-message: 'Preparing the data for E2E tests'
           base: ${{needs.prepare-env-job.outputs.test_pr_base_branch}}
           branch: ${{needs.prepare-env-job.outputs.short_sha}}
@@ -159,76 +159,76 @@ jobs:
       #      exit 1
       #    fi
 
-      #- name: Run Hosted pipeline
-      #  run: |
-      #    tkn pipeline start operator-hosted-pipeline \
-      #      --use-param-defaults \
-      #      --param git_pr_branch=$SHORT_SHA \
-      #      --param image_namespace=operator-pipeline-stage \
-      #      --param git_pr_title="${{needs.prepare-env-job.outputs.pr_title}}" \
-      #      --param git_pr_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/${{needs.prepare-test-data.outputs.test_pr_number}} \
-      #      --param git_fork_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
-      #      --param git_repo_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
-      #      --param git_username=rh-operator-bundle-bot \
-      #      --param git_commit=${{needs.prepare-test-data.outputs.test_pr_head_sha}} \
-      #      --param git_base_branch=${{needs.prepare-env-job.outputs.test_pr_base_branch}} \
-      #      --param pr_head_label=$SHORT_SHA \
-      #      --param env=stage \
-      #      --param preflight_min_version=0.0.0 \
-      #      --param ci_min_version=0.0.0 \
-      #      --workspace name=repository,volumeClaimTemplateFile=templates/workspace-template-small.yml \
-      #      --workspace name=results,volumeClaimTemplateFile=templates/workspace-template.yml \
-      #      --workspace name=registry-credentials-all,volumeClaimTemplateFile=templates/workspace-template-small.yml \
-      #      --workspace name=registry-credentials,secret=registry-dockerconfig-secret \
-      #      --workspace name=pyxis-ssl-credentials,secret=operator-pipeline-api-certs \
-      #      --workspace name=prow-kubeconfig,secret=prow-kubeconfig \
-      #      --workspace name=preflight-decryption-key,secret=preflight-decryption-key \
-      #      --workspace name=hydra-credentials,secret=hydra-credentials \
-      #      --workspace name=gpg-key,secret=isv-gpg-key \
-      #      --showlog
+      - name: Run Hosted pipeline
+        run: |
+          tkn pipeline start operator-hosted-pipeline \
+            --use-param-defaults \
+            --param git_pr_branch=$SHORT_SHA \
+            --param image_namespace=operator-pipeline-stage \
+            --param git_pr_title="${{needs.prepare-env-job.outputs.pr_title}}" \
+            --param git_pr_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/${{needs.prepare-test-data.outputs.test_pr_number}} \
+            --param git_fork_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
+            --param git_repo_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
+            --param git_username=rh-operator-bundle-bot \
+            --param git_commit=${{needs.prepare-test-data.outputs.test_pr_head_sha}} \
+            --param git_base_branch=${{needs.prepare-env-job.outputs.test_pr_base_branch}} \
+            --param pr_head_label=$SHORT_SHA \
+            --param env=stage \
+            --param preflight_min_version=0.0.0 \
+            --param ci_min_version=0.0.0 \
+            --workspace name=repository,volumeClaimTemplateFile=templates/workspace-template-small.yml \
+            --workspace name=results,volumeClaimTemplateFile=templates/workspace-template.yml \
+            --workspace name=registry-credentials-all,volumeClaimTemplateFile=templates/workspace-template-small.yml \
+            --workspace name=registry-credentials,secret=registry-dockerconfig-secret \
+            --workspace name=pyxis-ssl-credentials,secret=operator-pipeline-api-certs \
+            --workspace name=prow-kubeconfig,secret=prow-kubeconfig \
+            --workspace name=preflight-decryption-key,secret=preflight-decryption-key \
+            --workspace name=hydra-credentials,secret=hydra-credentials \
+            --workspace name=gpg-key,secret=isv-gpg-key \
+            --showlog
 
-      #- name: Check if Hosted pipeline passed
-      #  run: |
-      #    PIPELINERUN_NAME=$(oc get pr --no-headers -l tekton.dev/pipeline=operator-ci-pipeline -o custom-columns=":metadata.name")
-      #    PIPELINERUN_SUCCEEDED=$(oc get pr $PIPELINERUN_NAME -o jsonpath={'.status.conditions[].status'})
-      #    if [[ "$PIPELINERUN_SUCCEEDED" != "True" ]]; then
-      #      oc get pr
-      #      exit 1
-      #    fi
+      - name: Check if Hosted pipeline passed
+        run: |
+          PIPELINERUN_NAME=$(oc get pr --no-headers -l tekton.dev/pipeline=operator-ci-pipeline -o custom-columns=":metadata.name")
+          PIPELINERUN_SUCCEEDED=$(oc get pr $PIPELINERUN_NAME -o jsonpath={'.status.conditions[].status'})
+          if [[ "$PIPELINERUN_SUCCEEDED" != "True" ]]; then
+            oc get pr
+            exit 1
+          fi
 
-  #cleanup:
-  #  runs-on: ubuntu-latest
-  #  if: ${{ always() }}
-  #  needs:
-  #    - run-e2e
-  #    - prepare-env-job
-  #    - prepare-test-data
-  #  env:
-  #    OC_PROJECT: ${{needs.prepare-env-job.outputs.oc_project}}
-  #  steps:
-  #    - name: Clean OC project
-  #      if: always()
-  #      run: |
+  cleanup:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - run-e2e
+      - prepare-env-job
+      - prepare-test-data
+    env:
+      OC_PROJECT: ${{needs.prepare-env-job.outputs.oc_project}}
+    steps:
+      - name: Clean OC project
+        if: always()
+        run: |
 
-  #        echo $OC_PROJECT
+          echo $OC_PROJECT
 
-  #        # Prepare Kubeconfig.
-  #        # Use GitHub secret which contains the Kubeconfig for SA with admin privilleges (same as in ansible vault)
-  #        # to create Kubernetes context.
-  #        mkdir $HOME/.kube
-  #        cat <<EOF > $HOME/.kube/config
-  #        ${{ secrets.KUBECONFIG }}
-  #        EOF
+          # Prepare Kubeconfig.
+          # Use GitHub secret which contains the Kubeconfig for SA with admin privilleges (same as in ansible vault)
+          # to create Kubernetes context.
+          mkdir $HOME/.kube
+          cat <<EOF > $HOME/.kube/config
+          ${{ secrets.KUBECONFIG }}
+          EOF
 
-  #        oc delete project $OC_PROJECT
+          oc delete project $OC_PROJECT
 
-  #    # Deleting the branches associated with the PR will also close the PR- if it still exists
-  #    - name: Clean test branches
-  #      if: always()
-  #      uses: dawidd6/action-delete-branch@v3
-  #      with:
-  #        github_token: ${{ secrets.BOT_TOKEN }}
-  #        owner: redhat-openshift-ecosystem
-  #        repository: operator-pipelines-test
-  #        branches: ${{needs.prepare-env-job.outputs.test_pr_base_branch}},${{needs.prepare-env-job.outputs.short_sha}}
-  #        soft_fail: true
+      # Deleting the branches associated with the PR will also close the PR- if it still exists
+      - name: Clean test branches
+        if: always()
+        uses: dawidd6/action-delete-branch@v3
+        with:
+          github_token: ${{ secrets.BOT_TOKEN }}
+          owner: redhat-openshift-ecosystem
+          repository: operator-pipelines-test
+          branches: ${{needs.prepare-env-job.outputs.test_pr_base_branch}},${{needs.prepare-env-job.outputs.short_sha}}
+          soft_fail: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,6 +23,7 @@ jobs:
            echo "::set-output name=pr_title::operator test-e2e-operator (0.0.7-${SHORT_SHA})"
   prepare-test-data:
     runs-on: ubuntu-latest
+    needs: prepare-env-job
     env:
       SHORT_SHA: ${{needs.prepare-env-job.outputs.short_sha}}
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,8 @@ jobs:
       # from branch e2e-test-operator- just with the new version.
       - name: Create commit to create PR with test data
         run: |
+          git fetch
+
           # If something would go wrong with the test branch, backup is on branch e2e-test-operator-backup
           git checkout e2e-test-operator
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,8 +46,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: 'redhat-openshift-ecosystem/operator-pipelines-test'
-          # If something go wrong with the test branch, backup is on branch e2e-test-operator-backup
-          ref: 'e2e-test-operator'
 
       - name: Prepare environment
         run: |
@@ -58,21 +56,27 @@ jobs:
       # from branch e2e-test-operator- just with the new version.
       - name: Create commit to create PR with test data
         run: |
+          # If something would go wrong with the test branch, backup is on branch e2e-test-operator-backup
+          git checkout e2e-test-operator
+
           git config user.name 'rh-operator-bundle-bot'
           git config user.email 'exd-guild-isv+operators@redhat.com'
 
           cd operators/test-e2e-operator
 
+          # Modify the test operator version
           mv 0.0.7 0.0.7-$SHORT_SHA
           find ./ -type f -exec sed -i "s/0.0.7/0.0.7-$SHORT_SHA/g" {} \;
+
+          # Create HEAD branch of test PR
+          git checkout -b $SHORT_SHA
           git commit -am "new version of operator"
 
       # Create test branch as copy of main. This branch will be base for
-      # created test PR
-      - name: Create test branch
+      # created test PR. It will be deleted later for cleanup.
+      - name: Create test PR base branch
         run: |
           echo "Creating branch $PR_BASE_BRANCH as copy of main"
-          git fetch
           git branch -c main ${PR_BASE_BRANCH}
 
       # Create PR.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -159,76 +159,76 @@ jobs:
       #      exit 1
       #    fi
 
-      - name: Run Hosted pipeline
-        run: |
-          tkn pipeline start operator-hosted-pipeline \
-            --use-param-defaults \
-            --param git_pr_branch=$SHORT_SHA \
-            --param image_namespace=operator-pipeline-stage \
-            --param git_pr_title="${{needs.prepare-env-job.outputs.pr_title}}" \
-            --param git_pr_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/${{needs.prepare-test-data.outputs.test_pr_number}} \
-            --param git_fork_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
-            --param git_repo_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
-            --param git_username=rh-operator-bundle-bot \
-            --param git_commit=${{needs.prepare-test-data.outputs.test_pr_head_sha}} \
-            --param git_base_branch=${{needs.prepare-env-job.outputs.test_pr_base_branch}} \
-            --param pr_head_label=$SHORT_SHA \
-            --param env=stage \
-            --param preflight_min_version=0.0.0 \
-            --param ci_min_version=0.0.0 \
-            --workspace name=repository,volumeClaimTemplateFile=templates/workspace-template-small.yml \
-            --workspace name=results,volumeClaimTemplateFile=templates/workspace-template.yml \
-            --workspace name=registry-credentials-all,volumeClaimTemplateFile=templates/workspace-template-small.yml \
-            --workspace name=registry-credentials,secret=registry-dockerconfig-secret \
-            --workspace name=pyxis-ssl-credentials,secret=operator-pipeline-api-certs \
-            --workspace name=prow-kubeconfig,secret=prow-kubeconfig \
-            --workspace name=preflight-decryption-key,secret=preflight-decryption-key \
-            --workspace name=hydra-credentials,secret=hydra-credentials \
-            --workspace name=gpg-key,secret=isv-gpg-key \
-            --showlog
+      #- name: Run Hosted pipeline
+      #  run: |
+      #    tkn pipeline start operator-hosted-pipeline \
+      #      --use-param-defaults \
+      #      --param git_pr_branch=$SHORT_SHA \
+      #      --param image_namespace=operator-pipeline-stage \
+      #      --param git_pr_title="${{needs.prepare-env-job.outputs.pr_title}}" \
+      #      --param git_pr_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/${{needs.prepare-test-data.outputs.test_pr_number}} \
+      #      --param git_fork_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
+      #      --param git_repo_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
+      #      --param git_username=rh-operator-bundle-bot \
+      #      --param git_commit=${{needs.prepare-test-data.outputs.test_pr_head_sha}} \
+      #      --param git_base_branch=${{needs.prepare-env-job.outputs.test_pr_base_branch}} \
+      #      --param pr_head_label=$SHORT_SHA \
+      #      --param env=stage \
+      #      --param preflight_min_version=0.0.0 \
+      #      --param ci_min_version=0.0.0 \
+      #      --workspace name=repository,volumeClaimTemplateFile=templates/workspace-template-small.yml \
+      #      --workspace name=results,volumeClaimTemplateFile=templates/workspace-template.yml \
+      #      --workspace name=registry-credentials-all,volumeClaimTemplateFile=templates/workspace-template-small.yml \
+      #      --workspace name=registry-credentials,secret=registry-dockerconfig-secret \
+      #      --workspace name=pyxis-ssl-credentials,secret=operator-pipeline-api-certs \
+      #      --workspace name=prow-kubeconfig,secret=prow-kubeconfig \
+      #      --workspace name=preflight-decryption-key,secret=preflight-decryption-key \
+      #      --workspace name=hydra-credentials,secret=hydra-credentials \
+      #      --workspace name=gpg-key,secret=isv-gpg-key \
+      #      --showlog
 
-      - name: Check if Hosted pipeline passed
-        run: |
-          PIPELINERUN_NAME=$(oc get pr --no-headers -l tekton.dev/pipeline=operator-ci-pipeline -o custom-columns=":metadata.name")
-          PIPELINERUN_SUCCEEDED=$(oc get pr $PIPELINERUN_NAME -o jsonpath={'.status.conditions[].status'})
-          if [[ "$PIPELINERUN_SUCCEEDED" != "True" ]]; then
-            oc get pr
-            exit 1
-          fi
+      #- name: Check if Hosted pipeline passed
+      #  run: |
+      #    PIPELINERUN_NAME=$(oc get pr --no-headers -l tekton.dev/pipeline=operator-ci-pipeline -o custom-columns=":metadata.name")
+      #    PIPELINERUN_SUCCEEDED=$(oc get pr $PIPELINERUN_NAME -o jsonpath={'.status.conditions[].status'})
+      #    if [[ "$PIPELINERUN_SUCCEEDED" != "True" ]]; then
+      #      oc get pr
+      #      exit 1
+      #    fi
 
-  cleanup:
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs:
-      - run-e2e
-      - prepare-env-job
-      - prepare-test-data
-    env:
-      OC_PROJECT: ${{needs.prepare-env-job.outputs.oc_project}}
-    steps:
-      - name: Clean OC project
-        if: always()
-        run: |
+  #cleanup:
+  #  runs-on: ubuntu-latest
+  #  if: ${{ always() }}
+  #  needs:
+  #    - run-e2e
+  #    - prepare-env-job
+  #    - prepare-test-data
+  #  env:
+  #    OC_PROJECT: ${{needs.prepare-env-job.outputs.oc_project}}
+  #  steps:
+  #    - name: Clean OC project
+  #      if: always()
+  #      run: |
 
-          echo $OC_PROJECT
+  #        echo $OC_PROJECT
 
-          # Prepare Kubeconfig.
-          # Use GitHub secret which contains the Kubeconfig for SA with admin privilleges (same as in ansible vault)
-          # to create Kubernetes context.
-          mkdir $HOME/.kube
-          cat <<EOF > $HOME/.kube/config
-          ${{ secrets.KUBECONFIG }}
-          EOF
+  #        # Prepare Kubeconfig.
+  #        # Use GitHub secret which contains the Kubeconfig for SA with admin privilleges (same as in ansible vault)
+  #        # to create Kubernetes context.
+  #        mkdir $HOME/.kube
+  #        cat <<EOF > $HOME/.kube/config
+  #        ${{ secrets.KUBECONFIG }}
+  #        EOF
 
-          oc delete project $OC_PROJECT
+  #        oc delete project $OC_PROJECT
 
-      # Deleting the branches associated with the PR will also close the PR- if it still exists
-      - name: Clean test branches
-        if: always()
-        uses: dawidd6/action-delete-branch@v3
-        with:
-          github_token: ${{ secrets.BOT_TOKEN }}
-          owner: redhat-openshift-ecosystem
-          repository: operator-pipelines-test
-          branches: ${{needs.prepare-env-job.outputs.test_pr_base_branch}},${{needs.prepare-env-job.outputs.short_sha}}
-          soft_fail: true
+  #    # Deleting the branches associated with the PR will also close the PR- if it still exists
+  #    - name: Clean test branches
+  #      if: always()
+  #      uses: dawidd6/action-delete-branch@v3
+  #      with:
+  #        github_token: ${{ secrets.BOT_TOKEN }}
+  #        owner: redhat-openshift-ecosystem
+  #        repository: operator-pipelines-test
+  #        branches: ${{needs.prepare-env-job.outputs.test_pr_base_branch}},${{needs.prepare-env-job.outputs.short_sha}}
+  #        soft_fail: true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,9 +25,9 @@ jobs:
        - id: prepare
          run: |
            echo "::set-output name=short_sha::${GITHUB_SHA::7}"
-           echo "::set-output name=pr_title::operator test-e2e-operator (0.0.7-${SHORT_SHA})"
-           echo "::set-output name=oc_project::test-e2e-${SHORT_SHA}"
-           echo "::set-output name=test_pr_base_branch::${SHORT_SHA}-base"
+           echo "::set-output name=pr_title::operator test-e2e-operator (0.0.7-${GITHUB_SHA::7})"
+           echo "::set-output name=oc_project::test-e2e-${GITHUB_SHA::7}"
+           echo "::set-output name=test_pr_base_branch::${GITHUB_SHA::7}-base"
 
   # Create a Pull Request with the fake version of fake operator in the repository operator-pipelines-test.
   # Pipelines will run against this PR.

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -722,28 +722,30 @@ spec:
         - name: pyxis-ssl-credentials
           workspace: pyxis-ssl-credentials
 
-    # Query Hydra API for status of the pre-certification checklist
-    - name: query-publishing-checklist
-      runAfter:
-        - link-pull-request
-        - verify-ci-results
-      taskRef:
-        name: query-publishing-checklist
-      params:
-        - name: pipeline_image
-          value: "$(params.pipeline_image)"
-        - name: cert_project_id
-          value: "$(tasks.certification-project-check.results.certification_project_id)"
-        - name: connect_url
-          value: "$(tasks.set-env.results.connect_url)"
-      workspaces:
-        - name: hydra-credentials
-          workspace: hydra-credentials
+    ## Query Hydra API for status of the pre-certification checklist
+    #- name: query-publishing-checklist
+    #  runAfter:
+    #    - link-pull-request
+    #    - verify-ci-results
+    #  taskRef:
+    #    name: query-publishing-checklist
+    #  params:
+    #    - name: pipeline_image
+    #      value: "$(params.pipeline_image)"
+    #    - name: cert_project_id
+    #      value: "$(tasks.certification-project-check.results.certification_project_id)"
+    #    - name: connect_url
+    #      value: "$(tasks.set-env.results.connect_url)"
+    #  workspaces:
+    #    - name: hydra-credentials
+    #      workspace: hydra-credentials
 
     # merge PR
     - name: merge-pr
       runAfter:
-        - query-publishing-checklist
+        #- query-publishing-checklist
+        - link-pull-request
+        - verify-ci-results
       taskRef:
         name: merge-pr
       params:

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -722,30 +722,28 @@ spec:
         - name: pyxis-ssl-credentials
           workspace: pyxis-ssl-credentials
 
-    ## Query Hydra API for status of the pre-certification checklist
-    #- name: query-publishing-checklist
-    #  runAfter:
-    #    - link-pull-request
-    #    - verify-ci-results
-    #  taskRef:
-    #    name: query-publishing-checklist
-    #  params:
-    #    - name: pipeline_image
-    #      value: "$(params.pipeline_image)"
-    #    - name: cert_project_id
-    #      value: "$(tasks.certification-project-check.results.certification_project_id)"
-    #    - name: connect_url
-    #      value: "$(tasks.set-env.results.connect_url)"
-    #  workspaces:
-    #    - name: hydra-credentials
-    #      workspace: hydra-credentials
+    # Query Hydra API for status of the pre-certification checklist
+    - name: query-publishing-checklist
+      runAfter:
+        - link-pull-request
+        - verify-ci-results
+      taskRef:
+        name: query-publishing-checklist
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: cert_project_id
+          value: "$(tasks.certification-project-check.results.certification_project_id)"
+        - name: connect_url
+          value: "$(tasks.set-env.results.connect_url)"
+      workspaces:
+        - name: hydra-credentials
+          workspace: hydra-credentials
 
     # merge PR
     - name: merge-pr
       runAfter:
-        #- query-publishing-checklist
-        - link-pull-request
-        - verify-ci-results
+        - query-publishing-checklist
       taskRef:
         name: merge-pr
       params:

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -6,6 +6,6 @@ Both deployment and E2E tests needs GitHub secrets to work properly. Following s
 
 | Secret name | Secret value | Purpose |
 | ----------- | ------------ | ------- |
-| BOT_TOKEN | PAT (Personal Access Token) of rh-operator-bundle-bot | E2E tests- allows access to repository operator-pipelines-test |
+| BOT_TOKEN | PAT (Personal Access Token) of rh-operator-bundle-test-e2e | E2E tests- fake "partner" account, allows access to repository operator-pipelines-test |
 | KUBECONFIG | Kubeconfig of the cluster, where E2E tests should run | E2E tests- resources are deployed to the namespace $SHORT_COMMIT_HASH in this cluster |
 | VAULT_PASSWORD | Password to the Ansible Vault stored in the repository | E2E tests- password is needed to decrypt the secrets and thus- recreate the resources |

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,11 @@
+# GitHub actions
+Project uses GitHub actions for CI (tests, linters) and CD (deployment).
+
+# Secrets
+Both deployment and E2E tests needs GitHub secrets to work properly. Following secrets should be kept in the repository:
+
+| Secret name | Secret value | Purpose |
+| ----------- | ------------ | ------- |
+| BOT_TOKEN | PAT (Personal Access Token) of rh-operator-bundle-bot | E2E tests- allows access to repository operator-pipelines-test |
+| KUBECONFIG | Kubeconfig of the cluster, where E2E tests should run | E2E tests- resources are deployed to the namespace $SHORT_COMMIT_HASH in this cluster |
+| VAULT_PASSWORD | Password to the Ansible Vault stored in the repository | E2E tests- password is needed to decrypt the secrets and thus- recreate the resources |


### PR DESCRIPTION
Currently, tests have two issues that could be resolved better:
1. Only one e2e test action can run at a time. Otherwise, two PRs for the test operator will be created, and step `Submission-Validation` will fail, as there are multiple PRs for one operator. To change that, we would have to fabricate operator name instead of operator version, but since we want to run the tests only before deployment, it shouldn't be an issue.
2.  Preflight tests are running each time, as the submission hash is always different. To change that, we would need an additional step that uploads mock results to Pyxis. 

Jira task: ISV-890