### PR TITLE
Add missing arguments in signing trigger

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/webhook-community-signing-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/webhook-community-signing-trigger.yml
@@ -51,6 +51,8 @@
               - name: manifest_digest
               - name: reference
               - name: requester
+              - name: umb_client_name
+              - name: pipeline_image
             resourcetemplates:
               - apiVersion: tekton.dev/v1beta1
                 kind: PipelineRun
@@ -69,6 +71,10 @@
                       value: $(tt.params.reference)
                     - name: requester
                       value: $(tt.params.requester)
+                    - name: umb_client_name
+                      value: $(tt.params.umb_client_name)
+                    - name: pipeline_image
+                      value: $(tt.params.pipeline_image)
                   workspaces:
                     - name: pipeline
                       volumeClaimTemplate:


### PR DESCRIPTION
There were 2 missing arguments in community signing trigger. This commit
adds missing arguments and fixes a webhook.