### PR TITLE
[ISV-1778] Change bundle and index image format from oci to docker

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/buildah.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/buildah.yml
@@ -32,7 +32,7 @@ spec:
         registry)
       name: TLSVERIFY
       type: string
-    - default: oci
+    - default: docker
       description: The format of the built container, oci or docker
       name: FORMAT
       type: string


### PR DESCRIPTION
Quay.io recently added support for OCI images but IIB doesn't support
them yet. Prior to this, buildah was likely converting the OCI images
to docker format when pushed. This auto-conversion is no longer occurring
so IIB is now failing to process the OCI images.