### PR TITLE
Use latest pipeline image in e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -153,6 +153,7 @@ jobs:
             --param bundle_path=operators/test-e2e-operator/0.0.7-$SHORT_SHA \
             --param env=stage \
             --param submit=false \
+            --param pipeline_image=quay.io/redhat-isv/operator-pipelines-images:${{ github.sha }} \
             --workspace name=pipeline,volumeClaimTemplateFile=templates/workspace-template.yml \
             --workspace name=kubeconfig,secret=kubeconfig \
             --workspace name=ssh-dir,secret=github-ssh-credentials \
@@ -184,6 +185,7 @@ jobs:
             --param env=stage \
             --param preflight_min_version=0.0.0 \
             --param ci_min_version=0.0.0 \
+            --param pipeline_image=quay.io/redhat-isv/operator-pipelines-images:${{ github.sha }} \
             --workspace name=repository,volumeClaimTemplateFile=templates/workspace-template-small.yml \
             --workspace name=results,volumeClaimTemplateFile=templates/workspace-template.yml \
             --workspace name=registry-credentials-all,volumeClaimTemplateFile=templates/workspace-template-small.yml \


### PR DESCRIPTION
E2E tests were using the default :released tag. This caused bugs in case
new component was introduced in the image. This change uses the latest
image with commit sha tag that is build in previous step.

JIRA: ISV-1774