### PR TITLE
Reverts #366 for issues affecting OpenShift proper

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
@@ -41,16 +41,12 @@ spec:
         # This is needed to ensure the inspect-base-index step, which runs
         # under a different UID, has access to its output file
         truncate -s 0 podman-inspect.json
-        chown :1000 podman-inspect.json
         chmod 664 podman-inspect.json
 
         mkdir -p $DOCKER_CONFIG
-        chown :1000 $DOCKER_CONFIG
         chmod 775 $DOCKER_CONFIG
         cp $HOME/.docker/config.json $DOCKER_CONFIG/config.json
-        chown :1000 $DOCKER_CONFIG/config.json
         chmod 664 $DOCKER_CONFIG/config.json
-        chown :1000 .
         chmod go+rx .
 
     - name: inspect-base-index


### PR DESCRIPTION
The mentioned changes (merged late yesterday evening) are breaking generate-index at the `extract-database` step.

There is a permission denied error when copying index.db into the output workspace.

This PR resolves that by reverting the changes in #366.