### PR TITLE
[ISV-2597] Tweak the Tekton global and namespace pruner settings

### DIFF
--- a/ansible/inventory/group_vars/operator-pipeline-prod.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-prod.yml
@@ -19,6 +19,8 @@ operator_pipeline_preflight_decryption_key_public_local_path: ../../vaults/prod/
 
 pipelines_metrics_endpoint: http://pipeline-metrics.pipeline-metrics-prod
 
+tekton_pruner_keep: 50
+
 # Settings for importing index imagestreams
 certified_operator_index: registry.redhat.io/redhat/certified-operator-index
 redhat_marketplace_index: registry.redhat.io/redhat/redhat-marketplace-index

--- a/ansible/inventory/group_vars/operator-pipeline.yml
+++ b/ansible/inventory/group_vars/operator-pipeline.yml
@@ -13,6 +13,8 @@ operator_pipeline_image_tag: latest
 operator_pipeline_image_pull_spec: "{{ operator_pipeline_image_repo }}:{{ operator_pipeline_image_tag }}"
 operator_pipeline_pending_namespace: "{{ oc_namespace }}"
 
+tekton_pruner_keep: 10
+
 ##### Secrets locations
 operator_pipeline_private_key_local_path: ../../vaults/{{ env }}/operator-pipeline.key
 operator_pipeline_private_cert_local_path: ../../vaults/{{ env }}/operator-pipeline.pem

--- a/ansible/roles/config-ocp-cluster/files/tektonconfig.yml
+++ b/ansible/roles/config-ocp-cluster/files/tektonconfig.yml
@@ -6,9 +6,9 @@ metadata:
 spec:
   pipeline:
     scope-when-expressions-to-task: true
+  # Default pruner settings. May be overridden using namespace annotations.
   pruner:
-    keep: 100
+    keep: 50
     resources:
       - pipelinerun
-      - taskrun
     schedule: "*/5 * * * *"

--- a/ansible/roles/config-ocp-cluster/tasks/pipelinerun-listener.yml
+++ b/ansible/roles/config-ocp-cluster/tasks/pipelinerun-listener.yml
@@ -12,6 +12,10 @@
           apiVersion: v1
           metadata:
             name: "{{ pipelinerun_listener_namespace }}"
+            annotations:
+              # TaskRuns are created without a corresponding PipelineRun.
+              # Make sure the pruner cleans up both.
+              operator.tekton.dev/prune.resources: "pipelinerun, taskrun"
 
     - name: Create Tasks
       k8s:

--- a/ansible/roles/operator-pipeline/tasks/main.yml
+++ b/ansible/roles/operator-pipeline/tasks/main.yml
@@ -9,6 +9,8 @@
       apiVersion: v1
       metadata:
         name: "{{ oc_namespace }}"
+        annotations:
+          operator.tekton.dev/prune.keep: "{{ tekton_pruner_keep | int }}"
 
 - name: Deploy namespace resources
   when: namespace_state == 'present'


### PR DESCRIPTION
Only PipelineRuns are pruned by default since removal of TaskRuns from an inflight PipelineRun may result in unexpected restart behavior. The pipelinerun-listener namespace is an exception since TaskRuns are created without use of a PipelineRun.

Preprod operator pipeline namespaces will be cleaned up more aggressively to reduce the chances of PVC quota issues on the shared cluster. This effectively restores the preprod behavior of the defunct cleaner CronJob.