### PR TITLE
Switch to v2 Hydra checklist endpoint + logging

### DIFF
--- a/operator-pipeline-images/operatorcert/__init__.py
+++ b/operator-pipeline-images/operatorcert/__init__.py
@@ -20,6 +20,8 @@ PACKAGE_ANNOTATION = "operators.operatorframework.io.bundle.package.v1"
 OLM_PROPS_ANNOTATION = "olm.properties"
 MAX_OCP_VERSION_PROPERTY = "olm.maxOpenShiftVersion"
 
+LOGGER = logging.getLogger("operator-cert")
+
 
 def get_bundle_annotations(bundle_path: pathlib.Path) -> Dict:
     """
@@ -235,7 +237,7 @@ def get_files_added_in_pr(
     if modified_files:
         for modified_file in modified_files:
             if not modified_file["filename"].endswith("ci.yaml"):
-                logging.error(
+                LOGGER.error(
                     f"Change not permitted: file: {modified_file['filename']}, status: {modified_file['status']}"
                 )
                 raise RuntimeError("There are changes done to previously merged files")
@@ -257,7 +259,7 @@ def verify_changed_files_location(
     path = parent_path + "/" + bundle_version
     config_path = parent_path + "/ci.yaml"
 
-    logging.info(
+    LOGGER.info(
         f"Changes for operator {operator_name} in version {bundle_version}"
         f" are expected to be in paths: \n"
         f" {path}/* \n"
@@ -267,9 +269,9 @@ def verify_changed_files_location(
     wrong_changes = False
     for file_path in changed_files:
         if file_path.startswith(path) or file_path == config_path:
-            logging.info(f"Permitted change: {file_path}")
+            LOGGER.info(f"Permitted change: {file_path}")
         else:
-            logging.error(f"Unpermitted change: {file_path}")
+            LOGGER.error(f"Unpermitted change: {file_path}")
             wrong_changes = True
 
     if wrong_changes:
@@ -304,7 +306,7 @@ def validate_user(git_username: str, contacts: List[str]):
             f"User {git_username} doesn't have permissions to submit the bundle."
         )
     else:
-        logging.info(f"User {git_username} has permission to submit the bundle.")
+        LOGGER.info(f"User {git_username} has permission to submit the bundle.")
 
 
 def verify_pr_uniqueness(
@@ -342,11 +344,11 @@ def verify_pr_uniqueness(
 
         # Log duplicates and exit with error
         if duplicate_prs:
-            logging.error(
+            LOGGER.error(
                 f"There is more than one pull request for the Operator Bundle {base_pr_bundle_name}"
             )
             for duplicate in duplicate_prs:
-                logging.error(f"DUPLICATE: {duplicate}")
+                LOGGER.error(f"DUPLICATE: {duplicate}")
             raise RuntimeError("Multiple pull requests for one Operator Bundle")
 
 
@@ -373,7 +375,7 @@ def download_test_results(args) -> Optional[str]:
     query_results = rsp.json()["data"]
 
     if len(query_results) == 0:
-        logging.error(f"There is no test results for given parameters")
+        LOGGER.error(f"There is no test results for given parameters")
         return None
 
     # Get needed data from the query result
@@ -392,5 +394,5 @@ def download_test_results(args) -> Optional[str]:
     with open(file_path, "w") as file:
         file.write(result)
 
-    logging.info(f"Test results retrieved successfully for given parameters")
+    LOGGER.info(f"Test results retrieved successfully for given parameters")
     return query_results[0]["_id"]

--- a/operator-pipeline-images/operatorcert/entrypoints/bundle_dockerfile.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/bundle_dockerfile.py
@@ -4,6 +4,7 @@ import pathlib
 from typing import Any
 
 import operatorcert
+from operatorcert.logger import setup_logger
 from operatorcert.utils import store_results
 
 
@@ -77,7 +78,7 @@ def main() -> None:  # pragma: no cover
     if args.verbose:
         log_level = "DEBUG"
 
-    logging.basicConfig(level=log_level)
+    setup_logger(level=log_level)
     dockerfile_content = generate_dockerfile_content(args)
 
     results = {args.destination: dockerfile_content}

--- a/operator-pipeline-images/operatorcert/entrypoints/create_container_image.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/create_container_image.py
@@ -209,7 +209,7 @@ def main():  # pragma: no cover
     parser = setup_argparser()
     args = parser.parse_args()
     log_level = "DEBUG" if args.verbose else "INFO"
-    setup_logger(log_level)
+    setup_logger(level=log_level)
 
     with open(args.skopeo_result) as json_file:
         skopeo_result = json.load(json_file)

--- a/operator-pipeline-images/operatorcert/entrypoints/download_test_results.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/download_test_results.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 
 from operatorcert import download_test_results
+from operatorcert.logger import setup_logger
 from operatorcert.utils import store_results
 
 
@@ -38,7 +39,7 @@ def main() -> None:
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    logging.basicConfig(level=log_level)
+    setup_logger(level=log_level)
 
     # Logic
     test_results_id = download_test_results(args)

--- a/operator-pipeline-images/operatorcert/entrypoints/get_cert_project_related_data.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/get_cert_project_related_data.py
@@ -3,6 +3,7 @@ import logging
 from urllib.parse import urljoin
 
 from operatorcert import pyxis, store_results
+from operatorcert.logger import setup_logger
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -53,7 +54,7 @@ def main() -> None:  # pragma: no cover
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    logging.basicConfig(level=log_level)
+    setup_logger(level=log_level)
 
     get_cert_project_related_data(args.pyxis_url, args.cert_project_id)
 

--- a/operator-pipeline-images/operatorcert/entrypoints/get_vendor_related_data.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/get_vendor_related_data.py
@@ -3,6 +3,7 @@ import logging
 from urllib.parse import urljoin
 
 from operatorcert import pyxis, store_results
+from operatorcert.logger import setup_logger
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -52,7 +53,7 @@ def main() -> None:  # pragma: no cover
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    logging.basicConfig(level=log_level)
+    setup_logger(level=log_level)
 
     get_vendor_related_data(args.pyxis_url, args.org_id)
 

--- a/operator-pipeline-images/operatorcert/entrypoints/github_pr.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/github_pr.py
@@ -9,6 +9,7 @@ from typing import Any, Dict
 import giturlparse
 import operatorcert
 from operatorcert import github
+from operatorcert.logger import setup_logger
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -151,7 +152,7 @@ def main() -> None:  # pragma: no cover
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    logging.basicConfig(level=log_level)
+    setup_logger(level=log_level)
 
     pr_body = get_pr_body(args)
     head = get_head(args.git_repo_url, args.source_branch)

--- a/operator-pipeline-images/operatorcert/entrypoints/hydra_checklist.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/hydra_checklist.py
@@ -115,7 +115,7 @@ def main() -> None:
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    setup_logger(log_level)
+    setup_logger(level=log_level)
 
     check_hydra_checklist_status(
         args.cert_project_id, args.hydra_url, args.ignore_publishing_checklist == "true"

--- a/operator-pipeline-images/operatorcert/entrypoints/hydra_checklist.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/hydra_checklist.py
@@ -1,9 +1,10 @@
 import argparse
 import logging
 import sys
-from typing import Any
+from typing import Any, Dict
 
 from operatorcert import hydra
+from operatorcert.logger import setup_logger
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -34,13 +35,48 @@ def setup_argparser() -> Any:  # pragma: no cover
     return parser
 
 
+def check_single_hydra_checklist(checklist: Dict[str, Any]) -> bool:
+    """
+    Check a single Hydra checklist and return if it passed and log failed tests
+
+    Args:
+        checklist (Dict[str, Any]): Hydra single checklist
+
+    Returns:
+        bool: A flag that determines if a all checks in the checklist passed
+    """
+
+    checklist_items = checklist["checklistItems"]
+    completed = True
+    for item in checklist_items:
+        completed = completed and item["completed"]
+        if not item["completed"]:
+            LOGGER.error(
+                f"FAILED: Checklist item not completed: {item['title']} - {item['reasons']}"
+            )
+        else:
+            LOGGER.info(f"PASSED: Checklist item completed: {item['title']}")
+    return completed
+
+
 def check_hydra_checklist_status(
     cert_project_id: str, hydra_url: str, ignore_publishing_checklist: bool
-) -> Any:
+) -> None:
+    """
+    Call Hydra checklist API and check if all test passed
+
+    Args:
+        cert_project_id (str): Certification project identifier
+        hydra_url (str): Base Hydra API URL
+        ignore_publishing_checklist (bool): Set this flag to True to avoid an abrupt
+            `sys.exit` with a non-zero status code when there are failed checklist results.
+            The failures will still be logged.
+
+    """
     # query hydra checklist API
     # Not using urljoin because for some reason it will eat up the prm at the end if
     # url doesn't end with a /
-    hydra_checklist_url = f"{hydra_url}/v1/projects/{cert_project_id}/checklist/status"
+    hydra_checklist_url = f"{hydra_url}/v2/projects/{cert_project_id}/checklist/status"
 
     LOGGER.info("Examining pre-certification checklist from Hydra...")
     hydra_resp = hydra.get(hydra_checklist_url)
@@ -54,13 +90,11 @@ def check_hydra_checklist_status(
     LOGGER.debug("Checklist overall status is incomplete. Checking individual items...")
 
     # if checklist is not complete, go through each item and log which ones are missing
-    checklist_items = hydra_resp["checklistItems"]
-    completed = True
-    for item in checklist_items:
-        completed = completed and item["completed"]
-        if not item["completed"]:
-            LOGGER.error(f"Checklist item not completed: {item['title']}")
+    checklists = hydra_resp.get("checklists", [])
 
+    completed = True
+    for checklist in checklists:
+        completed = completed and check_single_hydra_checklist(checklist)
     if not completed:
         LOGGER.info(
             f"Pre-certification checklist is not completed for cert project with id "
@@ -81,7 +115,7 @@ def main() -> None:
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    logging.basicConfig(level=log_level)
+    setup_logger(log_level)
 
     check_hydra_checklist_status(
         args.cert_project_id, args.hydra_url, args.ignore_publishing_checklist == "true"

--- a/operator-pipeline-images/operatorcert/entrypoints/index.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/index.py
@@ -1,12 +1,12 @@
 import argparse
 import logging
+import os
+import time
+from datetime import datetime, timedelta
+from typing import Any, List
 
 from operatorcert import iib, utils
-from typing import Any, List
-import time
-import os
-from datetime import datetime, timedelta
-
+from operatorcert.logger import setup_logger
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -163,7 +163,7 @@ def main() -> None:  # pragma: no cover
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    logging.basicConfig(level=log_level)
+    setup_logger(level=log_level)
 
     utils.set_client_keytab(os.environ.get("KRB_KEYTAB_FILE", "/etc/krb5.krb"))
 

--- a/operator-pipeline-images/operatorcert/entrypoints/link_pull_request.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/link_pull_request.py
@@ -84,7 +84,7 @@ def main():  # pragma: no cover
     parser = setup_argparser()
     args = parser.parse_args()
     log_level = "DEBUG" if args.verbose else "INFO"
-    setup_logger(log_level)
+    setup_logger(level=log_level)
 
     link_pr_to_test_results(
         args.pyxis_url,

--- a/operator-pipeline-images/operatorcert/entrypoints/marketplace_replication.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/marketplace_replication.py
@@ -124,7 +124,7 @@ def main():  # pragma: no cover
     parser = setup_argparser()
     args = parser.parse_args()
     log_level = "DEBUG" if args.verbose else "INFO"
-    setup_logger(log_level)
+    setup_logger(level=log_level)
 
     call_ibm_webhook(args)
 

--- a/operator-pipeline-images/operatorcert/entrypoints/ocp_version_info.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/ocp_version_info.py
@@ -5,6 +5,9 @@ import pathlib
 import sys
 
 from operatorcert import ocp_version_info
+from operatorcert.logger import setup_logger
+
+LOGGER = logging.getLogger("operator-cert")
 
 
 def setup_argparser() -> argparse.ArgumentParser:  # pragma: no cover
@@ -22,19 +25,21 @@ def setup_argparser() -> argparse.ArgumentParser:  # pragma: no cover
         default="https://catalog.redhat.com/api/containers/",
         help="Base URL for Pyxis container metadata API",
     )
+    parser.add_argument("--verbose", action="store_true", help="Verbose output")
 
     return parser
 
 
 def main() -> None:
-    logging.basicConfig(stream=sys.stdout, level="INFO", format="%(message)s")
 
     parser = setup_argparser()
     args = parser.parse_args()
+    log_level = "DEBUG" if args.verbose else "INFO"
+    setup_logger(level=log_level, log_format="%(message)s")
 
     bundle_path = pathlib.Path(args.bundle_path)
     version_info = ocp_version_info(bundle_path, args.pyxis_url, args.organization)
-    logging.info(json.dumps(version_info))
+    LOGGER.info(json.dumps(version_info))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/operator-pipeline-images/operatorcert/entrypoints/pipelinerun_summary.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/pipelinerun_summary.py
@@ -2,7 +2,10 @@ import argparse
 import logging
 import sys
 
+from operatorcert.logger import setup_logger
 from operatorcert.tekton import PipelineRun
+
+LOGGER = logging.getLogger("operator-cert")
 
 
 def parse_args() -> argparse.ArgumentParser:  # pragma: no cover
@@ -16,14 +19,16 @@ def parse_args() -> argparse.ArgumentParser:  # pragma: no cover
         help="Include final tasks in the output",
         action="store_true",
     )
+    parser.add_argument("--verbose", action="store_true", help="Verbose output")
 
     return parser.parse_args()
 
 
 def main() -> None:
-    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(message)s")
 
     args = parse_args()
+    log_level = "DEBUG" if args.verbose else "INFO"
+    setup_logger(level=log_level, log_format="%(message)s")
     pr = PipelineRun.from_files(args.pr_path, args.trs_path)
 
     logging.info(pr.markdown_summary(include_final_tasks=args.include_final_tasks))

--- a/operator-pipeline-images/operatorcert/entrypoints/publish.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/publish.py
@@ -9,6 +9,7 @@ from urllib.parse import urljoin
 
 import html2text
 from operatorcert import pyxis, utils
+from operatorcert.logger import setup_logger
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -197,7 +198,7 @@ def main() -> None:  # pragma: no cover
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    logging.basicConfig(level=log_level)
+    setup_logger(level=log_level)
 
     args.func(args)
 

--- a/operator-pipeline-images/operatorcert/entrypoints/reserve_operator_name.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/reserve_operator_name.py
@@ -4,6 +4,7 @@ import sys
 from urllib.parse import urljoin
 
 from operatorcert import pyxis
+from operatorcert.logger import setup_logger
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -86,7 +87,7 @@ def main() -> None:  # pragma: no cover
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    logging.basicConfig(level=log_level)
+    setup_logger(level=log_level)
 
     check_operator_name(args)
     reserve_operator_name(args)

--- a/operator-pipeline-images/operatorcert/entrypoints/set_github_status.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/set_github_status.py
@@ -2,7 +2,8 @@ import argparse
 import logging
 from urllib.parse import urljoin
 
-from operatorcert import github, get_repo_and_org_from_github_url
+from operatorcert import get_repo_and_org_from_github_url, github
+from operatorcert.logger import setup_logger
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -65,7 +66,7 @@ def main() -> None:
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    logging.basicConfig(level=log_level)
+    setup_logger(level=log_level)
 
     set_github_status(args)
 

--- a/operator-pipeline-images/operatorcert/entrypoints/update_cert_project_status.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/update_cert_project_status.py
@@ -3,11 +3,12 @@ Script for updating the cert project status
 """
 import argparse
 import logging
-from typing import Any
 from datetime import datetime, timezone
+from typing import Any
 from urllib.parse import urljoin
 
 from operatorcert import pyxis
+from operatorcert.logger import setup_logger
 from operatorcert.utils import store_results
 
 LOGGER = logging.getLogger("operator-cert")
@@ -68,7 +69,7 @@ def main() -> None:  # pragma: no cover
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    logging.basicConfig(level=log_level)
+    setup_logger(level=log_level)
 
     update_cert_project_status(args)
 

--- a/operator-pipeline-images/operatorcert/entrypoints/upload_artifacts.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/upload_artifacts.py
@@ -202,7 +202,7 @@ def main():  # pragma: no cover
     parser = setup_argparser()
     args = parser.parse_args()
     log_level = "DEBUG" if args.verbose else "INFO"
-    setup_logger(log_level)
+    setup_logger(level=log_level)
 
     response = upload_results_and_artifacts(args)
     with open(args.output, "w") as output:

--- a/operator-pipeline-images/operatorcert/entrypoints/verify_changed_dirs.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/verify_changed_dirs.py
@@ -6,6 +6,9 @@ from operatorcert import (
     verify_changed_files_location,
     get_repo_and_org_from_github_url,
 )
+from operatorcert.logger import setup_logger
+
+LOGGER = logging.getLogger("operator-cert")
 
 
 def setup_argparser() -> argparse.ArgumentParser:  # pragma: no cover
@@ -45,7 +48,7 @@ def main() -> None:
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    logging.basicConfig(level=log_level)
+    setup_logger(level=log_level)
 
     # Logic
     organization, repository = get_repo_and_org_from_github_url(args.git_repo_url)

--- a/operator-pipeline-images/operatorcert/entrypoints/verify_pr_title.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/verify_pr_title.py
@@ -2,7 +2,10 @@ import argparse
 import logging
 
 from operatorcert import parse_pr_title
+from operatorcert.logger import setup_logger
 from operatorcert.utils import store_results
+
+LOGGER = logging.getLogger("operator-cert")
 
 
 def setup_argparser() -> argparse.ArgumentParser:  # pragma: no cover
@@ -24,7 +27,7 @@ def main() -> None:
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    logging.basicConfig(level=log_level)
+    setup_logger(level=log_level)
 
     # Logic- verify the pr title
     bundle_name, bundle_version = parse_pr_title(args.pr_title)

--- a/operator-pipeline-images/operatorcert/entrypoints/verify_pr_uniqueness.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/verify_pr_uniqueness.py
@@ -2,6 +2,9 @@ import argparse
 import logging
 
 from operatorcert import verify_pr_uniqueness
+from operatorcert.logger import setup_logger
+
+LOGGER = logging.getLogger("operator-cert")
 
 
 def setup_argparser() -> argparse.ArgumentParser:  # pragma: no cover
@@ -30,7 +33,7 @@ def main() -> None:
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    logging.basicConfig(level=log_level)
+    setup_logger(level=log_level)
 
     # Logic
     # Verify, that there is no other PR opened for this Bundle

--- a/operator-pipeline-images/operatorcert/entrypoints/verify_pr_user.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/verify_pr_user.py
@@ -2,6 +2,9 @@ import argparse
 import logging
 
 from operatorcert import validate_user
+from operatorcert.logger import setup_logger
+
+LOGGER = logging.getLogger("operator-cert")
 
 
 def setup_argparser() -> argparse.ArgumentParser:  # pragma: no cover
@@ -28,7 +31,7 @@ def main() -> None:
     log_level = "INFO"
     if args.verbose:
         log_level = "DEBUG"
-    logging.basicConfig(level=log_level)
+    setup_logger(level=log_level)
 
     # Logic
     # Validate the Github user which created the PR

--- a/operator-pipeline-images/operatorcert/logger.py
+++ b/operator-pipeline-images/operatorcert/logger.py
@@ -4,15 +4,26 @@ from typing import Any
 STREAM_FORMAT = "%(asctime)s [%(name)s] %(levelname)s %(message)s"
 
 
-def setup_logger(level: str = "INFO") -> Any:
+def setup_logger(level: str = "INFO", log_format: Any = None) -> Any:
     """
     Set up and configure 'operator-cert' logger.
+
+    Args:
+        level (str, optional): Logging level. Defaults to "INFO".
+        log_format (Any, optional): Logging message format. Defaults to None.
+
+    Returns:
+        Any: Logger object
     """
+
     logger = logging.getLogger("operator-cert")
     logger.propagate = False
     logger.setLevel(level)
 
-    stream_formatter = logging.Formatter(STREAM_FORMAT)
+    if log_format is None:
+        log_format = STREAM_FORMAT
+
+    stream_formatter = logging.Formatter(log_format)
     stream_handler = logging.StreamHandler()
     stream_handler.setLevel(level)
     stream_handler.setFormatter(stream_formatter)


### PR DESCRIPTION
The new v2 endpoint supports multiple checklists for a single project.
The new endpoint returns a different response body with multiple
checklists. This commit iterates over all checklists + all checks and
reports failed tests.

This pull request also contains logging changes. 

JIRA: ISV-1492