### PR TITLE
[ISV-3093] Fix image pull in rootless containers

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
@@ -51,6 +51,9 @@ spec:
 
     - name: inspect-base-index
       image: "$(params.podman_image)"
+      env:
+        - name: STORAGE_DRIVER
+          value: vfs
       workingDir: $(workspaces.output.path)
       securityContext:
         runAsUser: 1000
@@ -66,7 +69,6 @@ spec:
 
         podman pull $FROM_INDEX
         podman image inspect $FROM_INDEX | tee -a podman-inspect.json
-
     - name: determine-index-format
       image: "$(params.pipeline_image)"
       workingDir: $(workspaces.output.path)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/inspect-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/inspect-image.yml
@@ -36,6 +36,9 @@ spec:
       securityContext:
         runAsUser: 1000
       image: "$(params.podman_image)"
+      env:
+        - name: STORAGE_DRIVER
+          value: vfs
       script: |
         set -xe
 


### PR DESCRIPTION
Some images can fail to pull because podman uses overlayfs by default even in rootless mode, causing an overlay fs to be mounted on top of another overlay fs, preventing whiteout files from working as expected.

With this patch we force podman to use the "vfs" storage driver instead.