### PR TITLE
Add yamllint to tox

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -9,13 +9,6 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
 
 jobs:
-  yaml-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: yaml-lint
-        uses: ibiqlik/action-yamllint@v3
-
   tox:
     name: Run unit tests and linters
     runs-on: ubuntu-latest
@@ -23,5 +16,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: fedora-python/tox-github-action@v0.4
         with:
-          tox_env: black,test
+          tox_env: black,test,yamllint
           dnf_install: krb5-devel krb5-workstation

--- a/operator-pipeline-images/requirements-dev.txt
+++ b/operator-pipeline-images/requirements-dev.txt
@@ -1,3 +1,4 @@
 black
 pytest
 pytest-cov
+yamllint

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ OPERATOR_MODULE = operator-pipeline-images/operatorcert
 
 [tox]
 envlist = test,
-          black
+          black,
+          yamllint,
 skipsdist = True
 
 [testenv]
@@ -25,3 +26,11 @@ commands = black --check --diff .
 [testenv:black-format]
 deps = -r operator-pipeline-images/requirements-dev.txt
 commands = black .
+
+[testenv:yamllint]
+basepython = python3
+deps = -r operator-pipeline-images/requirements-dev.txt
+files =
+    .
+commands =
+    yamllint {[testenv:yamllint]files}


### PR DESCRIPTION
Adding yamllint to the tox run, so errors can be caught before the
github workflow.