### PR TITLE
Fixed errors during execution of the CI pipeline on non-amd64 cluster

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -467,7 +467,7 @@ spec:
           value: "$(params.pyxis_api_key_secret_name)"
         - name: pyxis_api_key_secret_key
           value: "$(params.pyxis_api_key_secret_key)"
-       workspaces:
+      workspaces:
         - name: source   
           workspace: pipeline
           subPath: src 

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -467,6 +467,10 @@ spec:
           value: "$(params.pyxis_api_key_secret_name)"
         - name: pyxis_api_key_secret_key
           value: "$(params.pyxis_api_key_secret_key)"
+       workspaces:
+        - name: source   
+          workspace: pipeline
+          subPath: src 
 
     - name: show-support-link
       taskRef:

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -470,7 +470,6 @@ spec:
       workspaces:
         - name: source
           workspace: pipeline
-          subPath: src
 
     - name: show-support-link
       taskRef:

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -468,9 +468,9 @@ spec:
         - name: pyxis_api_key_secret_key
           value: "$(params.pyxis_api_key_secret_key)"
       workspaces:
-        - name: source   
+        - name: source  
           workspace: pipeline
-          subPath: src 
+          subPath: src
 
     - name: show-support-link
       taskRef:

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -468,7 +468,7 @@ spec:
         - name: pyxis_api_key_secret_key
           value: "$(params.pyxis_api_key_secret_key)"
       workspaces:
-        - name: source  
+        - name: source
           workspace: pipeline
           subPath: src
 

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -902,6 +902,10 @@ spec:
           value: "$(params.pyxis_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
           value: "$(params.pyxis_ssl_key_secret_key)"
+      workspaces:
+        - name: source
+          workspace: pipeline
+          subPath: src
 
     # In the event of a failure, comment with the support link on the github PR
     - name: github-add-support-comment

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -904,8 +904,7 @@ spec:
           value: "$(params.pyxis_ssl_key_secret_key)"
       workspaces:
         - name: source
-          workspace: pipeline
-          subPath: src
+          workspace: repository
 
     # In the event of a failure, comment with the support link on the github PR
     - name: github-add-support-comment

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -467,8 +467,7 @@ spec:
           value: "$(params.pyxis_ssl_key_secret_key)"
       workspaces:
         - name: source
-          workspace: pipeline
-          subPath: src
+          workspace: repository
 
     # In the event of a failure, comment with the support link on the github PR
     - name: github-add-support-comment

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -465,6 +465,10 @@ spec:
           value: "$(params.pyxis_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
           value: "$(params.pyxis_ssl_key_secret_key)"
+      workspaces:
+        - name: source
+          workspace: pipeline
+          subPath: src
 
     # In the event of a failure, comment with the support link on the github PR
     - name: github-add-support-comment

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -104,6 +104,7 @@ spec:
 
         mv $PFLT_ARTIFACTS/results.json results.json
         chmod +r results.json
+        chmod +r preflight.log
         echo -n $PFLT_LOGFILE | tee $(results.log_output_file.path)
         echo -n results.json | tee $(results.result_output_file.path)
         echo -n $PFLT_ARTIFACTS | tee $(results.artifacts_output_dir.path)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
@@ -36,6 +36,8 @@ spec:
       description: Tekton pipeline run name where logs will be gathered from
   results:
     - name: pipeline_log_url
+  workspaces:
+    - name: source
   volumes:
     - name: pyxis-ssl-volume
       secret:
@@ -50,7 +52,7 @@ spec:
 
         echo "Getting pipeline logs"
 
-        tkn pipelinerun logs "$(params.pipeline_name)" > pipeline.logs
+        tkn pipelinerun logs "$(params.pipeline_name)" > $(workspaces.source.path)/pipeline.logs
 
     - name: upload-pipeline-logs
       image: "$(params.pipeline_image)"
@@ -80,7 +82,7 @@ spec:
           --operator-package-name "$(params.package_name)" \
           --certification-hash "$(params.md5sum)" \
           --pyxis-url "$(params.pyxis_url)" \
-          --path pipeline.logs \
+          --path $(workspaces.source.path)/pipeline.logs \
           --type pipeline-logs \
           --output pipeline-logs-artifact.json \
           --verbose


### PR DESCRIPTION
Fixed below errors on the non-amd64 cluster -
"PermissionError: [Errno 13] Permission denied: 'preflight.log'" error at upload-artifacts step
"FileNotFoundError: [Errno 2] No such file or directory: 'pipeline.logs'" error at upload-pipeline-logs step
 