### PR TITLE
[ISV-2499] The CI pipeline doesn't support OCP 4.11

### DIFF
--- a/ansible/init-custom-env.sh
+++ b/ansible/init-custom-env.sh
@@ -45,7 +45,7 @@ update_token() {
     # because of the changes in the SA token API in k8s 1.24.
     local token=$(oc --namespace $NAMESPACE get secret \
         -o custom-columns=NAME:.metadata.name,TYPE:.type,TOKEN:.data.token \
-        | awk '$2=="kubernetes.io/service-account-token" && $1~/^operator-pipeline-admin-token/ {print $3}' \
+        | awk '$2=="kubernetes.io/service-account-token" && $1~/^operator-pipeline-admin-token/ {print $3; exit}' \
         | base64 -d)
 
     echo "ocp_token: $token" > $SECRET

--- a/ansible/init-custom-env.sh
+++ b/ansible/init-custom-env.sh
@@ -41,7 +41,12 @@ initialize_environment() {
 
 # Get the token of created service account and make it available for further steps
 update_token() {
-    local token=$(oc --namespace $NAMESPACE serviceaccounts get-token operator-pipeline-admin)
+    # In openshift 4.11 we don't have `oc serviceaccount get-token` anymore
+    # because of the changes in the SA token API in k8s 1.24.
+    local token=$(oc --namespace $NAMESPACE get secret \
+        -o custom-columns=NAME:.metadata.name,TYPE:.type,TOKEN:.data.token \
+        | awk '$2=="kubernetes.io/service-account-token" && $1~/^operator-pipeline-admin-token/ {print $3}' \
+        | base64 -d)
 
     echo "ocp_token: $token" > $SECRET
     ansible-vault encrypt $SECRET --vault-password-file $PASSWD_FILE > /dev/null

--- a/ansible/init.sh
+++ b/ansible/init.sh
@@ -46,7 +46,7 @@ update_token() {
     # because of the changes in the SA token API in k8s 1.24.
     local token=$(oc --namespace operator-pipeline-$1 get secret \
         -o custom-columns=NAME:.metadata.name,TYPE:.type,TOKEN:.data.token \
-        | awk '$2=="kubernetes.io/service-account-token" && $1~/^operator-pipeline-admin-token/ {print $3}' \
+        | awk '$2=="kubernetes.io/service-account-token" && $1~/^operator-pipeline-admin-token/ {print $3; exit}' \
         | base64 -d)
 
     local secret=$(dirname "$0")/vaults/$env/secret-vars.yml

--- a/ansible/init.sh
+++ b/ansible/init.sh
@@ -42,7 +42,13 @@ execute_playbook() {
 
 # update token for given environment
 update_token() {
-    local token=$(oc --namespace operator-pipeline-$1 serviceaccounts get-token operator-pipeline-admin)
+    # In openshift 4.11 we don't have `oc serviceaccount get-token` anymore
+    # because of the changes in the SA token API in k8s 1.24.
+    local token=$(oc --namespace operator-pipeline-$1 get secret \
+        -o custom-columns=NAME:.metadata.name,TYPE:.type,TOKEN:.data.token \
+        | awk '$2=="kubernetes.io/service-account-token" && $1~/^operator-pipeline-admin-token/ {print $3}' \
+        | base64 -d)
+
     local secret=$(dirname "$0")/vaults/$env/secret-vars.yml
 
     echo "ocp_token: $token" > $secret

--- a/ansible/roles/operator-pipeline/tasks/main.yml
+++ b/ansible/roles/operator-pipeline/tasks/main.yml
@@ -41,6 +41,7 @@
   uri:
     url: "{{ ocp_host }}/apis/image.openshift.io/v1/namespaces/{{ oc_namespace }}/imagestreamimports"
     method: POST
+    validate_certs: "{{ lookup('env', 'K8S_AUTH_VERIFY_SSL', default='yes') }}"
     status_code: 201
     body_format: json
     headers:
@@ -73,6 +74,7 @@
   uri:
     url: "{{ ocp_host }}/apis/image.openshift.io/v1/namespaces/{{ oc_namespace }}/imagestreamimports"
     method: POST
+    validate_certs: "{{ lookup('env', 'K8S_AUTH_VERIFY_SSL', default='yes') }}"
     status_code: 201
     body_format: json
     headers:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/buildah.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/buildah.yml
@@ -54,6 +54,7 @@ spec:
       script: |
         # This is needed to ensure the push step, which runs under a different
         # UID, has access to its output file
+        chmod go+rx $(workspaces.source.path)
         truncate -s 0 /digest/image-digest
         chmod 666 /digest/image-digest
       workingDir: $(workspaces.source.path)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/buildah.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/buildah.yml
@@ -49,19 +49,36 @@ spec:
       name: IMAGE_DIGEST
   steps:
     - image: $(params.BUILDER_IMAGE)
-      name: build
+      name: prepare
       resources: {}
       script: |
+        # This is needed to ensure the push step, which runs under a different
+        # UID, has access to its output file
+        truncate -s 0 /digest/image-digest
+        chmod 666 /digest/image-digest
+      workingDir: $(workspaces.source.path)
+      volumeMounts:
+        - mountPath: /digest
+          name: digest
+    - image: $(params.BUILDER_IMAGE)
+      name: build
+      securityContext:
+        runAsUser: 1000
+      resources: {}
+      script: |
+        echo "Building $(params.IMAGE)"
         buildah --storage-driver=$(params.STORAGE_DRIVER) bud \
           $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
           --tls-verify=$(params.TLSVERIFY) --no-cache \
           -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
       volumeMounts:
-        - mountPath: /var/lib/containers
+        - mountPath: /home/build/.local/share/containers
           name: varlibcontainers
       workingDir: $(workspaces.source.path)
     - image: $(params.BUILDER_IMAGE)
       name: push
+      securityContext:
+        runAsUser: 1000
       resources: {}
       # Added authfile argument to support private registries
       script: |
@@ -70,21 +87,29 @@ spec:
           EXTRA_ARGS+=" --authfile $(workspaces.credentials.path)/.dockerconfigjson"
         fi
 
+        echo "Pushing $(params.IMAGE)"
         buildah --storage-driver=$(params.STORAGE_DRIVER) push \
           $(params.PUSH_EXTRA_ARGS) $EXTRA_ARGS --tls-verify=$(params.TLSVERIFY) \
-          --digestfile $(workspaces.source.path)/image-digest $(params.IMAGE) \
+          --digestfile /digest/image-digest $(params.IMAGE) \
           docker://$(params.IMAGE)
       volumeMounts:
-        - mountPath: /var/lib/containers
+        - mountPath: /home/build/.local/share/containers
           name: varlibcontainers
+        - mountPath: /digest
+          name: digest
       workingDir: $(workspaces.source.path)
     - image: $(params.BUILDER_IMAGE)
       name: digest-to-results
       resources: {}
-      script: cat $(workspaces.source.path)/image-digest | tee /tekton/results/IMAGE_DIGEST
+      script: cat /digest/image-digest | tee /tekton/results/IMAGE_DIGEST
+      volumeMounts:
+        - mountPath: /digest
+          name: digest
   volumes:
     - emptyDir: {}
       name: varlibcontainers
+    - emptyDir: {}
+      name: digest
   workspaces:
     - name: source
     - name: credentials

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/check-ocp-cluster-version.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/check-ocp-cluster-version.yml
@@ -32,7 +32,7 @@ spec:
         # Grab only the major and minor version for comparison
         CLUSTER_VERSION=$(echo $CLUSTER_VERSION | cut -d. -f1,2)
         # parse indices into a list of strings with OCP versions
-        SUPPORTED_VERSIONS=$(echo '$(params.indices_ocp_versions)' | jq -r '.[]')
+        SUPPORTED_VERSIONS=$(echo '$(params.indices_ocp_versions)' | base64 -d | jq -r '.[]')
 
         for version in $SUPPORTED_VERSIONS; do
           if [ "$version" == "$CLUSTER_VERSION" ]; then

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
@@ -47,6 +47,7 @@ spec:
         chmod 755 $DOCKER_CONFIG
         cp $HOME/.docker/config.json $DOCKER_CONFIG/config.json
         chmod 644 $DOCKER_CONFIG/config.json
+        chmod go+rx .
 
     - name: inspect-base-index
       image: "$(params.podman_image)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
@@ -33,19 +33,29 @@ spec:
       - name: FBC_FILE
         value: fbc.txt
   steps:
-    - name: inspect-base-index
+    - name: prepare
       image: "$(params.podman_image)"
       workingDir: $(workspaces.output.path)
       script: |
         #! /usr/bin/env bash
-        set -exo pipefail
+        # This is needed to ensure the inspect-base-index step, which runs
+        # under a different UID, has access to its output file
+        truncate -s 0 podman-inspect.json
+        chmod 666 podman-inspect.json
 
-        # Copy the default credentials to the "output" workspace so they can be
-        # accessed without root access in other steps.
         mkdir -p $DOCKER_CONFIG
-        chmod 777 $DOCKER_CONFIG
+        chmod 755 $DOCKER_CONFIG
         cp $HOME/.docker/config.json $DOCKER_CONFIG/config.json
-        chmod 664 $DOCKER_CONFIG/config.json
+        chmod 644 $DOCKER_CONFIG/config.json
+
+    - name: inspect-base-index
+      image: "$(params.podman_image)"
+      workingDir: $(workspaces.output.path)
+      securityContext:
+        runAsUser: 1000
+      script: |
+        #! /usr/bin/env bash
+        set -exo pipefail
 
         # Pull the index image from a pre-configured imagestream in the current namespace.
         # It may be possible to eliminate this once sqlite-based index images are no
@@ -54,7 +64,7 @@ spec:
         FROM_INDEX="$(params.internal_registry)/$(context.taskRun.namespace)/$INDEX_IMG_STREAM"
 
         podman pull $FROM_INDEX
-        podman image inspect $FROM_INDEX | tee podman-inspect.json
+        podman image inspect $FROM_INDEX | tee -a podman-inspect.json
 
     - name: determine-index-format
       image: "$(params.pipeline_image)"
@@ -63,6 +73,7 @@ spec:
         #! /usr/bin/env bash
         set -x
 
+        chmod 644 podman-inspect.json
         # Create a special file in the workspace if this index uses file-based configs
         CONFIGS_QUERY='.[0].Labels."operators.operatorframework.io.index.configs.v1"'
         jq -e "$CONFIGS_QUERY" podman-inspect.json && touch $FBC_FILE

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/get-supported-versions.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/get-supported-versions.yml
@@ -9,14 +9,18 @@ spec:
     - name: bundle_path
       description: path indicating the location of the certified bundle within the repository
   results:
+    # NOTE: as a workaround for https://github.com/tektoncd/pipeline/issues/5414
+    # that affects recent versions of Tekton Pipelines, including the version
+    # shipped with Openshift Pipelines 1.8, all results containing JSON payload
+    # have been changed to be base64 encoded
     - name: max_supported_ocp_version
       description: Maximum version of OpenShift supported by this Operator
     - name: max_supported_index
       description: Pull spec for the index corresponding to the max OCP version
     - name: indices
-      description: All known supported OCP indices paths
+      description: All known supported OCP indices paths (base64 encoded, see NOTE)
     - name: indices_ocp_versions
-      description: All known supported OCP indices' OCP versions
+      description: All known supported OCP indices' OCP version (base64 encoded, see NOTE)s
     - name: max_version_indices
       description: Latest known supported OCP indices
     - name: ocp_version

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/get-supported-versions.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/get-supported-versions.yml
@@ -48,11 +48,13 @@ spec:
         echo $VERSION_INFO \
           | jq -r '[.indices[].path]' \
           | tr -d '\n\r' \
+          | base64 \
           | tee $(results.indices.path)
 
         echo $VERSION_INFO \
           | jq -r '[.indices[].ocp_version]' \
           | tr -d '\n\r' \
+          | base64 \
           | tee $(results.indices_ocp_versions.path)
 
         echo $VERSION_INFO \


### PR DESCRIPTION
- Workaround a Tekton bug affecting the Openshift Pipeline Operator 1.8 where a task output containing valid json is not propagated correctly
- Ensure that task steps involving podman or buildah run as non-root to support the new SCCs in OCP 4.11