### PR TITLE
Fix variable substitution

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/check-ocp-cluster-version.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/check-ocp-cluster-version.yml
@@ -32,7 +32,11 @@ spec:
         # Grab only the major and minor version for comparison
         CLUSTER_VERSION=$(echo $CLUSTER_VERSION | cut -d. -f1,2)
         # parse indices into a list of strings with OCP versions
-        SUPPORTED_VERSIONS=$(echo '$(params.indices_ocp_versions)' | base64 -d | jq -r '.[]')
+        # The base64 step here is part of the workaround for
+        # https://github.com/tektoncd/pipeline/issues/5414 affecting new tekton
+        # pipelines versions (Openshift Pipelines Operator v1.8)
+        raw_indices_ocp_versions=$(echo '$(params.indices_ocp_versions)' | base64 -d)
+        SUPPORTED_VERSIONS=$(echo "$raw_indices_ocp_versions" | jq -r '.[]')
 
         for version in $SUPPORTED_VERSIONS; do
           if [ "$version" == "$CLUSTER_VERSION" ]; then

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/check-ocp-cluster-version.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/check-ocp-cluster-version.yml
@@ -35,8 +35,8 @@ spec:
         # The base64 step here is part of the workaround for
         # https://github.com/tektoncd/pipeline/issues/5414 affecting new tekton
         # pipelines versions (Openshift Pipelines Operator v1.8)
-        raw_indices_ocp_versions=$(echo '$(params.indices_ocp_versions)' | base64 -d)
-        SUPPORTED_VERSIONS=$(echo "$raw_indices_ocp_versions" | jq -r '.[]')
+        RAW_INDICES_OCP_VERSIONS=$(echo '$(params.indices_ocp_versions)' | base64 -d)
+        SUPPORTED_VERSIONS=$(echo "$RAW_INDICES_OCP_VERSIONS" | jq -r '.[]')
 
         for version in $SUPPORTED_VERSIONS; do
           if [ "$version" == "$CLUSTER_VERSION" ]; then

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-bundle.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-bundle.yml
@@ -102,8 +102,8 @@ spec:
         # The base64 step here is part of the workaround for
         # https://github.com/tektoncd/pipeline/issues/5414 affecting new tekton
         # pipelines versions (Openshift Pipelines Operator v1.8)
-        raw_bundle_versions=$(echo '$(params.bundle_versions)' | base64 -d)
-        INDICES="$(echo "$raw_bundle_versions" | tr -d '[,]')"
+        RAW_BUNDLE_VERSIONS=$(echo '$(params.bundle_versions)' | base64 -d)
+        INDICES="$(echo "$RAW_BUNDLE_VERSIONS" | tr -d '[,]')"
 
         # DO NOT use `--verbose` to avoid auth headers appearing in logs
         index \

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-bundle.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-bundle.yml
@@ -102,7 +102,8 @@ spec:
         # The base64 step here is part of the workaround for
         # https://github.com/tektoncd/pipeline/issues/5414 affecting new tekton
         # pipelines versions (Openshift Pipelines Operator v1.8)
-        INDICES="$(echo $(params.bundle_versions) | base64 -d | tr -d '[,]')"
+        raw_bundle_versions=$(echo '$(params.bundle_versions)' | base64 -d)
+        INDICES="$(echo "$raw_bundle_versions" | tr -d '[,]')"
 
         # DO NOT use `--verbose` to avoid auth headers appearing in logs
         index \


### PR DESCRIPTION
Tekton variable substitution is interfering with shell variable substitution. This should fix the syntax errors happening in stage after the tekton bug workaround was introduced.