### PR TITLE
Fix generate-index:prepare to use podman gid 1000

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
@@ -41,12 +41,16 @@ spec:
         # This is needed to ensure the inspect-base-index step, which runs
         # under a different UID, has access to its output file
         truncate -s 0 podman-inspect.json
+        chown :1000 podman-inspect.json
         chmod 664 podman-inspect.json
 
         mkdir -p $DOCKER_CONFIG
+        chown :1000 $DOCKER_CONFIG
         chmod 775 $DOCKER_CONFIG
         cp $HOME/.docker/config.json $DOCKER_CONFIG/config.json
+        chown :1000 $DOCKER_CONFIG/config.json
         chmod 664 $DOCKER_CONFIG/config.json
+        chown :1000 .
         chmod go+rx .
 
     - name: inspect-base-index


### PR DESCRIPTION
This relates to Jira ISV-2654. PR is linked to EET-3092 in RH Jira.

## Summary
I've discoverd the root cause of the permission denied error when running as the intended uid (1000) in the generate-index: inspect-base-index task step.

The root cause was identified in the preceding step generate-index: prepare where the podman-inspect.json file is given group read/write permissions, effective to gid 0/root.

Typically, the restricted SCC would launch containers as part of the root group on OCP, so it was a safe assumption that group permissions would apply.

There are two issues, however:

1. Podman assumes it can write to the uidmap in the kernel /proc filesystem if it is run as either UID or GID 0.
2. Setting even just the GID to 0 will cause podman to exit due to the uidmap error, requiring the pod to run as privileged. Doing this draws a warning on OCP 4.11, and will likely not work out-of-the-box on OCP 4.12

Therefore, the best course of action was to update the group ownership of podman-inspect.json, as well as other files in the pipeline workspace volume to gid 1000 (podman). 