### PR TITLE
add '' to {annotation_value}

### DIFF
--- a/operator-pipeline-images/operatorcert/entrypoints/bundle_dockerfile.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/bundle_dockerfile.py
@@ -54,7 +54,7 @@ def generate_dockerfile_content(args: Any) -> str:
     annotations = operatorcert.get_bundle_annotations(bundle_path)
 
     for annotation_key, annotation_value in annotations.items():
-        dockerfile_content += f"LABEL {annotation_key}={annotation_value}\n"
+        dockerfile_content += f"LABEL {annotation_key}='{annotation_value}'\n"
 
     dockerfile_content += "\n"
 

--- a/operator-pipeline-images/tests/entrypoints/test_bundle_dockerfile.py
+++ b/operator-pipeline-images/tests/entrypoints/test_bundle_dockerfile.py
@@ -18,5 +18,5 @@ def test_generate_dockerfile_content(
     dockerfile = generate_dockerfile_content(args)
     assert (
         dockerfile
-        == "FROM scratch\n\nLABEL operators.operatorframework.io.bundle.manifests.v1=demo1\nLABEL operators.operatorframework.io.bundle.metadata.v1=demo2\n\nCOPY demo1 /manifests/\nCOPY demo2 /metadata/\n\n"
+        == "FROM scratch\n\nLABEL operators.operatorframework.io.bundle.manifests.v1='demo1'\nLABEL operators.operatorframework.io.bundle.metadata.v1='demo2'\n\nCOPY demo1 /manifests/\nCOPY demo2 /metadata/\n\n"
     )


### PR DESCRIPTION
if there is no **''** for **{annotation_value}**, when the values has blank in annotations.yaml, the dockerflie could not used to build the bundle image, it will fail with the similar error as following:
[dockerfile-creation : generate-dockerfile] LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
[dockerfile-creation : generate-dockerfile] LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
[dockerfile-creation : generate-dockerfile] LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
[dockerfile-creation : generate-dockerfile] LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
[dockerfile-creation : generate-dockerfile] LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
[dockerfile-creation : generate-dockerfile] LABEL operators.operatorframework.io.bundle.package.v1=crunchy-postgres-operator
[dockerfile-creation : generate-dockerfile] LABEL operators.operatorframework.io.bundle.channels.v1=v5
[dockerfile-creation : generate-dockerfile] LABEL operators.operatorframework.io.bundle.channel.default.v1=v5
[dockerfile-creation : generate-dockerfile] LABEL com.redhat.delivery.operator.bundle=True
[dockerfile-creation : generate-dockerfile] LABEL com.redhat.openshift.versions=v4.6-v4.9
[dockerfile-creation : generate-dockerfile] LABEL org.opencontainers.image.authors=info@crunchydata.com
[dockerfile-creation : generate-dockerfile] LABEL org.opencontainers.image.url=https://crunchydata.com
**[dockerfile-creation : generate-dockerfile] LABEL org.opencontainers.image.vendor=Crunchy Data**
[dockerfile-creation : generate-dockerfile] 
[dockerfile-creation : generate-dockerfile] COPY manifests/ /manifests/
[dockerfile-creation : generate-dockerfile] COPY metadata/ /metadata/
[dockerfile-creation : generate-dockerfile] 
[dockerfile-creation : generate-dockerfile] Dockerfile
[build-bundle : build] + buildah --storage-driver=vfs bud --format=docker --tls-verify=true --no-cache -f ./Dockerfile -t quay.io/operator-pipeline-prod/crunchy-postgres-operator:5.0.5 operators/crunchy-postgres-operator/5.0.5
[build-bundle : build] error parsing main Dockerfile: Syntax error - can't find = in "Data". Must be of the form: name=value
[build-bundle : build] level=error msg="exit status 125"

The scenario from support case:03170896

