### PR TITLE
Remove default_ccache_name from kerberos config

### DIFF
--- a/operator-pipeline-images/config/krb5.conf
+++ b/operator-pipeline-images/config/krb5.conf
@@ -8,7 +8,6 @@ dns_canonicalize_hostname = fallback
 ticket_lifetime = 24h
 forwardable = true
 udp_preference_limit = 0
-default_ccache_name = KEYRING:persistent:%{uid}
 
 [realms]
 


### PR DESCRIPTION
The custom value of default_ccache_name property in krb5.conf file
caused a errors in IIB authentication on stage. The removing the custom
value fixed the issue.

JIRA: ISV-1817