### PR TITLE
Update release pipeline to support workaround for tekton bug

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-bundle.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-bundle.yml
@@ -99,7 +99,10 @@ spec:
             ;;
         esac
 
-        INDICES="$(echo $(params.bundle_versions) | tr -d '[,]')"
+        # The base64 step here is part of the workaround for
+        # https://github.com/tektoncd/pipeline/issues/5414 affecting new tekton
+        # pipelines versions (Openshift Pipelines Operator v1.8)
+        INDICES="$(echo $(params.bundle_versions) | base64 -d | tr -d '[,]')"
 
         # DO NOT use `--verbose` to avoid auth headers appearing in logs
         index \


### PR DESCRIPTION
The changes introduced in https://github.com/redhat-openshift-ecosystem/operator-pipelines/pull/337 to workaround the tekton bug affecting the Openshift Pipeline Operator v1.8 require this change to ensure the release pipeline will continue to work.
