### PR TITLE
[ISV-1612] Increase timeout for catalog import-image

### DIFF
--- a/ansible/init-custom-env.sh
+++ b/ansible/init-custom-env.sh
@@ -56,7 +56,7 @@ execute_playbook() {
 pull_parent_index() {
   oc project $NAMESPACE
   # Must be run once before certifying against the certified catalog.
-  oc import-image certified-operator-index \
+  oc --request-timeout 5m import-image certified-operator-index \
     --from=registry.redhat.io/redhat/certified-operator-index \
     --reference-policy local \
     --scheduled \
@@ -64,7 +64,7 @@ pull_parent_index() {
     --all
 
   # Must be run once before certifying against the Red Hat Martketplace catalog.
-  oc import-image redhat-marketplace-index \
+  oc --request-timeout 5m import-image redhat-marketplace-index \
     --from=registry.redhat.io/redhat/redhat-marketplace-index \
     --reference-policy local \
     --scheduled \

--- a/docs/pipeline-env-setup.md
+++ b/docs/pipeline-env-setup.md
@@ -33,7 +33,7 @@ there is a one time configuration for each desired distribution catalog.
 
 ```bash
 # Must be run once before certifying against the certified catalog.
-oc import-image certified-operator-index \
+oc --request-timeout 5m import-image certified-operator-index \
   --from=registry.redhat.io/redhat/certified-operator-index \
   --reference-policy local \
   --scheduled \
@@ -41,7 +41,7 @@ oc import-image certified-operator-index \
   --all
 
 # Must be run once before certifying against the Red Hat Marketplace catalog.
-oc import-image redhat-marketplace-index \
+oc --request-timeout 5m import-image redhat-marketplace-index \
   --from=registry.redhat.io/redhat/redhat-marketplace-index \
   --reference-policy local \
   --scheduled \


### PR DESCRIPTION
The default timeout was cuasing intermittent failures while setting up
the environment for the E2E tests.