### PR TITLE
Temporarily add redhat-marketplace-index support to community signing

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/verify-whitelisted-index-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/verify-whitelisted-index-image.yml
@@ -13,7 +13,9 @@ spec:
         #! /usr/bin/env bash
         INDEX_IMAGE="$(cut -d':' -f1 <<< '$(params.reference)')"
         echo $INDEX_IMAGE
-        if [ $INDEX_IMAGE == "registry.redhat.io/redhat/community-operator-index" ]; then
+        if [[ $INDEX_IMAGE == "registry.redhat.io/redhat/community-operator-index" ||
+              $INDEX_IMAGE == "registry.redhat.io/redhat/redhat-marketplace-index" ||
+              $INDEX_IMAGE == "registry.redhat.io/redhat/certified-operator-index" ]]; then
           echo "The index image is white listed."
         else
           echo "The index image is not white listed."


### PR DESCRIPTION
This is to make the manual signing workaround easier for
redhat-marketplace-index images, since there's a gap in the signing
support for republished bundles.