### PR TITLE
Fixed errors during execution of the CI pipeline on non-amd64 cluster

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
@@ -40,7 +40,7 @@ spec:
         # Copy the default credentials to the "output" workspace so they can be
         # accessed without root access in other steps.
         mkdir -p $DOCKER_CONFIG
-        chmod 775 $DOCKER_CONFIG
+        chmod 777 $DOCKER_CONFIG
         cp $HOME/.docker/config.json $DOCKER_CONFIG/config.json
         chmod 664 $DOCKER_CONFIG/config.json
 


### PR DESCRIPTION
Fixed below error on the non-amd64 cluster -
[generate-index : generate] mv: cannot move 'temp-config.json' to '/workspace/output/opm-docker-config/config.json': Permission denied