### PR TITLE
Add retries for all HTTP(S) requests made with requests

### DIFF
--- a/operator-pipeline-images/operatorcert/github.py
+++ b/operator-pipeline-images/operatorcert/github.py
@@ -3,8 +3,8 @@ import os
 from typing import Any, Dict, Optional
 
 import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+
+from operatorcert.utils import add_session_retries
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -25,14 +25,7 @@ def _get_session(auth_required: bool = False) -> requests.Session:
         requests.Session: Github session
     """
     session = requests.Session()
-
-    # Exponential retry backoff for a max wait of ~8.5 mins
-    retries = Retry(
-        total=10, backoff_factor=1, status_forcelist=(408, 500, 502, 503, 504)
-    )
-    adapter = HTTPAdapter(max_retries=retries)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
+    add_session_retries(session)
 
     if auth_required:
         token = os.environ.get("GITHUB_TOKEN")

--- a/operator-pipeline-images/operatorcert/github.py
+++ b/operator-pipeline-images/operatorcert/github.py
@@ -1,8 +1,10 @@
 import logging
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -22,16 +24,60 @@ def _get_session(auth_required: bool = False) -> requests.Session:
     Returns:
         requests.Session: Github session
     """
-    token = os.environ.get("GITHUB_TOKEN")
-
-    if auth_required and not token:
-        raise Exception("No auth details provided for Github. Define GITHUB_TOKEN.")
-
     session = requests.Session()
-    session.headers.update(
-        {"Authorization": f"Bearer {token}", "Accept": "application/vnd.github.v3+json"}
+
+    # Exponential retry backoff for a max wait of ~8.5 mins
+    retries = Retry(
+        total=10, backoff_factor=1, status_forcelist=(408, 500, 502, 503, 504)
     )
+    adapter = HTTPAdapter(max_retries=retries)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
+    if auth_required:
+        token = os.environ.get("GITHUB_TOKEN")
+
+        if not token:
+            raise Exception("No auth details provided for Github. Define GITHUB_TOKEN.")
+
+        session.headers.update(
+            {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github.v3+json",
+            }
+        )
+
     return session
+
+
+def get(
+    url: str, params: Optional[Dict[str, str]] = None, auth_required: bool = True
+) -> Dict[str, Any]:
+    """
+    Issue a GET request to the GitHub API
+
+    Args:
+        url (str): Github API URL
+        params (dict): Additional query parameters
+        auth_required (bool): Whether authentication should be required for the session
+
+    Returns:
+        Dict[str, Any]: GitHub response
+    """
+    session = _get_session(auth_required=auth_required)
+    LOGGER.debug(f"GET GitHub request url: {url}")
+    LOGGER.debug(f"GET GitHub request params: {params}")
+    resp = session.get(url, params=params)
+
+    try:
+        resp.raise_for_status()
+    except requests.HTTPError:
+        LOGGER.exception(
+            f"GitHub GET query failed with {url} - {resp.status_code} - {resp.text}"
+        )
+        raise
+
+    return resp.json()
 
 
 def post(url: str, body: Dict[str, Any]) -> Dict[str, Any]:

--- a/operator-pipeline-images/operatorcert/hydra.py
+++ b/operator-pipeline-images/operatorcert/hydra.py
@@ -5,9 +5,8 @@ import sys
 from typing import Any, Dict
 
 import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 
+from operatorcert.utils import add_session_retries
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -31,14 +30,7 @@ def _get_session() -> requests.Session:
 
     session = requests.Session()
     session.auth = (username, password)
-
-    # Exponential retry backoff for a max wait of ~8.5 mins
-    retries = Retry(
-        total=10, backoff_factor=1, status_forcelist=(408, 500, 502, 503, 504)
-    )
-    adapter = HTTPAdapter(max_retries=retries)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
+    add_session_retries(session)
 
     return session
 

--- a/operator-pipeline-images/operatorcert/iib.py
+++ b/operator-pipeline-images/operatorcert/iib.py
@@ -3,9 +3,9 @@ from typing import Any, Dict
 from urllib.parse import urljoin
 
 import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 from requests_kerberos import HTTPKerberosAuth
+
+from operatorcert.utils import add_session_retries
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -21,17 +21,10 @@ def get_session(kerberos_auth=True) -> Any:
         Any: IIB session
     """
     session = requests.Session()
+    add_session_retries(session)
 
     if kerberos_auth:
         session.auth = HTTPKerberosAuth()
-
-    # Exponential retry backoff for a max wait of ~8.5 mins
-    retries = Retry(
-        total=10, backoff_factor=1, status_forcelist=(408, 500, 502, 503, 504)
-    )
-    adapter = HTTPAdapter(max_retries=retries)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
 
     return session
 

--- a/operator-pipeline-images/operatorcert/pyxis.py
+++ b/operator-pipeline-images/operatorcert/pyxis.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, Optional
 from urllib.parse import urljoin
 
 import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+
+from operatorcert.utils import add_session_retries
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -54,14 +54,7 @@ def _get_session(pyxis_url: str, auth_required: bool = True) -> requests.Session
         }
 
     session = requests.Session()
-
-    # Exponential retry backoff for a max wait of ~8.5 mins
-    retries = Retry(
-        total=10, backoff_factor=1, status_forcelist=(408, 500, 502, 503, 504)
-    )
-    adapter = HTTPAdapter(max_retries=retries)
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
+    add_session_retries(session)
 
     if auth_required:
         if api_key:

--- a/operator-pipeline-images/operatorcert/utils.py
+++ b/operator-pipeline-images/operatorcert/utils.py
@@ -4,6 +4,10 @@ import os
 import pathlib
 from typing import Dict, List, Optional, Tuple
 
+from requests import Session
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
 LOGGER = logging.getLogger("operator-cert")
 
 
@@ -82,3 +86,35 @@ def set_client_keytab(keytab_file: str):
     LOGGER.debug(
         "Set KRB5_CLIENT_KTNAME env variable: %s", os.environ["KRB5_CLIENT_KTNAME"]
     )
+
+
+def add_session_retries(
+    session: Session,
+    total: int = 10,
+    backoff_factor: int = 1,
+    status_forcelist: Optional[Tuple[int]] = (408, 500, 502, 503, 504),
+) -> None:
+    """
+    Adds retries to a requests HTTP/HTTPS session.
+    The default values provide exponential backoff for a max wait of ~8.5 mins
+
+    Reference the urllib3 documentation for more details about the kwargs.
+
+    Args:
+        session (Session): A requests session
+        total (int): See urllib3 docs
+        backoff_factor (int): See urllib3 docs
+        status_forcelist (tuple[int]|None): See urllib3 docs
+    """
+    retries = Retry(
+        total=total,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+        # Don't raise a MaxRetryError for codes in status_forcelist.
+        # This allows for more graceful exception handling using
+        # Response.raise_for_status.
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retries)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)

--- a/operator-pipeline-images/tests/test_github.py
+++ b/operator-pipeline-images/tests/test_github.py
@@ -8,18 +8,37 @@ from requests import HTTPError, Response
 
 def test_get_session_github_token(monkeypatch: Any) -> None:
     monkeypatch.setenv("GITHUB_TOKEN", "123")
-    session = github._get_session()
+    session = github._get_session(auth_required=True)
 
     assert session.headers["Authorization"] == "Bearer 123"
 
 
 def test_get_session_no_auth() -> None:
-    github._get_session(auth_required=False)
+    session = github._get_session(auth_required=False)
+    assert "Authorization" not in session.headers
 
 
-def test_get_session_no_auth() -> None:
+def test_get_session_missing_token() -> None:
     with pytest.raises(Exception):
         github._get_session(auth_required=True)
+
+
+@patch("operatorcert.github._get_session")
+def test_get(mock_session: MagicMock) -> None:
+    mock_session.return_value.get.return_value.json.return_value = {"key": "val"}
+    resp = github.get("https://foo.com/v1/bar", {})
+    assert resp == {"key": "val"}
+
+
+@patch("operatorcert.github._get_session")
+def test_get_with_error(mock_session: MagicMock) -> None:
+    response = Response()
+    response.status_code = 500
+    mock_session.return_value.get.return_value.raise_for_status.side_effect = HTTPError(
+        response=response
+    )
+    with pytest.raises(HTTPError):
+        github.get("https://foo.com/v1/bar", {})
 
 
 @patch("operatorcert.github._get_session")

--- a/operator-pipeline-images/tests/test_pyxis.py
+++ b/operator-pipeline-images/tests/test_pyxis.py
@@ -54,7 +54,13 @@ def test_get_session_cert_not_exist(
         pyxis._get_session("test")
 
 
-def test_get_session_no_auth(monkeypatch: Any) -> None:
+def test_get_session_no_auth() -> None:
+    session = pyxis._get_session("test", auth_required=False)
+    assert session.cert is None
+    assert session.headers.get("X-API-KEY") is None
+
+
+def test_get_session_no_credentials(monkeypatch: Any) -> None:
     with pytest.raises(Exception):
         pyxis._get_session("test")
 

--- a/operator-pipeline-images/tests/test_utils.py
+++ b/operator-pipeline-images/tests/test_utils.py
@@ -69,3 +69,22 @@ def test_set_client_keytab() -> None:
         mock_isfile.return_value = True
         utils.set_client_keytab("test")
         assert os.environ["KRB5_CLIENT_KTNAME"] == "FILE:test"
+
+
+def test_add_session_retries() -> None:
+    status_forcelist = (404, 503)
+    total = 3
+    backoff_factor = 0.5
+    session = utils.Session()
+    utils.add_session_retries(
+        session,
+        total=total,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+    )
+    assert session.adapters["http://"].max_retries.total == total
+    assert session.adapters["http://"].max_retries.backoff_factor == backoff_factor
+    assert session.adapters["http://"].max_retries.status_forcelist == status_forcelist
+    assert session.adapters["https://"].max_retries.total == total
+    assert session.adapters["https://"].max_retries.backoff_factor == backoff_factor
+    assert session.adapters["https://"].max_retries.status_forcelist == status_forcelist


### PR DESCRIPTION
The retry status codes are a best effort guess at this point but should
be sane defaults to start with. The same goes for the backoff strategy.