### PR TITLE
Update preflight task to use 1.5.2

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:a8d588c61ccf189dfe1d994a334ee084ecedc6fa9a1a1aab892b5a2092f46dd1
+      default: quay.io/redhat-isv/preflight-test@sha256:de46d6b6fdc6149ad23df6318535ecfb148e9dd94fe7c43356a4ecd2f82bc1f2
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
Preflight has pushed the `stable` tag to release 1.5.2. This updates the pipeline to use that version (from 1.5.1).

The current image digest pointing to 1.5.1.
```
 $ skopeo inspect docker://quay.io/redhat-isv/preflight-test:1.5.1 | jq -r .Digest
sha256:a8d588c61ccf189dfe1d994a334ee084ecedc6fa9a1a1aab892b5a2092f46dd1
```

Will be replaced with 1.5.2.
```
 $ skopeo inspect docker://quay.io/redhat-isv/preflight-test:1.5.2 | jq -r .Digest
sha256:de46d6b6fdc6149ad23df6318535ecfb148e9dd94fe7c43356a4ecd2f82bc1f2
```

Matches the upstream preflight stable tag as of this writing.
```
 $ skopeo inspect docker://quay.io/opdev/preflight:stable | jq -r .Digest
sha256:de46d6b6fdc6149ad23df6318535ecfb148e9dd94fe7c43356a4ecd2f82bc1f2
```
Signed-off-by: Jose R. Gonzalez <jrg@redhat.com>