### PR TITLE
[CVP-3294] Switch setenv and checkout

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -78,19 +78,8 @@ spec:
     - name: registry-cacert
       optional: true
   tasks:
-    - name: set-env
-      taskRef:
-        name: set-env
-        kind: Task
-      params:
-        - name: env
-          value: $(params.env)
-        - name: access_type
-          value: "external"
 
     - name: checkout
-      runAfter:
-        - set-env
       taskRef:
         name: git-clone
         kind: Task
@@ -108,10 +97,22 @@ spec:
         - name: ssh-directory
           workspace: ssh-dir
 
+    - name: set-env
+      runAfter:
+        - checkout
+      taskRef:
+        name: set-env
+        kind: Task
+      params:
+        - name: env
+          value: $(params.env)
+        - name: access_type
+          value: "external"
+
     # Verify the bundle path exists
     - name: bundle-path-validation
       runAfter:
-        - checkout
+        - set-env
       taskRef:
         name: bundle-path-validation
       params:


### PR DESCRIPTION
Signed-off-by: Martin Vala <mavala@redhat.com>

Switching order `set-env` after `checkout`. The order should not influence pipeline and checkout is needed to get `config.yaml` before `set-env` task. In this way we would be able to setup community operators services for ocp and k8s. Example configs

- Community ocp: https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/blob/upstream-community/config.yaml
- Community k8s: https://github.com/k8s-operatorhub/operator-pipelines-test/blob/main/config.yaml