### PR TITLE
Store ocp version into file

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/get-supported-versions.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/get-supported-versions.yml
@@ -32,7 +32,13 @@ spec:
         set -xe
 
         ORGANIZATION=$(cat config.yaml | yq -r '.organization')
-        VERSION_INFO=$(ocp-version-info $(params.bundle_path) $ORGANIZATION)
+        OCP_VERSIONS_OUTPUT_FILE="./ocp_versions.json"
+        ocp-version-info \
+          --output-file $OCP_VERSIONS_OUTPUT_FILE \
+          $(params.bundle_path) \
+          $ORGANIZATION
+
+        VERSION_INFO=$(cat $OCP_VERSIONS_OUTPUT_FILE)
         echo $VERSION_INFO | jq
 
         echo $VERSION_INFO \

--- a/operator-pipeline-images/operatorcert/entrypoints/ocp_version_info.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/ocp_version_info.py
@@ -25,6 +25,10 @@ def setup_argparser() -> argparse.ArgumentParser:  # pragma: no cover
         default="https://catalog.redhat.com/api/containers/",
         help="Base URL for Pyxis container metadata API",
     )
+    parser.add_argument(
+        "--output-file",
+        help="Path to a json file where ocp version will be stored",
+    )
     parser.add_argument("--verbose", action="store_true", help="Verbose output")
 
     return parser
@@ -39,7 +43,12 @@ def main() -> None:
 
     bundle_path = pathlib.Path(args.bundle_path)
     version_info = ocp_version_info(bundle_path, args.pyxis_url, args.organization)
+
     LOGGER.info(json.dumps(version_info))
+
+    if args.output_file:
+        with open(args.output_file, "w") as output_file:
+            json.dump(version_info, output_file)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
The previous solution used a script stdout to parse json output. Unfortunately log messages produced by the script added new lines into output and output was no longer valid json.

This commit stores the ocp version json into separate file and read metadata from the file instead of from script stdout/stderr.

JIRA: ISV-2820