### PR TITLE
[ISV-2866] Permission error in CI pipeline after 4.11 cluster upgrade

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -29,7 +29,7 @@ spec:
       default: image-registry.openshift-image-registry.svc:5000
     - name: podman_image
       description: Podman image
-      default: "registry.redhat.io/rhel8/podman:8.5-13"
+      default: "registry.redhat.io/rhel8/podman:8.7"
     - name: env
       description: Which environment to run in. Can be one of [dev, qa, stage, prod]
       default: "prod"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
@@ -8,7 +8,7 @@ spec:
     - name: pipeline_image
     - name: podman_image
       description: Podman image
-      default: "registry.redhat.io/rhel8/podman:8.5-13"
+      default: "registry.redhat.io/rhel8/podman:8.7"
     - name: bundle_image
       description: Pull spec of a bundle image
     - name: from_index

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
@@ -125,7 +125,7 @@ spec:
           opm migrate index.db index
 
           # Generate the index Dockerfile
-          opm alpha generate dockerfile index
+          opm generate dockerfile index
 
           # Amend the Dockerfile with the addition of the sqlite DB for backwards compatibility
           echo -e "\nADD index.db $DB_PATH\n" >> index.Dockerfile

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/inspect-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/inspect-image.yml
@@ -29,11 +29,16 @@ spec:
         skopeo login $(params.registry) --authfile $(workspaces.registry-credentials.path)/.dockerconfigjson \
 
         skopeo inspect docker://$(params.image) > $(workspaces.image-data.path)/skopeo.json
+
+        truncate -s 0 $(workspaces.image-data.path)/podman.json
+        chmod 664 $(workspaces.image-data.path)/podman.json
     - name: podman-inspect
+      securityContext:
+        runAsUser: 1000
       image: "$(params.podman_image)"
       script: |
         set -xe
 
         podman pull $(params.image)
 
-        podman image inspect $(params.image) > $(workspaces.image-data.path)/podman.json
+        podman image inspect $(params.image) >> $(workspaces.image-data.path)/podman.json

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/inspect-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/inspect-image.yml
@@ -7,10 +7,10 @@ spec:
   params:
     - name: skopeo_image
       description: Skopeo image
-      default: "registry.redhat.io/rhel8/skopeo:8.4-13"
+      default: "registry.redhat.io/rhel8/skopeo:8.7"
     - name: podman_image
       description: Podman image
-      default: "registry.redhat.io/rhel8/podman:8.4-14"
+      default: "registry.redhat.io/rhel8/podman:8.7"
     - name: image
       description: reference to the existing bundle image
     - name: registry


### PR DESCRIPTION
- Update use of `opm alpha generate` to `opm generate` after #373 
- Update `inspect-image:podman-inspect` to use rootless podman
- Bump podman image version to avoid the harmless but misleading error `Failed to created default CNI network: error creating CNI configuration directory: mkdir /home/podman/.config/cni: permission denied`
- Bump skopeo image version to match the podman image
