### PR TITLE
fix missing ( in variable name for image in upload-pipeline-logs.yml

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/upload-pipeline-logs.yml
@@ -53,7 +53,7 @@ spec:
         optional: true
   steps:
     - name: get-pipeline-logs
-      image: "$params.pipelines_cli_tkn_image)"
+      image: "$(params.pipelines_cli_tkn_image)"
       script: |
         #! /usr/bin/env bash
         set -xe


### PR DESCRIPTION
- Fixing a bug that was introduced with image refactor to `default`

Signed-off-by: Adam D. Cornett <adc@redhat.com>