### PR TITLE
Update Pyxis module to also verify that cert paths exist

### DIFF
--- a/operator-pipeline-images/operatorcert/pyxis.py
+++ b/operator-pipeline-images/operatorcert/pyxis.py
@@ -47,21 +47,26 @@ def _get_session() -> requests.Session:
             "https": "http://squid.corp.redhat.com:3128",
         }
 
-    # API key or cert + key need to be provided using env variable
-    if not api_key and (not cert or not key):
-        raise Exception(
-            "No auth details provided for Pyxis. "
-            "Either define PYXIS_API_KEY or PYXIS_CERT_PATH + PYXIS_KEY_PATH"
-        )
-
     session = requests.Session()
 
     if api_key:
         LOGGER.debug("Pyxis session using API key is created")
         session.headers.update({"X-API-KEY": api_key})
+    elif cert and key:
+        if os.path.exists(cert) and os.path.exists(key):
+            LOGGER.debug("Pyxis session using cert + key is created")
+            session.cert = (cert, key)
+        else:
+            raise Exception(
+                "PYXIS_CERT_PATH or PYXIS_KEY_PATH does not point to a file that "
+                "exists."
+            )
     else:
-        LOGGER.debug("Pyxis session using cert + key is created")
-        session.cert = (cert, key)
+        # API key or cert + key need to be provided using env variable
+        raise Exception(
+            "No auth details provided for Pyxis. "
+            "Either define PYXIS_API_KEY or PYXIS_CERT_PATH + PYXIS_KEY_PATH"
+        )
 
     if proxies:
         LOGGER.debug(

--- a/operator-pipeline-images/tests/test_pyxis.py
+++ b/operator-pipeline-images/tests/test_pyxis.py
@@ -33,7 +33,9 @@ def test_get_session_cert(mock_path_exists: MagicMock, monkeypatch: Any) -> None
 
 
 @patch("os.path.exists")
-def test_get_session_cert_not_exist(mock_path_exists: MagicMock, monkeypatch: Any) -> None:
+def test_get_session_cert_not_exist(
+    mock_path_exists: MagicMock, monkeypatch: Any
+) -> None:
     mock_path_exists.return_value = False
     monkeypatch.setenv("PYXIS_CERT_PATH", "/path/to/cert.pem")
     monkeypatch.setenv("PYXIS_KEY_PATH", "/path/to/key.key")

--- a/operator-pipeline-images/tests/test_pyxis.py
+++ b/operator-pipeline-images/tests/test_pyxis.py
@@ -22,12 +22,24 @@ def test_get_session_api_key(monkeypatch: Any) -> None:
     assert session.headers["X-API-KEY"] == "123"
 
 
-def test_get_session_cert(monkeypatch: Any) -> None:
+@patch("os.path.exists")
+def test_get_session_cert(mock_path_exists: MagicMock, monkeypatch: Any) -> None:
+    mock_path_exists.return_value = True
     monkeypatch.setenv("PYXIS_CERT_PATH", "/path/to/cert.pem")
     monkeypatch.setenv("PYXIS_KEY_PATH", "/path/to/key.key")
     session = pyxis._get_session()
 
     assert session.cert == ("/path/to/cert.pem", "/path/to/key.key")
+
+
+@patch("os.path.exists")
+def test_get_session_cert_not_exist(mock_path_exists: MagicMock, monkeypatch: Any) -> None:
+    mock_path_exists.return_value = False
+    monkeypatch.setenv("PYXIS_CERT_PATH", "/path/to/cert.pem")
+    monkeypatch.setenv("PYXIS_KEY_PATH", "/path/to/key.key")
+
+    with pytest.raises(Exception):
+        pyxis._get_session()
 
 
 def test_get_session_no_auth(monkeypatch: Any) -> None:


### PR DESCRIPTION
With some upcoming changes for ISV-1278, the cert+key filepaths
could be set but not point to existent file. This will detect the
case and provide a clearer error message.

This should be merged and semver tagged before https://github.com/redhat-openshift-ecosystem/operator-pipelines/pull/181