### PR TITLE
updating preflight task to use preflight v1.5.1

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:ee7a75ad3d343f8721745926ca654e24920366620dba74d6838ca341dc344e19
+      default: quay.io/redhat-isv/preflight-test@sha256:a8d588c61ccf189dfe1d994a334ee084ecedc6fa9a1a1aab892b5a2092f46dd1
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
Updating to new version of preflight. The change in this release is for `check container`, so has no affect on the pipelines(s).

```
╭─acornett at acornett-mac in ~
╰─○ crane digest quay.io/redhat-isv/preflight-test:1.5.0                                                                  
sha256:ee7a75ad3d343f8721745926ca654e24920366620dba74d6838ca341dc344e19
╭─acornett at acornett-mac in ~
╰─○ crane digest quay.io/redhat-isv/preflight-test:1.5.1
sha256:a8d588c61ccf189dfe1d994a334ee084ecedc6fa9a1a1aab892b5a2092f46dd1
```

Signed-off-by: Adam D. Cornett <adc@redhat.com>