### PR TITLE
updating preflight task to use preflight v1.4.2

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:2e1791cfeba16c7bf0ecd7519dd1c29ae394daf819b9e9f8d3f001707b022554
+      default: quay.io/redhat-isv/preflight-test@sha256:0aaa4a01de17a27b12424085265d1ee0fd6421ee6f14d4c7646b3ec3fb574210
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
- Update preflight task to point to v1.4.2

```
podman run -it quay.io/redhat-isv/preflight-test@sha256:0aaa4a01de17a27b12424085265d1ee0fd6421ee6f14d4c7646b3ec3fb574210 /bin/bash --version
preflight version 1.4.2 <commit: f9cff772837132149df69f8ae251d3caf81c49ac>
```

Signed-off-by: Adam D. Cornett <adc@redhat.com>