### PR TITLE
Add signature data output to request-signature task

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/request-signature.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/request-signature.yml
@@ -39,6 +39,7 @@ spec:
       default: umb.api.redhat.com
   results:
     - name: signature_data_file
+    - name: signature_data
   volumes:
     - name: umb-ssl-volume
       secret:
@@ -78,6 +79,6 @@ spec:
 
         SIG_DATA=$(cat signing_response.json)
         echo "Signed claims and their metadata: "
-        echo -n $SIG_DATA
+        echo -n $SIG_DATA | tee $(results.signature_data.path)
         echo -n signing_response.json | tee $(results.signature_data_file.path)
       workingDir: $(workspaces.source.path)


### PR DESCRIPTION
The data is returned from the task to be available in other tastks.