### PR TITLE
updating preflight task to use preflight v1.3.2

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:fba6919bfb5c647877453dd948b1e7d3394c4573482e3776ae9a85abd70f912e
+      default: quay.io/redhat-isv/preflight-test@sha256:10ae11bd3f40b9507175eb6ff0e9206079a67dfcb27d1a22c8db8b4e06a5b648
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
- Bumping the preflight task to use the latest preflight image

Signed-off-by: Adam D. Cornett <adc@redhat.com>