### PR TITLE
Fix index task - missing character

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-bundle.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-bundle.yml
@@ -109,7 +109,7 @@ spec:
           --iib-url "$(params.iib_url)" \
           --from-index $FROM_INDEX \
           --indices $INDICES \
-          --bundle-pullspec "$(params.bundle_pullspec)"
+          --bundle-pullspec "$(params.bundle_pullspec)" \
           --output manifest-digests.txt
 
 


### PR DESCRIPTION
There was an empty break line character in the index task.