### PR TITLE
Add missing OCP_VER variable

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
@@ -152,6 +152,15 @@ spec:
             exit 0
           fi
 
+          DPTP_VER="4.9"
+          CP_VER="$(params.ocp_version)"
+
+          if [ "$(printf '%s\n' "$DPTP_VER" "$CP_VER" | sort -V | head -n1)" = "$DPTP_VER" ]; then
+              OCP_VER="${DPTP_VER}"
+          else
+              OCP_VER="${CP_VER}"
+          fi
+
           if [ "$(params.ocp_version)" == "4.6" ] || [ "$(params.ocp_version)" == "4.7" ]; then
               JOB_SUFFIX="aws"
           else


### PR DESCRIPTION
While working on failing e2e-ci runs discovered missing addition
of the OCP_VER in the preflight-trigger task's
get-prowjob-artifacts-and-decrypt step

Signed-off-by: Melvin Hillsman <mhillsma@redhat.com>