### PR TITLE
Use proxy for external preprod environments

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -451,6 +451,8 @@ spec:
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: pipeline_name
           value: "$(context.pipelineRun.name)"
+        - name: env
+          value: $(params.env)
 
     - name: show-support-link
       taskRef:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
@@ -27,6 +27,8 @@ spec:
       description: Operator package name
     - name: pipeline_name
       description: Tekton pipeline run name where logs will be gathered from
+    - name: env
+      description: Environment. One of [dev, qa, stage, prod]
   results:
     - name: pipeline_log_url
   workspaces:
@@ -52,6 +54,8 @@ spec:
           value: $(params.pyxis_cert_path)
         - name: PYXIS_KEY_PATH
           value: $(params.pyxis_key_path)
+        - name: ENVIRONMENT
+          value: $(params.env)
       script: |
         #! /usr/bin/env bash
         echo "Uploading pipeline logs"

--- a/operator-pipeline-images/operatorcert/pyxis.py
+++ b/operator-pipeline-images/operatorcert/pyxis.py
@@ -37,6 +37,8 @@ def _get_session() -> requests.Session:
     key = os.environ.get("PYXIS_KEY_PATH")
     env = os.environ.get("ENVIRONMENT")
 
+    # Document about the proxy configuration:
+    # https://source.redhat.com/groups/public/customer-platform-devops/digital_experience_operations_dxp_ops_wiki/using_squid_proxy_to_access_akamai_preprod_domains_over_vpn
     proxies = {}
     # If it's external preprod
     if env != "prod" and api_key:

--- a/operator-pipeline-images/operatorcert/pyxis.py
+++ b/operator-pipeline-images/operatorcert/pyxis.py
@@ -35,6 +35,14 @@ def _get_session() -> requests.Session:
     api_key = os.environ.get("PYXIS_API_KEY")
     cert = os.environ.get("PYXIS_CERT_PATH")
     key = os.environ.get("PYXIS_KEY_PATH")
+    env = os.environ.get("ENVIRONMENT")
+
+    proxies = {}
+    if env != "prod":
+        proxies = {
+            "http": "http://squid.corp.redhat.com:3128",
+            "https": "http://squid.corp.redhat.com:3128",
+        }
 
     # API key or cert + key need to be provided using env variable
     if not api_key and (not cert or not key):
@@ -44,12 +52,18 @@ def _get_session() -> requests.Session:
         )
 
     session = requests.Session()
+
     if api_key:
         LOGGER.debug("Pyxis session using API key is created")
         session.headers.update({"X-API-KEY": api_key})
     else:
         LOGGER.debug("Pyxis session using cert + key is created")
         session.cert = (cert, key)
+
+    if proxies:
+        LOGGER.debug("Pyxis session configured for Proxy (preprod environment)")
+        session.proxies.update(proxies)
+
     return session
 
 

--- a/operator-pipeline-images/operatorcert/pyxis.py
+++ b/operator-pipeline-images/operatorcert/pyxis.py
@@ -62,7 +62,9 @@ def _get_session() -> requests.Session:
         session.cert = (cert, key)
 
     if proxies:
-        LOGGER.debug("Pyxis session configured for Proxy (external preprod environment)")
+        LOGGER.debug(
+            "Pyxis session configured for Proxy (external preprod environment)"
+        )
         session.proxies.update(proxies)
 
     return session

--- a/operator-pipeline-images/operatorcert/pyxis.py
+++ b/operator-pipeline-images/operatorcert/pyxis.py
@@ -38,7 +38,8 @@ def _get_session() -> requests.Session:
     env = os.environ.get("ENVIRONMENT")
 
     proxies = {}
-    if env != "prod":
+    # If it's external preprod
+    if env != "prod" and api_key:
         proxies = {
             "http": "http://squid.corp.redhat.com:3128",
             "https": "http://squid.corp.redhat.com:3128",
@@ -61,7 +62,7 @@ def _get_session() -> requests.Session:
         session.cert = (cert, key)
 
     if proxies:
-        LOGGER.debug("Pyxis session configured for Proxy (preprod environment)")
+        LOGGER.debug("Pyxis session configured for Proxy (external preprod environment)")
         session.proxies.update(proxies)
 
     return session


### PR DESCRIPTION
E2E tests are using an external preprod environment- and it has domain lockdown. 
Jira task: ISV-1479