### PR TITLE
updating the CI pipeline to add in `-bundle` to the bundleImage variable

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -284,7 +284,9 @@ spec:
         kind: Task
       params:
         - name: IMAGE
-          value: &bundleImage "$(params.registry)/$(params.image_namespace)/$(tasks.bundle-path-validation.results.package_name):$(tasks.bundle-path-validation.results.bundle_version)"
+          # adding in `-bundles` to the bundleImage path to support users that use quay for their operator image,
+          # otherwise this would overwrite their operator image
+          value: &bundleImage "$(params.registry)/$(params.image_namespace)/$(tasks.bundle-path-validation.results.package_name)-bundle:$(tasks.bundle-path-validation.results.bundle_version)"
         - name: CONTEXT
           value: "$(params.bundle_path)"
       workspaces:


### PR DESCRIPTION
### Motivation
If a partner already has their operator hosted in quay, and then passes in arguments to tekton to use quay as the registry, instead of the registry in the cluster, the ci-pipeline overwrites their controller image. 

This PR addresses that by adding `-bundle` to the `build-bundle` just like `operator-sdk` would add if running manually and how the `build-index` in this `ci-pipeline` works by adding `-index`.