### PR TITLE
Remove unused suffix from image tag

### DIFF
--- a/operator-pipeline-images/operatorcert/entrypoints/create_container_image.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/create_container_image.py
@@ -138,9 +138,7 @@ def create_container_image(
                 "tags": [
                     {
                         "added_date": date_now,
-                        # suffix -1 is added to indicate,
-                        # that it's non- floating tag
-                        "name": args.bundle_version + "-1",
+                        "name": args.bundle_version,
                     },
                 ],
             }

--- a/operator-pipeline-images/tests/entrypoints/test_create_container_image.py
+++ b/operator-pipeline-images/tests/entrypoints/test_create_container_image.py
@@ -82,7 +82,7 @@ def test_create_container_image(
                     "tags": [
                         {
                             "added_date": "1970-10-10T10:10:10.000000+00:00",
-                            "name": "some_version-1",
+                            "name": "some_version",
                         }
                     ],
                 }
@@ -137,7 +137,7 @@ def test_create_container_image_latest(
                     "tags": [
                         {
                             "added_date": "1970-10-10T10:10:10.000000+00:00",
-                            "name": "some_version-1",
+                            "name": "some_version",
                         },
                         {
                             "added_date": "1970-10-10T10:10:10.000000+00:00",


### PR DESCRIPTION
When creating container image in Pyxis, the script was adding
unnecessary suffix "-1". This caused inaccurate pull spec in Red Hat
catalog.

JIRA: ISV-1857