### PR TITLE
Update max ocp version available from openshift-ci

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
@@ -10,7 +10,7 @@ spec:
       default: "quay.io/opdev/preflight-trigger:stable"
     - name: preflight_trigger_environment
       description: Which openshift-ci step-registry steps and ProwJob templates to use. Can be one of [preprod, prod]
-    - default: '4.11'
+    - default: '4.12'
       name: ocp_version
       type: string
     - default: trace
@@ -106,7 +106,7 @@ spec:
           fi
 
           # This is the maximum version supported by openshift-ci
-          DPTP_VER="4.11"
+          DPTP_VER="4.12"
           CP_VER="$(params.ocp_version)"
 
           if [ "$(printf '%s\n' "$DPTP_VER" "$CP_VER" | sort -V | head -n1)" == "$DPTP_VER" ]; then
@@ -164,7 +164,7 @@ spec:
               exit 0
           fi
 
-          DPTP_VER="4.11"
+          DPTP_VER="4.12"
           CP_VER="$(params.ocp_version)"
 
           if [ "$(printf '%s\n' "$DPTP_VER" "$CP_VER" | sort -V | head -n1)" == "$DPTP_VER" ]; then


### PR DESCRIPTION
We currently rely on openshift-ci cluster pools whose manifests can be found here
https://github.com/openshift/release/tree/master/clusters/hive/pools/openshift-ci and when a version of OpenShift is available here we can then run the hosted certification pipeline against said version but changes found in this PR need to be done for each version; we are exploring more reliable means to do this.

Signed-off-by: Melvin Hillsman <mhillsma@redhat.com>