### PR TITLE
updating preflight task to use preflight v1.5.0

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:10d4f23b9532a1bac3a6c775ce473228d448072b6c75864ac05b9bca7e9b83e0
+      default: quay.io/redhat-isv/preflight-test@sha256:ee7a75ad3d343f8721745926ca654e24920366620dba74d6838ca341dc344e19
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
- Moving preflight from 1.4.3 -> 1.5.0

```
╭─acornett at acornett-mac in ~/go/src/github.com/acornett21/operator-pipelines on update_preflight_sha✔
╰─± crane digest quay.io/redhat-isv/preflight-test:1.4.3
sha256:10d4f23b9532a1bac3a6c775ce473228d448072b6c75864ac05b9bca7e9b83e0
╭─acornett at acornett-mac in ~/go/src/github.com/acornett21/operator-pipelines on update_preflight_sha✔
╰─± crane digest quay.io/redhat-isv/preflight-test:1.5.0
sha256:ee7a75ad3d343f8721745926ca654e24920366620dba74d6838ca341dc344e19
```

Signed-off-by: Adam D. Cornett <adc@redhat.com>