### PR TITLE
Hardcoded images as parameters

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/commit-pinned-digest.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/commit-pinned-digest.yml
@@ -23,6 +23,9 @@ spec:
         Binding a Secret to this Workspace is strongly recommended over other
         volume types.
   params:
+    - name: gitInitImage
+      description: Git init image
+      default: "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9"
     - name: dirty_flag
     - name: git_branch
     - name: verbose
@@ -51,7 +54,7 @@ spec:
     - name: branch
   steps:
     - name: commit-changes
-      image: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
+      image: "$(params.gitInitImage)"
       workingDir: $(workspaces.source.path)
       env:
         - name: CURRENT_BRANCH

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/copy-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/copy-image.yml
@@ -5,6 +5,9 @@ metadata:
   name: copy-image
 spec:
   params:
+    - name: skopeo_image
+      description: Skopeo image
+      default: "registry.redhat.io/rhel8/skopeo:8.4-13"
     - name: src_image
       description: reference to the source bundle image
     - name: dest_image
@@ -16,7 +19,7 @@ spec:
       description: Docker config for the destination registry
   steps:
     - name: skopeo-copy
-      image: registry.redhat.io/rhel8/skopeo:8.4-13
+      image: "$(params.skopeo_image)"
       script: |
         set -xe
 

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
@@ -9,6 +9,9 @@ spec:
     - name: enabled
       default: "true"
     - name: pipeline_image
+    - name: digest_pinning_tool_image
+      description: Digest pinning tool image
+      default: "quay.io/redhat-isv/digest-pinning-tool@sha256:7e9dd84000e597e5591d94e791e7c0be1f1efe7e60ab915b200c5c0dff2fa6ba"
   results:
     - name: dirty_flag
     - name: related_images_flag
@@ -38,7 +41,7 @@ spec:
             > "$REGISTRY_AUTH_FILE"
         fi
     - name: pin-digest
-      image: quay.io/redhat-isv/digest-pinning-tool@sha256:7e9dd84000e597e5591d94e791e7c0be1f1efe7e60ab915b200c5c0dff2fa6ba
+      image: "$(params.digest_pinning_tool_image)"
       workingDir: $(workspaces.source.path)
       script: |
         #! /usr/bin/env bash

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
@@ -6,6 +6,9 @@ metadata:
 spec:
   params:
     - name: pipeline_image
+    - name: podman_image
+      description: Podman image
+      default: "registry.redhat.io/rhel8/podman:8.5-13"
     - name: bundle_image
       description: Pull spec of a bundle image
     - name: from_index
@@ -31,7 +34,7 @@ spec:
         value: fbc.txt
   steps:
     - name: inspect-base-index
-      image: registry.redhat.io/rhel8/podman:8.5-13
+      image: "$(params.podman_image)"
       workingDir: $(workspaces.output.path)
       script: |
         #! /usr/bin/env bash

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/get-bundle-path.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/get-bundle-path.yml
@@ -5,12 +5,15 @@ metadata:
   name: get-bundle-path
 spec:
   params:
+    - name: ubi8_minimal_image
+      description: ubi8 minimal image
+      default: "registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe"
     - name: git_pr_title
   results:
     - name: bundle_path
   steps:
     - name: get-bundle-path
-      image: registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe
+      image: "$(params.ubi8_minimal_image)"
       env:
         - name: PR_TITLE
           value: $(params.git_pr_title)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
@@ -11,6 +11,9 @@ spec:
       description: Scratch space and storage for the comment
 
   params:
+    - name: pipelines_cli_tkn_image
+      description: Teknton cli image
+      default: "registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:cc8bbdb079578605a66447529d7de76f32882dc2ada571e39ff18e483cdbdf49"
     - name: github_host_url
       description: |
         The GitHub host, adjust this if you run a GitHub enteprise.
@@ -44,7 +47,7 @@ spec:
   steps:
     - name: gather-info
       workingDir: $(workspaces.output.path)
-      image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:cc8bbdb079578605a66447529d7de76f32882dc2ada571e39ff18e483cdbdf49
+      image: "$(params.pipelines_cli_tkn_image)"
       script: |
         #! /usr/bin/env bash
         set -xe

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/inspect-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/inspect-image.yml
@@ -5,6 +5,12 @@ metadata:
   name: inspect-image
 spec:
   params:
+    - name: skopeo_image
+      description: Skopeo image
+      default: "registry.redhat.io/rhel8/skopeo:8.4-13"
+    - name: podman_image
+      description: Podman image
+      default: "registry.redhat.io/rhel8/podman:8.4-14"
     - name: image
       description: reference to the existing bundle image
     - name: registry
@@ -16,7 +22,7 @@ spec:
       description: Workspace to store the large json files with the image data
   steps:
     - name: skopeo-inspect
-      image: registry.redhat.io/rhel8/skopeo:8.4-13
+      image: "$(params.skopeo_image)"
       script: |
         set -xe
 
@@ -24,7 +30,7 @@ spec:
 
         skopeo inspect docker://$(params.image) > $(workspaces.image-data.path)/skopeo.json
     - name: podman-inspect
-      image: registry.redhat.io/rhel8/podman:8.4-14
+      image: "$(params.podman_image)"
       script: |
         set -xe
 

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
@@ -6,6 +6,9 @@ metadata:
 spec:
   params:
     - name: pipeline_image
+    - name: ubi8_minimal_image
+      description: ubi8 minimal image
+      default: "registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe"
     - name: git_pr_url
     - name: bundle_path
     - name: github_token_secret_name
@@ -31,7 +34,7 @@ spec:
         echo -n "$BOOL_MERGE" | tee $(results.bool_merge.path)
 
     - name: review-pull-request
-      image: registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe
+      image: "$(params.ubi8_minimal_image)"
       env:
         - name: GITHUB_BOT_TOKEN
           valueFrom:
@@ -62,7 +65,7 @@ spec:
         echo "Merge request has been approved!"
 
     - name: merge-pull-request
-      image: registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe
+      image: "$(params.ubi8_minimal_image)"
       env:
         - name: GITHUB_BOT_TOKEN
           valueFrom:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
@@ -4,6 +4,15 @@ metadata:
   name: preflight-trigger
 spec:
   params:
+    - name: fedora_image
+      description: Fedora image
+      default: "docker.io/library/fedora"
+    - name: go_toolset_image
+      description: GO toolset image
+      default: "registry.access.redhat.com/ubi8/go-toolset"
+    - name: preflight_trigger_image
+      description: Preflight trigger image
+      default: "quay.io/opdev/preflight-trigger"
     - default: '4.9'
       name: ocp_version
       type: string
@@ -50,7 +59,7 @@ spec:
           value: /etc/gpg-key/$(params.gpg_decryption_private_key_secret_key)
         - name: PIPELINE_GPG_DECRYPTION_PUBLIC_KEY
           value: /etc/gpg-key/$(params.gpg_decryption_public_key_secret_key)
-      image: docker.io/library/fedora
+      image: "$(params.fedora_image)"
       name: encrypt-and-encode-docker-config-json
       resources: {}
       volumeMounts:
@@ -78,7 +87,7 @@ spec:
               gpg --encrypt --sign --armor -r "$(gpg --list-keys|grep -B1 'Preflight Trigger'|awk 'NR==1 { print }'|tr -d '[:space:]')" -o- "$(workspaces.credentials.path)/project_dockerconfigjson" | basenc --base16 -w0 > "$(workspaces.credentials.path)/project_dockerconfigjson.gpg.b16"
           fi
       workingDir: $(workspaces.output.path)
-    - image: registry.access.redhat.com/ubi8/go-toolset
+    - image: "$(params.go_toolset_image)"
       name: clone-openshift-release-for-configs
       resources: {}
       script: |
@@ -95,7 +104,7 @@ spec:
     - env:
         - name: KUBECONFIG
           value: /etc/kubeconfig-volume/$(params.prow_kubeconfig_secret_key)
-      image: quay.io/opdev/preflight-trigger
+      image: "$(params.preflight_trigger_image)"
       name: create-openshift-ci-prowjob
       resources: {}
       volumeMounts:
@@ -163,7 +172,7 @@ spec:
           value: /etc/gpg-key/$(params.gpg_decryption_private_key_secret_key)
         - name: PIPELINE_GPG_DECRYPTION_PUBLIC_KEY
           value: /etc/gpg-key/$(params.gpg_decryption_public_key_secret_key)
-      image: docker.io/library/fedora
+      image: "$(params.fedora_image)"
       name: get-prowjob-artifacts-and-decrypt
       resources: {}
       volumeMounts:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-ocp-registry.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-ocp-registry.yml
@@ -5,6 +5,9 @@ metadata:
   name: publish-to-ocp-registry
 spec:
   params:
+    - name: ose_cli_image
+      description: OSE cli image
+      default: "registry.redhat.io/openshift4/ose-cli@sha256:eed7052f0013b85087cd9fa8e4b328f56a027846107d32a65daeb3a50cf23b49"
     - name: cert_project_id
       description: ID of the bundle Certification Project (as in bundle ci.yaml)
     - name: vendor_label
@@ -35,7 +38,7 @@ spec:
         secretName: "$(params.ocp_registry_kubeconfig_secret_name)"
   steps:
     - name: imagestream-manipulations
-      image: registry.redhat.io/openshift4/ose-cli@sha256:eed7052f0013b85087cd9fa8e4b328f56a027846107d32a65daeb3a50cf23b49
+      image: "$(params.ose_cli_image)"
       volumeMounts:
         - name: kubeconfig-volume
           readOnly: true

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env.yml
@@ -5,6 +5,9 @@ metadata:
   name: set-env
 spec:
   params:
+    - name: ubi8_minimal_image
+      description: ubi8 minimal image
+      default: "registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe"
     - name: env
       description: Environment. One of [dev, qa, stage, prod]
     - name: access_type
@@ -30,7 +33,7 @@ spec:
       description: Client name to connect to umb, usually a service account name
   steps:
     - name: set-env
-      image: registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe
+      image: "$(params.ubi8_minimal_image)"
       script: |
         #! /usr/bin/env bash
         set -ex

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/update-metrics.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/update-metrics.yml
@@ -12,18 +12,20 @@ spec:
       description: Scratch space and storage for the metrics
 
   params:
+    - name: ubi8_minimal_image
+      description: ubi8 minimal image
+      default: "registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe"
     - name: metrics_url
       description: |
         A metrics collector route.
       default: "http://pipeline-metrics.pipeline-metrics-prod"
-
     - name: pipelinerun
       description: The name of the PipelineRun to summarize.
 
   steps:
     - name: gather-info
       workingDir: $(workspaces.output.path)
-      image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:cc8bbdb079578605a66447529d7de76f32882dc2ada571e39ff18e483cdbdf49
+      image: "$(params.ubi8_minimal_image)"
       script: |
         #! /usr/bin/env bash
         set -xe
@@ -38,7 +40,7 @@ spec:
 
     - name: submit-metrics
       workingDir: $(workspaces.output.path)
-      image: registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe
+      image: "$(params.ubi8_minimal_image)"
       script: |
         #! /usr/bin/env bash
         set -xe

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
@@ -6,6 +6,9 @@ metadata:
 spec:
   params:
     - name: pipeline_image
+    - name: pipelines_cli_tkn_image
+      description: Teknton cli image
+      default: "registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:cc8bbdb079578605a66447529d7de76f32882dc2ada571e39ff18e483cdbdf49"
     - name: pyxis_api_key_secret_name
       default: default-api-secret
       description: Kubernetes secret name that contains Pyxis API key. Valid only when external Pyxis is used.
@@ -50,7 +53,7 @@ spec:
         optional: true
   steps:
     - name: get-pipeline-logs
-      image: registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8@sha256:cc8bbdb079578605a66447529d7de76f32882dc2ada571e39ff18e483cdbdf49
+      image: "$params.pipelines_cli_tkn_image)"
       script: |
         #! /usr/bin/env bash
         set -xe

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/verify-pinned-digest.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/verify-pinned-digest.yml
@@ -5,11 +5,14 @@ metadata:
   name: verify-pinned-digest
 spec:
   params:
+    - name: ubi8_minimal_image
+      description: ubi8 minimal image
+      default: "registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe"
     - name: dirty_flag
     - name: related_images_flag
   steps:
     - name: check-dirty-flag
-      image: registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe
+      image: "$(params.ubi8_minimal_image)"
       script: |
         #! /usr/bin/env bash
         DIRTY_FLAG="$(params.dirty_flag)"
@@ -19,7 +22,7 @@ spec:
           exit 1
         fi
     - name: check-related-images
-      image: registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe
+      image: "$(params.ubi8_minimal_image)"
       script: |
         #! /usr/bin/env bash
         RELATED_IMAGES_FLAG="$(params.related_images_flag)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/verify-whitelisted-index-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/verify-whitelisted-index-image.yml
@@ -5,10 +5,13 @@ metadata:
   name: verify-whitelisted-index-image
 spec:
   params:
+    - name: ubi8_minimal_image
+      description: ubi8 minimal image
+      default: "registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe"
     - name: reference
   steps:
     - name: check-index-image
-      image: registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe
+      image: "$(params.ubi8_minimal_image)"
       script: |
         #! /usr/bin/env bash
         INDEX_IMAGE="$(cut -d':' -f1 <<< '$(params.reference)')"


### PR DESCRIPTION
Existing parameters
- gitInitImage in commit-pinned-digests.yaml

New parameters
- skopeo_image
- digest_pinning_tool_image
- podman_image
- ubi8_minimal_image
- fedora_image
- go_toolset_image
- preflight_trigger_image
- ose_cli_image
- pipelines_cli_tkn_image

Signed-off-by: Martin Vala <mavala@redhat.com>