### PR TITLE
[ISV-2647] Fix how supported index lists are passed

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -429,7 +429,7 @@ spec:
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
-        - name: bundle_versions
+        - name: index_images
           value: "$(tasks.get-supported-versions.results.indices)"
         - name: bundle_pullspec
           value: "$(tasks.publish-to-ocp-registry.results.image_pullspec)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/check-ocp-cluster-version.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/check-ocp-cluster-version.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: indices_ocp_versions
-      description: All known supported OCP indices' OCP versions
+      description: All known supported OCP versions (space separated)
     - name: kubeconfig_secret_name
       description: The name of the Kubernetes Secret that contains the kubeconfig.
     - name: kubeconfig_secret_key
@@ -31,14 +31,8 @@ spec:
         CLUSTER_VERSION=$(oc get clusterversion -o jsonpath="{.items[0].status.desired.version}" --kubeconfig $KUBECONFIG)
         # Grab only the major and minor version for comparison
         CLUSTER_VERSION=$(echo $CLUSTER_VERSION | cut -d. -f1,2)
-        # parse indices into a list of strings with OCP versions
-        # The base64 step here is part of the workaround for
-        # https://github.com/tektoncd/pipeline/issues/5414 affecting new tekton
-        # pipelines versions (Openshift Pipelines Operator v1.8)
-        RAW_INDICES_OCP_VERSIONS=$(echo '$(params.indices_ocp_versions)' | base64 -d)
-        SUPPORTED_VERSIONS=$(echo "$RAW_INDICES_OCP_VERSIONS" | jq -r '.[]')
 
-        for version in $SUPPORTED_VERSIONS; do
+        for version in $(params.indices_ocp_versions); do
           if [ "$version" == "$CLUSTER_VERSION" ]; then
             echo "The Operator does claim support for the provided cluster version ($CLUSTER_VERSION)."
             exit 0

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/get-supported-versions.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/get-supported-versions.yml
@@ -9,18 +9,14 @@ spec:
     - name: bundle_path
       description: path indicating the location of the certified bundle within the repository
   results:
-    # NOTE: as a workaround for https://github.com/tektoncd/pipeline/issues/5414
-    # that affects recent versions of Tekton Pipelines, including the version
-    # shipped with Openshift Pipelines 1.8, all results containing JSON payload
-    # have been changed to be base64 encoded
     - name: max_supported_ocp_version
       description: Maximum version of OpenShift supported by this Operator
     - name: max_supported_index
       description: Pull spec for the index corresponding to the max OCP version
     - name: indices
-      description: All known supported OCP indices paths (base64 encoded, see NOTE)
+      description: All known supported index image pull specs (space separated)
     - name: indices_ocp_versions
-      description: All known supported OCP indices' OCP version (base64 encoded, see NOTE)s
+      description: All known supported OCP versions (space separated)
     - name: max_version_indices
       description: Latest known supported OCP indices
     - name: ocp_version
@@ -50,15 +46,13 @@ spec:
           | tee $(results.max_supported_index.path)
 
         echo $VERSION_INFO \
-          | jq -r '[.indices[].path]' \
+          | jq -r '.indices | map(.path) | join(" ")' \
           | tr -d '\n\r' \
-          | base64 \
           | tee $(results.indices.path)
 
         echo $VERSION_INFO \
-          | jq -r '[.indices[].ocp_version]' \
+          | jq -r '.indices | map(.ocp_version) | join(" ")' \
           | tr -d '\n\r' \
-          | base64 \
           | tee $(results.indices_ocp_versions.path)
 
         echo $VERSION_INFO \

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-bundle.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-bundle.yml
@@ -8,8 +8,8 @@ spec:
     - name: pipeline_image
     - name: bundle_pullspec
       description: Bundle pullspec
-    - name: bundle_versions
-      description: All known supported OCP indices
+    - name: index_images
+      description: All known supported index image pull specs (space separated)
     - name: iib_url
       description: IIB API url
       default: https://iib.engineering.redhat.com
@@ -99,17 +99,11 @@ spec:
             ;;
         esac
 
-        # The base64 step here is part of the workaround for
-        # https://github.com/tektoncd/pipeline/issues/5414 affecting new tekton
-        # pipelines versions (Openshift Pipelines Operator v1.8)
-        RAW_BUNDLE_VERSIONS=$(echo '$(params.bundle_versions)' | base64 -d)
-        INDICES="$(echo "$RAW_BUNDLE_VERSIONS" | tr -d '[,]')"
-
         # DO NOT use `--verbose` to avoid auth headers appearing in logs
         index \
           --iib-url "$(params.iib_url)" \
           --from-index $FROM_INDEX \
-          --indices $INDICES \
+          --indices $(params.index_images) \
           --bundle-pullspec "$(params.bundle_pullspec)" \
           --output manifest-list-digests.txt
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -62,3 +62,21 @@ ansible-pull \
   --vault-password-file $VAULT_PASSWORD_PATH \
   ansible/playbooks/operator-pipeline-integration-tests.yml
 ```
+
+It may be necessary to provide your own project and bundle to test certain
+aspects of the pipelines. This can be accomplished with the addition of a few
+extra vars (and proper configuration of the project).
+
+```bash
+ansible-pull \
+  -U "https://github.com/redhat-openshift-ecosystem/operator-pipelines.git" \
+  -i "ansible/inventory/operator-pipeline-integration-tests" \
+  -e "oc_namespace=$NAMESPACE" \
+  -e "src_operator_git_branch=$SRC_BRANCH" \
+  -e "src_operator_bundle_version=$SRC_VERSION" \
+  -e "operator_package_name=$PACKAGE_NAME" \
+  -e "operator_bundle_version=$NEW_VERSION" \
+  -e "ci_pipeline_pyxis_api_key=$API_KEY" \
+  --vault-password-file $VAULT_PASSWORD_PATH \
+  ansible/playbooks/operator-pipeline-integration-tests.yml
+```


### PR DESCRIPTION
The solves a problem with trailing slashes seen on the index image pull specs in the publish-bundle task. It removes the prior workaround.