### PR TITLE
Use environment specific registry when creating image

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -365,6 +365,8 @@ spec:
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
+        - name: environment
+          value: "$(params.env)"
         - name: isv_pid
           value: "$(tasks.get-cert-project-related-data.results.isv_pid)"
         - name: repository

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/create-container-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/create-container-image.yml
@@ -6,24 +6,47 @@ metadata:
 spec:
   params:
     - name: pipeline_image
+      description: A docker image of operator-pipeline-images for the steps to run in.
+
     - name: pyxis_ssl_secret_name
-      description: Kubernetes secret name that contains the Pyxis SSL files. Valid only when internal Pyxis is used.
+      description: |
+        Kubernetes secret name that contains the Pyxis SSL files.
+        Valid only when internal Pyxis is used.
+
     - name: pyxis_ssl_cert_secret_key
-      description: The key within the Kubernetes secret that contains the Pyxis SSL cert. Valid only when internal Pyxis is used.
+      description: |
+        The key within the Kubernetes secret that contains the Pyxis SSL cert.
+        Valid only when internal Pyxis is used.
+
     - name: pyxis_ssl_key_secret_key
-      description: The key within the Kubernetes secret that contains the Pyxis SSL key. Valid only when internal Pyxis is used.
+      description: |
+        The key within the Kubernetes secret that contains the Pyxis SSL key.
+        Valid only when internal Pyxis is used.
+
     - name: pyxis_url
       default: https://pyxis.engineering.redhat.com
+
     - name: isv_pid
       description: isv_pid of the certification project from Red Hat Connect
+
     - name: repository
-      description: Repository path, including namespace, assigned to certification project from Red Hat Connect
+      description: |
+        Repository path, including namespace, assigned to certification
+        project from Red Hat Connect
+
     - name: container_digest
       description: imagestream container_digest
+
     - name: bundle_version
       description: Operator bundle version
+
     - name: is_latest
       description: If explicitly set to "true", resulting image will be tagged as "latest"
+
+    - name: environment
+      default: prod
+      description: Environment where the pipeline runs
+
   workspaces:
     - name: image-data
       description: JSON files with data about image retrieved with Skopeo and Podman
@@ -43,6 +66,8 @@ spec:
           value: $(params.pyxis_url)
         - name: ISV_PID
           value: $(params.isv_pid)
+        - name: ENVIRONMENT
+          value: $(params.environment)
         - name: REPOSITORY
           value: $(params.repository)
         - name: CONTAINER_DIGEST
@@ -62,9 +87,9 @@ spec:
 
         create-container-image \
           --pyxis-url $PYXIS_URL \
+          --environment $ENVIRONMENT \
           --isv-pid $ISV_PID \
           --repo-published "true" \
-          --registry "registry.connect.redhat.com" \
           --repository $REPOSITORY \
           --certified "true" \
           --docker-image-digest $CONTAINER_DIGEST \

--- a/operator-pipeline-images/operatorcert/entrypoints/create_container_image.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/create_container_image.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, Dict, List
 from urllib.parse import urljoin
 
-from operatorcert import pyxis
+from operatorcert import pyxis, utils
 from operatorcert.logger import setup_logger
 
 LOGGER = logging.getLogger("operator-cert")
@@ -37,9 +37,10 @@ def setup_argparser() -> Any:  # pragma: no cover
         required=True,
     )
     parser.add_argument(
-        "--registry",
-        help="Certification Project Registry",
-        default="registry.connect.redhat.com",
+        "--environment",
+        help="Environment where a tool runs",
+        choices=["prod", "stage", "dev", "qa"],
+        default="dev",
     )
     parser.add_argument(
         "--repository",
@@ -125,12 +126,13 @@ def create_container_image(
     parsed_data = prepare_parsed_data(skopeo_result)
 
     upload_url = urljoin(args.pyxis_url, f"v1/images")
+    registry = utils.get_registry_for_env(args.environment)
     container_image_payload = {
         "isv_pid": args.isv_pid,
         "repositories": [
             {
                 "published": True,
-                "registry": args.registry,
+                "registry": registry,
                 "repository": args.repository,
                 "push_date": date_now,
                 "tags": [

--- a/operator-pipeline-images/tests/entrypoints/test_create_container_image.py
+++ b/operator-pipeline-images/tests/entrypoints/test_create_container_image.py
@@ -59,7 +59,7 @@ def test_create_container_image(
     args = MagicMock()
     args.pyxis_url = "https://catalog.redhat.com/api/containers/"
     args.isv_pid = "some_isv_pid"
-    args.registry = "some_registry"
+    args.environment = "prod"
     args.repository = "some_repo"
     args.docker_image_digest = "some_digest"
     args.bundle_version = "some_version"
@@ -76,7 +76,7 @@ def test_create_container_image(
             "repositories": [
                 {
                     "published": True,
-                    "registry": "some_registry",
+                    "registry": "registry.connect.redhat.com",
                     "repository": "some_repo",
                     "push_date": "1970-10-10T10:10:10.000000+00:00",
                     "tags": [
@@ -100,7 +100,7 @@ def test_create_container_image(
 @patch("operatorcert.entrypoints.create_container_image.pyxis.post")
 @patch("operatorcert.entrypoints.create_container_image.prepare_parsed_data")
 @patch("operatorcert.entrypoints.create_container_image.datetime")
-def test_create_container_image(
+def test_create_container_image_latest(
     mock_datetime: MagicMock, mock_prepare_parsed: MagicMock, mock_post: MagicMock
 ):
     # Arrange
@@ -113,7 +113,7 @@ def test_create_container_image(
     args = MagicMock()
     args.pyxis_url = "https://catalog.redhat.com/api/containers/"
     args.isv_pid = "some_isv_pid"
-    args.registry = "some_registry"
+    args.environment = "prod"
     args.repository = "some_repo"
     args.docker_image_digest = "some_digest"
     args.bundle_version = "some_version"
@@ -131,7 +131,7 @@ def test_create_container_image(
             "repositories": [
                 {
                     "published": True,
-                    "registry": "some_registry",
+                    "registry": "registry.connect.redhat.com",
                     "repository": "some_repo",
                     "push_date": "1970-10-10T10:10:10.000000+00:00",
                     "tags": [


### PR DESCRIPTION
The create image script now uses a environment specific registry based
on pipeline argument. Each environment uses a different registry while
creating container image metadata.

JIRA: ISV-1674