### PR TITLE
[ISV-2116] Increment minor version for integration test bundle

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,7 +51,7 @@ jobs:
           options: |
             -i inventory/operator-pipeline-integration-tests
             -e "oc_namespace=integration-tests-${{ github.run_number }}-${{ github.run_attempt }}"
-            -e "operator_bundle_version=0.0.${{ github.run_number }}-${{ github.run_attempt }}"
+            -e "operator_bundle_version=0.1.${{ github.run_number }}-${{ github.run_attempt }}"
             -e "operator_pipeline_image_tag=${{ github.sha }}"
             -e "suffix=${{ steps.prepare.outputs.suffix }}"
             -v


### PR DESCRIPTION
This is a fix for the new integration workflow which is failing to generate index images. The version was reset to 0.0.1-1 with the recent workflow changes but there are higher ordered semvers for this package already available in the index.