### PR TITLE
[ISV-1661] Automate the import of index images using ansible

### DIFF
--- a/ansible/init-custom-env.sh
+++ b/ansible/init-custom-env.sh
@@ -57,42 +57,10 @@ execute_playbook() {
     -e "custom=true"
 }
 
-pull_parent_index() {
-  local certified_repo="registry.redhat.io/redhat/certified-operator-index"
-  local marketplace_repo="registry.redhat.io/redhat/redhat-marketplace-index"
-  local extra_args=()
-
-  if [ "$ENV" != "prod" ]; then
-      certified_repo="registry.stage.redhat.io/redhat/certified-operator-index"
-      marketplace_repo="registry.stage.redhat.io/redhat/redhat-marketplace-index"
-      extra_args+=(--insecure)
-  fi
-
-  oc project $NAMESPACE
-  # Must be run once before certifying against the certified catalog.
-  oc --request-timeout 10m import-image certified-operator-index \
-    --from=$certified_repo \
-    --reference-policy local \
-    --scheduled \
-    --confirm \
-    --all \
-    "${extra_args[@]}"
-
-  # Must be run once before certifying against the Red Hat Martketplace catalog.
-  oc --request-timeout 10m import-image redhat-marketplace-index \
-    --from=$marketplace_repo \
-    --reference-policy local \
-    --scheduled \
-    --confirm \
-    --all \
-    "${extra_args[@]}"
-}
-
 main() {
   initialize_environment
   update_token
   execute_playbook
-  pull_parent_index
 }
 
 main

--- a/ansible/inventory/group_vars/operator-pipeline-dev.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-dev.yml
@@ -8,3 +8,8 @@ operator_pipeline_image_tag: "v1.0.8"
 
 # how many of newest pipelineruns should be preserved on cleanup?
 preserve_after_cleanup: "5"
+
+# Settings for importing index imagestreams
+insecure_index_import: true
+certified_operator_index: registry.stage.redhat.io/redhat/certified-operator-index
+redhat_marketplace_index: registry.stage.redhat.io/redhat/redhat-marketplace-index

--- a/ansible/inventory/group_vars/operator-pipeline-prod.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-prod.yml
@@ -22,3 +22,7 @@ github_ssh_credentials_path: ../../vaults/prod/github-bot-ssh
 e2e_kubeconfig_path: ../../vaults/prod/kubeconfig-e2e
 
 operator_pipeline_ibm_webhook_token_local_path: ../../vaults/prod/nonprod-ibm-webhook-token
+
+# Settings for importing index imagestreams
+certified_operator_index: registry.redhat.io/redhat/certified-operator-index
+redhat_marketplace_index: registry.redhat.io/redhat/redhat-marketplace-index

--- a/ansible/inventory/group_vars/operator-pipeline-qa.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-qa.yml
@@ -8,3 +8,8 @@ operator_pipeline_image_tag: "v1.0.8"
 
 # how many of newest pipelineruns should be preserved on cleanup?
 preserve_after_cleanup: "5"
+
+# Settings for importing index imagestreams
+insecure_index_import: true
+certified_operator_index: registry.stage.redhat.io/redhat/certified-operator-index
+redhat_marketplace_index: registry.stage.redhat.io/redhat/redhat-marketplace-index

--- a/ansible/inventory/group_vars/operator-pipeline-stage.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-stage.yml
@@ -8,3 +8,8 @@ operator_pipeline_image_tag: "v1.0.8"
 
 # how many of newest pipelineruns should be preserved on cleanup?
 preserve_after_cleanup: "5"
+
+# Settings for importing index imagestreams
+insecure_index_import: true
+certified_operator_index: registry.stage.redhat.io/redhat/certified-operator-index
+redhat_marketplace_index: registry.stage.redhat.io/redhat/redhat-marketplace-index

--- a/ansible/roles/operator-pipeline/tasks/main.yml
+++ b/ansible/roles/operator-pipeline/tasks/main.yml
@@ -306,6 +306,71 @@
       data:
         token: "{{ lookup('file', operator_pipeline_ibm_webhook_token_local_path, rstrip=False) | b64encode }}"
 
+# We can't use the k8s module here because it always tries to GET the resource
+# prior to creation or patching. The ImageStreamImport API only supports POST.
+- name: Import certified-operator-index imagestream
+  tags:
+    - import-index-images
+  no_log: yes
+  uri:
+    url: "{{ ocp_host }}/apis/image.openshift.io/v1/namespaces/{{ oc_namespace }}/imagestreamimports"
+    method: POST
+    status_code: 201
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ ocp_token }}"
+    body:
+      apiVersion: image.openshift.io/v1
+      kind: ImageStreamImport
+      metadata:
+        name: certified-operator-index
+        labels:
+          app: operator-pipeline
+          suffix: "{{ suffix }}"
+          env: "{{ env }}"
+      spec:
+        import: true
+        repository:
+          from:
+            kind: DockerImage
+            name: "{{ certified_operator_index }}"
+          importPolicy:
+            insecure: "{{ insecure_index_import | default(false) }}"
+            scheduled: true
+          referencePolicy:
+            type: Local
+
+- name: Import redhat-marketplace-index imagestream
+  tags:
+    - import-index-images
+  no_log: yes
+  uri:
+    url: "{{ ocp_host }}/apis/image.openshift.io/v1/namespaces/{{ oc_namespace }}/imagestreamimports"
+    method: POST
+    status_code: 201
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ ocp_token }}"
+    body:
+      apiVersion: image.openshift.io/v1
+      kind: ImageStreamImport
+      metadata:
+        name: redhat-marketplace-index
+        labels:
+          app: operator-pipeline
+          suffix: "{{ suffix }}"
+          env: "{{ env }}"
+      spec:
+        import: true
+        repository:
+          from:
+            kind: DockerImage
+            name: "{{ redhat_marketplace_index }}"
+          importPolicy:
+            insecure: "{{ insecure_index_import | default(false) }}"
+            scheduled: true
+          referencePolicy:
+            type: Local
 
 - name: Deploy pipeline tasks
   tags:


### PR DESCRIPTION
Each deployment will now create or update the index imagestreams
including any new tags. This also supports custom environments.