### PR TITLE
Enable signature verification on release pipeline and fix defaults

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -73,6 +73,12 @@ spec:
       description: >-
         The key within the Kubernetes Secret that contains the kerberos keytab for submitting IIB builds.
       default: krb5.keytab
+    - name: signing_pub_secret_name
+      description: The name of the Kubernetes Secret that contains the public key for verifying signatures.
+      default: signing-pub-key
+    - name: signing_pub_secret_key
+      description: The key within the Kubernetes Secret that contains the public key for verifying signatures.
+      default: sig-key.pub
   workspaces:
     - name: repository
     - name: results
@@ -469,9 +475,12 @@ spec:
           value: "$(params.pyxis_ssl_key_secret_key)"
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
-        # TODO: remove it after ISV-1798 is done
+        - name: signing_pub_secret_name
+          value: "$(params.signing_pub_secret_name)"
+        - name: signing_pub_secret_key
+          value: "$(params.signing_pub_secret_key)"
         - name: verify_signature
-          value: "false"
+          value: "true"
       workspaces:
         - name: source
           workspace: repository

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-signature.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-signature.yml
@@ -23,8 +23,10 @@ spec:
       default: "true"
     - name: signing_pub_secret_name
       description: The name of the Kubernetes Secret that contains the public key for verifying signatures.
+      default: signing-pub-key
     - name: signing_pub_secret_key
       description: The key within the Kubernetes Secret that contains the public key for verifying signatures.
+      default: sig-key.pub
   volumes:
     - name: pyxis-ssl-volume
       secret:


### PR DESCRIPTION
For signature verification to be truly optional, the 2 pub key
related params needed to have default values.

This PR was mostly to fix the release pipeline failure for not passing in signing_pub_secret_name and signing_pub_secret_key, but might as well turn on the verification now that it's supported.