### PR TITLE
Revert "Use proxy for external preprod environments (#194)"

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -451,8 +451,6 @@ spec:
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: pipeline_name
           value: "$(context.pipelineRun.name)"
-        - name: env
-          value: $(params.env)
 
     - name: show-support-link
       taskRef:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
@@ -27,8 +27,6 @@ spec:
       description: Operator package name
     - name: pipeline_name
       description: Tekton pipeline run name where logs will be gathered from
-    - name: env
-      description: Environment. One of [dev, qa, stage, prod]
   results:
     - name: pipeline_log_url
   workspaces:
@@ -54,8 +52,6 @@ spec:
           value: $(params.pyxis_cert_path)
         - name: PYXIS_KEY_PATH
           value: $(params.pyxis_key_path)
-        - name: ENVIRONMENT
-          value: $(params.env)
       script: |
         #! /usr/bin/env bash
         echo "Uploading pipeline logs"

--- a/operator-pipeline-images/operatorcert/pyxis.py
+++ b/operator-pipeline-images/operatorcert/pyxis.py
@@ -35,20 +35,8 @@ def _get_session() -> requests.Session:
     api_key = os.environ.get("PYXIS_API_KEY")
     cert = os.environ.get("PYXIS_CERT_PATH")
     key = os.environ.get("PYXIS_KEY_PATH")
-    env = os.environ.get("ENVIRONMENT")
-
-    # Document about the proxy configuration:
-    # https://source.redhat.com/groups/public/customer-platform-devops/digital_experience_operations_dxp_ops_wiki/using_squid_proxy_to_access_akamai_preprod_domains_over_vpn
-    proxies = {}
-    # If it's external preprod
-    if env != "prod" and api_key:
-        proxies = {
-            "http": "http://squid.corp.redhat.com:3128",
-            "https": "http://squid.corp.redhat.com:3128",
-        }
 
     session = requests.Session()
-
     if api_key:
         LOGGER.debug("Pyxis session using API key is created")
         session.headers.update({"X-API-KEY": api_key})
@@ -67,12 +55,6 @@ def _get_session() -> requests.Session:
             "No auth details provided for Pyxis. "
             "Either define PYXIS_API_KEY or PYXIS_CERT_PATH + PYXIS_KEY_PATH"
         )
-
-    if proxies:
-        LOGGER.debug(
-            "Pyxis session configured for Proxy (external preprod environment)"
-        )
-        session.proxies.update(proxies)
 
     return session
 


### PR DESCRIPTION
Revert "Use proxy for external preprod environments (#194)"
This reverts commit 57cad4863f2ae88802d9881668f32b4b125e1bc4.

The code change with proxy broke tekton tasks. We have to revert it to unblock production certification.