### PR TITLE
Fix upload log task

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -451,8 +451,6 @@ spec:
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: pipeline_name
           value: "$(context.pipelineRun.name)"
-        - name: env
-          value: $(params.env)
 
     - name: show-support-link
       taskRef:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
@@ -27,8 +27,6 @@ spec:
       description: Operator package name
     - name: pipeline_name
       description: Tekton pipeline run name where logs will be gathered from
-    - name: env
-      description: Environment. One of [dev, qa, stage, prod]
   results:
     - name: pipeline_log_url
   workspaces:
@@ -54,8 +52,6 @@ spec:
           value: $(params.pyxis_cert_path)
         - name: PYXIS_KEY_PATH
           value: $(params.pyxis_key_path)
-        - name: ENVIRONMENT
-          value: $(params.env)
       script: |
         #! /usr/bin/env bash
         echo "Uploading pipeline logs"


### PR DESCRIPTION
The unnecessary env argument is removed from upload task that caused
failure of hosted and release pipeline.