### PR TITLE
Changed opm binary to official release

### DIFF
--- a/operator-pipeline-images/Dockerfile-ppc64le
+++ b/operator-pipeline-images/Dockerfile-ppc64le
@@ -41,7 +41,7 @@ RUN dnf update -y && \
 COPY operator-pipeline-images/config/krb5.conf /etc/krb5.conf
 
 # Install opm CLI for ppc64le   
-RUN curl -LO https://github.com/mayurwaghmode/operator-registry/releases/download/v1.19.5/linux-ppc64le-opm && \
+RUN curl -LO https://github.com/operator-framework/operator-registry/releases/download/v1.20.0/linux-ppc64le-opm && \
     chmod +x linux-ppc64le-opm && \
     mv linux-ppc64le-opm /usr/local/bin/opm
 


### PR DESCRIPTION
OPM v1.20.0 is released and the ppc64le binaries are now included as part of the github releases - https://github.com/operator-framework/operator-registry/releases