### PR TITLE
Fix logger usage in entrypoints

### DIFF
--- a/operator-pipeline-images/operatorcert/entrypoints/bundle_dockerfile.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/bundle_dockerfile.py
@@ -7,6 +7,8 @@ import operatorcert
 from operatorcert.logger import setup_logger
 from operatorcert.utils import store_results
 
+LOGGER = logging.getLogger("operator-cert")
+
 
 class AnnotationFileNotFound(Exception):
     """
@@ -45,7 +47,7 @@ def generate_dockerfile_content(args: Any) -> str:
     Returns:
         str: Content of generated Dockerfile
     """
-    logging.debug("Generating a dockerfile...")
+    LOGGER.debug("Generating a dockerfile...")
     dockerfile_content = "FROM scratch\n\n"
 
     bundle_path = pathlib.Path(args.bundle_path)

--- a/operator-pipeline-images/operatorcert/entrypoints/pipelinerun_summary.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/pipelinerun_summary.py
@@ -31,4 +31,8 @@ def main() -> None:
     setup_logger(level=log_level, log_format="%(message)s")
     pr = PipelineRun.from_files(args.pr_path, args.trs_path)
 
-    logging.info(pr.markdown_summary(include_final_tasks=args.include_final_tasks))
+    LOGGER.info(pr.markdown_summary(include_final_tasks=args.include_final_tasks))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/operator-pipeline-images/operatorcert/utils.py
+++ b/operator-pipeline-images/operatorcert/utils.py
@@ -43,8 +43,8 @@ def store_results(results: Dict[str, str]):
     for result_name, result_value in results.items():
         if result_value is None:
             result_value = ""
-            logging.error(f"Result {result_name} is empty")
-        logging.debug(f"Storing {result_name}")
+            LOGGER.error(f"Result {result_name} is empty")
+        LOGGER.debug(f"Storing {result_name}")
         with open(result_name, "w") as result_file:
             if type(result_value) is dict:
                 json.dump(result_value, result_file)


### PR DESCRIPTION
2 scripts were using a default logger instead of the one that is used by
other scripts and pre-configured. This caused missing logs in these
scripts.

JIRA: ISV-1682