### PR TITLE
Proper fix for crc file perms issue using posix acl

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
@@ -42,6 +42,7 @@ spec:
         # under a different UID, has access to its output file
         truncate -s 0 podman-inspect.json
         chmod 664 podman-inspect.json
+        setfacl -m g:1000:rw- podman-inspect.json
 
         mkdir -p $DOCKER_CONFIG
         chmod 775 $DOCKER_CONFIG


### PR DESCRIPTION
Fixes #387

Tested in OpenShift Local (formerly CRC) and OpenShift Container Platform (both v4.11) running in AWS.

The POSIX ACL allows granular file owership/permissions versus singular user, group and other (ugo) permissions. This avoids side effects of #366 (change group ownership), which required reverting due to errors arising in OCP on AWS.

Signed-off-by: Josh Manning <19478595+jsm84@users.noreply.github.com>