### PR TITLE
Run deploy workflow only when e2e workflow passed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-latest
 
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This condition makes sure the deployment is triggered only when e2e test
passed.