### PR TITLE
Revert signature results

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-signing-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-signing-pipeline.yml
@@ -40,7 +40,7 @@ spec:
     - name: verify-whitelisted-index-image
       taskref:
         name: verify-whitelisted-index-image
-        bundle: "quay.io/redhat-isv/tkn-signing-bundle:3828559997"
+        bundle: "quay.io/redhat-isv/tkn-signing-bundle:3947415077"
         kind: Task
       params:
         - name: reference
@@ -61,7 +61,7 @@ spec:
     - name: request-signature
       taskRef:
         name: request-signature
-        bundle: "quay.io/redhat-isv/tkn-signing-bundle:3828559997"
+        bundle: "quay.io/redhat-isv/tkn-signing-bundle:3947415077"
         kind: Task
       runAfter:
         - set-env
@@ -96,7 +96,7 @@ spec:
     - name: upload-signature
       taskRef:
         name: upload-signature
-        bundle: "quay.io/redhat-isv/tkn-signing-bundle:3828559997"
+        bundle: "quay.io/redhat-isv/tkn-signing-bundle:3947415077"
         kind: Task
       runAfter:
         - request-signature

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -469,7 +469,7 @@ spec:
       when: *whenNotUndistributed
       taskRef:
         name: request-signature
-        bundle: "quay.io/redhat-isv/tkn-signing-bundle:3828559997"
+        bundle: "quay.io/redhat-isv/tkn-signing-bundle:3947415077"
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
@@ -504,7 +504,7 @@ spec:
       when: *whenNotUndistributed
       taskRef:
         name: upload-signature
-        bundle: "quay.io/redhat-isv/tkn-signing-bundle:3828559997"
+        bundle: "quay.io/redhat-isv/tkn-signing-bundle:3947415077"
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/request-signature.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/request-signature.yml
@@ -39,7 +39,6 @@ spec:
       default: umb.api.redhat.com
   results:
     - name: signature_data_file
-    - name: signature_data
   volumes:
     - name: umb-ssl-volume
       secret:
@@ -79,6 +78,6 @@ spec:
 
         SIG_DATA=$(cat signing_response.json)
         echo "Signed claims and their metadata: "
-        echo -n $SIG_DATA | tee $(results.signature_data.path)
+        echo -n $SIG_DATA
         echo -n signing_response.json | tee $(results.signature_data_file.path)
       workingDir: $(workspaces.source.path)


### PR DESCRIPTION
Signature results reached Tekton size limits and caused a pipeline failure.