### PR TITLE
Update preflight to 1.3.3

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:10ae11bd3f40b9507175eb6ff0e9206079a67dfcb27d1a22c8db8b4e06a5b648
+      default: quay.io/redhat-isv/preflight-test@sha256:6670809cbe8de9495325cbae12d565388b772c6773d6537fad74e7202c2b2403
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
Update preflight from 1.3.2. to 1.3.3 with changelog:

- Fallback to cli tag in container HasUniqueTag test by @jsm84 in https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/702
- Wait for layer file processing to complete before proceeding by @komish in https://github.com/redhat-openshift-ecosystem/openshift-preflight/pull/735


Confirming digests:
```
$ skopeo inspect --override-os linux docker://quay.io/redhat-isv/preflight-test:1.3.3 | jq .Digest -r
sha256:6670809cbe8de9495325cbae12d565388b772c6773d6537fad74e7202c2b2403

$ skopeo inspect --override-os linux docker://quay.io/opdev/preflight:1.3.3 | jq .Digest -r
sha256:6670809cbe8de9495325cbae12d565388b772c6773d6537fad74e7202c2b2403
```

Signed-off-by: Jose R. Gonzalez <jose@flutes.dev>