### PR TITLE
Link test result with pull request in CI pipeline

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -406,7 +406,7 @@ spec:
           workspace: pipeline
           subPath: preflight
 
-    - name: open-pr
+    - name: open-pull-request
       runAfter:
         - upload-artifacts
       taskRef:
@@ -438,6 +438,28 @@ spec:
         - name: source
           workspace: pipeline
           subPath: src
+
+    # link pull request details to test results
+    - name: link-pull-request-with-open-status
+      runAfter:
+        - open-pull-request
+      taskRef:
+        name: link-pull-request
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: test_result_id
+          value: "$(tasks.upload-artifacts.results.test_result_id)"
+        - name: pyxis_url
+          value: "$(tasks.set-env.results.pyxis_url)"
+        - name: pyxis_api_key_secret_name
+          value: "$(params.pyxis_api_key_secret_name)"
+        - name: pyxis_api_key_secret_key
+          value: "$(params.pyxis_api_key_secret_key)"
+        - name: pull_request_url
+          value: "$(tasks.open-pull-request.results.pr_url)"
+        - name: pull_request_status
+          value: "open"
 
   finally:
     - name: upload-pipeline-logs

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/link-pull-requst.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/link-pull-requst.yml
@@ -6,24 +6,44 @@ metadata:
 spec:
   params:
     - name: pipeline_image
+      description: A docker image of operator-pipeline-images for the steps to run in.
+
+    - name: pyxis_api_key_secret_name
+      default: default-api-secret
+      description: Kubernetes secret name that contains Pyxis API key. Valid only when external Pyxis is used.
+
+    - name: pyxis_api_key_secret_key
+      default: pyxis_api_key
+      description: The key within the Kubernetes secret that contains Pyxis API key. Valid only when external Pyxis is used.
+
     - name: pyxis_ssl_secret_name
+      default: default-api-certs
       description: Kubernetes secret name that contains the Pyxis SSL files. Valid only when internal Pyxis is used.
+
     - name: pyxis_ssl_cert_secret_key
+      default: default-ssl-cert
       description: The key within the Kubernetes secret that contains the Pyxis SSL cert. Valid only when internal Pyxis is used.
+
     - name: pyxis_ssl_key_secret_key
+      default: default-ssl-key
       description: The key within the Kubernetes secret that contains the Pyxis SSL key. Valid only when internal Pyxis is used.
+
     - name: test_result_id
       description: Identifier of preflight certification uploaded in Pyxis API.
+
     - name: pyxis_url
       description: Base URL of Pyxis container API.
+
     - name: pull_request_url
       description: URL to Github pull request with a new bundle submission.
+
     - name: pull_request_status
       description: Status of Github pull request.
   volumes:
     - name: pyxis-ssl-volume
       secret:
         secretName: "$(params.pyxis_ssl_secret_name)"
+        optional: true
   steps:
     - name: link-pull-request-details-to-test-results
       image: "$(params.pipeline_image)"
@@ -32,6 +52,12 @@ spec:
           value: /etc/pyxis-ssl-volume/$(params.pyxis_ssl_cert_secret_key)
         - name: PYXIS_KEY_PATH
           value: /etc/pyxis-ssl-volume/$(params.pyxis_ssl_key_secret_key)
+        - name: PYXIS_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: $(params.pyxis_api_key_secret_name)
+              key: $(params.pyxis_api_key_secret_key)
+              optional: true
       volumeMounts:
         - name: pyxis-ssl-volume
           readOnly: true

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/open-pr.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/open-pr.yml
@@ -77,4 +77,4 @@ spec:
 
         PR_URL=$(cat pull-request.logs | grep "Pull request URL" | sed 's/.*URL: //')
 
-        echo $PR_URL | tee $(results.pr_url.path)
+        echo -n $PR_URL | tee $(results.pr_url.path)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-artifact.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-artifact.yml
@@ -38,6 +38,8 @@ spec:
     - name: log_url
     - name: result_url
       description: URL to the Pyxis test results endpoint
+    - name: test_result_id
+      description: Test result identifier
     - name: result_spa_url
       description: URL to the Connect SPA test results page
   workspaces:
@@ -118,6 +120,7 @@ spec:
         if [ $PREFLIGHT_RESULTS_EXISTS == "true" ]; then
           echo "Preflight results already exists - skipping"
           echo "none" | tee $(results.result_url.path)
+          echo "none" | tee $(results.test_result_id.path)
           exit 0
         fi
 
@@ -136,6 +139,8 @@ spec:
 
         RESULTS_ID=$(cat preflight-results.json| jq -r "._id")
         RESULT_URL="$(params.pyxis_url)v1/projects/certification/test-results/id/$RESULTS_ID"
+
+        echo -n $RESULTS_ID | tee $(results.test_result_id.path)
 
         echo "Test result URL: "
         echo -n $RESULT_URL | tee $(results.result_url.path)


### PR DESCRIPTION
When a pull request is created in CI pipeline a next task that is added
in this commit link the PR with a test-results in Pyxis.

This feature request required to extend a link-pull-request task to
accept api keys and add it to CI pipeline.

JIRA: ISV-1630