### PR TITLE
Create custom SCC with privilege escalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ tkn pipeline start operator-ci-pipeline \
   --showlog
 ```
 
+A subset of tasks in the pipeline requires privilege escalation which is no longer
+supported with OpenShift Pipelines 1.9. Thus a new `SCC` needs to be created and linked
+with `pipeline` service account. Creating [SCC](https://docs.openshift.com/container-platform/4.11/authentication/managing-security-context-constraints.html#security-context-constraints-creating_configuring-internal-oauth)
+requires user with cluster-admin privileges.
+```bash
+# Create a new SCC
+oc apply -f ansible/roles/operator-pipeline/templates/openshift/openshift-pipelines-custom-scc.yml
+# Add SCC to a pipeline service account
+oc adm policy add-scc-to-user pipelines-custom-scc -z pipeline
+```
 
 
 To enable opening the PR and uploading the pipeline logs (visible to the certification project

--- a/ansible/inventory/group_vars/operator-pipeline.yml
+++ b/ansible/inventory/group_vars/operator-pipeline.yml
@@ -3,6 +3,7 @@
 ansible_connection: local
 env: unset
 oc_namespace: "operator-pipeline-{{ env }}"
+service_account_name: operator-pipeline-admin
 branch: "{{ env }}"
 preflight_min_version: 0.0.0
 preflight_trigger_environment: preprod

--- a/ansible/playbooks/operator-pipeline-env-setup.yml
+++ b/ansible/playbooks/operator-pipeline-env-setup.yml
@@ -1,0 +1,9 @@
+---
+- name: Setup operator-pipeline namespace
+  hosts: "operator-pipeline-{{ env }}"
+
+  tasks:
+    - name: Configure namespace + service account
+      include_role:
+        name: operator-pipeline
+        tasks_from: operator-pipeline-service-account

--- a/ansible/roles/operator-pipeline/tasks/main.yml
+++ b/ansible/roles/operator-pipeline/tasks/main.yml
@@ -15,77 +15,21 @@
 - name: Deploy namespace resources
   when: namespace_state == 'present'
   block:
+
     - include_tasks: tasks/pipeline-secrets.yml
+    - include_tasks: tasks/operator-pipeline-import-index-images.yml
 
-    # We can't use the k8s module here because it always tries to GET the resource
-    # prior to creation or patching. The ImageStreamImport API only supports POST.
-    - name: Import certified-operator-index imagestream
+    - name: Add custom pipeline SCC and link it with pipeline SA
       tags:
-        - import-index-images
-      no_log: yes
-      uri:
-        url: "{{ ocp_host }}/apis/image.openshift.io/v1/namespaces/{{ oc_namespace }}/imagestreamimports"
-        method: POST
-        # The 'or' condition is needed to support Ansible versions < 2.13
-        validate_certs: "{{ lookup('env', 'K8S_AUTH_VERIFY_SSL', default='yes') or 'yes' }}"
-        status_code: 201
-        body_format: json
-        headers:
-          Authorization: "Bearer {{ ocp_token }}"
-        body:
-          apiVersion: image.openshift.io/v1
-          kind: ImageStreamImport
-          metadata:
-            name: certified-operator-index
-            labels:
-              app: operator-pipeline
-              suffix: "{{ suffix }}"
-              env: "{{ env }}"
-          spec:
-            import: true
-            repository:
-              from:
-                kind: DockerImage
-                name: "{{ certified_operator_index }}"
-              importPolicy:
-                insecure: "{{ insecure_index_import | default(false) }}"
-                scheduled: true
-              referencePolicy:
-                type: Local
-
-    - name: Import redhat-marketplace-index imagestream
-      tags:
-        - import-index-images
-      no_log: true
-      ansible.builtin.uri:
-        url: "{{ ocp_host }}/apis/image.openshift.io/v1/namespaces/{{ oc_namespace }}/imagestreamimports"
-        method: POST
-        # The 'or' condition is needed to support Ansible versions < 2.13
-        validate_certs: "{{ lookup('env', 'K8S_AUTH_VERIFY_SSL', default='yes') or 'yes' }}"
-        status_code: 201
-        body_format: json
-        headers:
-          Authorization: "Bearer {{ ocp_token }}"
-        body:
-          apiVersion: image.openshift.io/v1
-          kind: ImageStreamImport
-          metadata:
-            name: redhat-marketplace-index
-            labels:
-              app: operator-pipeline
-              suffix: "{{ suffix }}"
-              env: "{{ env }}"
-          spec:
-            import: true
-            repository:
-              from:
-                kind: DockerImage
-                name: "{{ redhat_marketplace_index }}"
-              importPolicy:
-                insecure: "{{ insecure_index_import | default(false) }}"
-                scheduled: true
-              referencePolicy:
-                type: Local
+        - pipeline-scc
+      k8s:
+        state: present
+        apply: true
+        definition: "{{ lookup('template', '{{ item }}') }}"
+      with_items:
+        - ../templates/openshift/openshift-pipelines-custom-scc.yml
+        - ../templates/openshift/openshift-pipeline-sa-scc-role.yml
+        - ../templates/openshift/openshift-pipeline-sa-scc-role-bindings.yml
 
     - name: Deploy pipeline tasks
       tags:

--- a/ansible/roles/operator-pipeline/tasks/operator-pipeline-import-index-images.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-pipeline-import-index-images.yml
@@ -1,0 +1,70 @@
+---
+# We can't use the k8s module here because it always tries to GET the resource
+# prior to creation or patching. The ImageStreamImport API only supports POST.
+- name: Import certified-operator-index imagestream
+  tags:
+    - import-index-images
+  no_log: yes
+  uri:
+    url: "{{ ocp_host }}/apis/image.openshift.io/v1/namespaces/{{ oc_namespace }}/imagestreamimports"
+    method: POST
+    # The 'or' condition is needed to support Ansible versions < 2.13
+    validate_certs: "{{ lookup('env', 'K8S_AUTH_VERIFY_SSL', default='yes') or 'yes' }}"
+    status_code: 201
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ ocp_token }}"
+    body:
+      apiVersion: image.openshift.io/v1
+      kind: ImageStreamImport
+      metadata:
+        name: certified-operator-index
+        labels:
+          app: operator-pipeline
+          suffix: "{{ suffix }}"
+          env: "{{ env }}"
+      spec:
+        import: true
+        repository:
+          from:
+            kind: DockerImage
+            name: "{{ certified_operator_index }}"
+          importPolicy:
+            insecure: "{{ insecure_index_import | default(false) }}"
+            scheduled: true
+          referencePolicy:
+            type: Local
+
+- name: Import redhat-marketplace-index imagestream
+  tags:
+    - import-index-images
+  no_log: true
+  ansible.builtin.uri:
+    url: "{{ ocp_host }}/apis/image.openshift.io/v1/namespaces/{{ oc_namespace }}/imagestreamimports"
+    method: POST
+    # The 'or' condition is needed to support Ansible versions < 2.13
+    validate_certs: "{{ lookup('env', 'K8S_AUTH_VERIFY_SSL', default='yes') or 'yes' }}"
+    status_code: 201
+    body_format: json
+    headers:
+      Authorization: "Bearer {{ ocp_token }}"
+    body:
+      apiVersion: image.openshift.io/v1
+      kind: ImageStreamImport
+      metadata:
+        name: redhat-marketplace-index
+        labels:
+          app: operator-pipeline
+          suffix: "{{ suffix }}"
+          env: "{{ env }}"
+      spec:
+        import: true
+        repository:
+          from:
+            kind: DockerImage
+            name: "{{ redhat_marketplace_index }}"
+          importPolicy:
+            insecure: "{{ insecure_index_import | default(false) }}"
+            scheduled: true
+          referencePolicy:
+            type: Local

--- a/ansible/roles/operator-pipeline/tasks/operator-pipeline-service-account.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-pipeline-service-account.yml
@@ -1,0 +1,47 @@
+---
+- name: Configure Namespace
+  tags:
+    - namespace
+    - init
+  k8s:
+    state: "present"
+    definition:
+      kind: Namespace
+      apiVersion: v1
+      metadata:
+        name: "{{ oc_namespace }}"
+
+- name: Create service account
+  tags:
+    - service-account
+    - init
+  k8s:
+    state: present
+    namespace: "{{ oc_namespace }}"
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: "{{ service_account_name }}"
+
+- name: Grant SA "{{ service_account_name }}" role
+  tags:
+    - service-account
+    - init
+  k8s:
+    state: present
+    namespace: "{{ oc_namespace }}"
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: "{{ service_account_name }}-{{ item }}"
+      roleRef:
+        kind: ClusterRole
+        name: "{{ item }}"
+      subjects:
+        - kind: ServiceAccount
+          name: "{{ service_account_name }}"
+          namespace: "{{ oc_namespace }}"
+  with_items:
+    - cluster-admin

--- a/ansible/roles/operator-pipeline/templates/openshift/openshift-pipeline-sa-scc-role-bindings.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/openshift-pipeline-sa-scc-role-bindings.yml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "system:openshift:scc:pipelines-custom-scc"
+subjects:
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: "{{ oc_namespace }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "system:openshift:scc:pipelines-custom-scc"

--- a/ansible/roles/operator-pipeline/templates/openshift/openshift-pipeline-sa-scc-role.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/openshift-pipeline-sa-scc-role.yml
@@ -1,0 +1,13 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: 'system:openshift:scc:pipelines-custom-scc'
+rules:
+  - verbs:
+      - use
+    apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - pipelines-custom-scc

--- a/ansible/roles/operator-pipeline/templates/openshift/openshift-pipelines-custom-scc.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/openshift-pipelines-custom-scc.yml
@@ -1,0 +1,42 @@
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    kubernetes.io/description: pipelines-custom-scc is a close replica of pipeline scc with privilege escalation.
+    release.openshift.io/create-only: "true"
+  name: pipelines-custom-scc
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+  - SETFCAP
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+  - system:cluster-admins
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/buildah.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/buildah.yml
@@ -5,8 +5,12 @@ metadata:
   name: buildah
 spec:
   description: |-
-    Buildah task builds source into a container image and then pushes it to a container registry.
-    Buildah Task builds source into a container image using Project Atomic's Buildah build tool.It uses Buildah's support for building from Dockerfiles, using its buildah bud command.This command executes the directives in the Dockerfile to assemble a container image, then pushes that image to a container registry.
+    Buildah task builds source into a container image and then pushes
+    it to a container registry. Buildah Task builds source into a container
+    image using Project Atomic's Buildah build tool.It uses Buildah's support
+    for building from Dockerfiles, using its buildah bud command.
+    This command executes the directives in the Dockerfile to
+    assemble a container image, then pushes that image to a container registry.
   params:
     - description: Reference of the image buildah will produce.
       name: IMAGE
@@ -50,22 +54,7 @@ spec:
       name: IMAGE_DIGEST
   steps:
     - image: $(params.BUILDER_IMAGE)
-      name: prepare
-      resources: {}
-      script: |
-        # This is needed to ensure the push step, which runs under a different
-        # UID, has access to its output file
-        chmod go+rx $(workspaces.source.path)
-        truncate -s 0 /digest/image-digest
-        chmod 666 /digest/image-digest
-      workingDir: $(workspaces.source.path)
-      volumeMounts:
-        - mountPath: /digest
-          name: digest
-    - image: $(params.BUILDER_IMAGE)
       name: build
-      securityContext:
-        runAsUser: 1000
       resources: {}
       script: |
         echo "Building $(params.IMAGE)"
@@ -73,17 +62,7 @@ spec:
           $(params.BUILD_EXTRA_ARGS) --format=$(params.FORMAT) \
           --tls-verify=$(params.TLSVERIFY) --no-cache \
           -f $(params.DOCKERFILE) -t $(params.IMAGE) $(params.CONTEXT)
-      volumeMounts:
-        - mountPath: /home/build/.local/share/containers
-          name: varlibcontainers
-      workingDir: $(workspaces.source.path)
-    - image: $(params.BUILDER_IMAGE)
-      name: push
-      securityContext:
-        runAsUser: 1000
-      resources: {}
-      # Added authfile argument to support private registries
-      script: |
+
         EXTRA_ARGS=""
         if [[ "$(workspaces.credentials.bound)" == "true" ]]; then
           EXTRA_ARGS+=" --authfile $(workspaces.credentials.path)/.dockerconfigjson"
@@ -98,19 +77,16 @@ spec:
           $(params.PUSH_EXTRA_ARGS) $EXTRA_ARGS --tls-verify=$(params.TLSVERIFY) \
           --digestfile /digest/image-digest $(params.IMAGE) \
           docker://$(params.IMAGE)
+
+        cat /digest/image-digest | tee /tekton/results/IMAGE_DIGEST
       volumeMounts:
         - mountPath: /home/build/.local/share/containers
           name: varlibcontainers
         - mountPath: /digest
           name: digest
+      securityContext:
+        privileged: true
       workingDir: $(workspaces.source.path)
-    - image: $(params.BUILDER_IMAGE)
-      name: digest-to-results
-      resources: {}
-      script: cat /digest/image-digest | tee /tekton/results/IMAGE_DIGEST
-      volumeMounts:
-        - mountPath: /digest
-          name: digest
   volumes:
     - emptyDir: {}
       name: varlibcontainers

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-index.yml
@@ -38,27 +38,21 @@ spec:
       workingDir: $(workspaces.output.path)
       script: |
         #! /usr/bin/env bash
-        # This is needed to ensure the inspect-base-index step, which runs
-        # under a different UID, has access to its output file
-        truncate -s 0 podman-inspect.json
-        chown :1000 podman-inspect.json
         chmod 664 podman-inspect.json
 
         mkdir -p $DOCKER_CONFIG
         chmod 775 $DOCKER_CONFIG
         cp $HOME/.docker/config.json $DOCKER_CONFIG/config.json
         chmod 664 $DOCKER_CONFIG/config.json
-        chmod go+rx .
 
     - name: inspect-base-index
       image: "$(params.podman_image)"
       env:
         - name: STORAGE_DRIVER
           value: vfs
-      workingDir: $(workspaces.output.path)
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
+        privileged: true
+      workingDir: $(workspaces.output.path)
       script: |
         #! /usr/bin/env bash
         set -exo pipefail
@@ -78,7 +72,6 @@ spec:
         #! /usr/bin/env bash
         set -x
 
-        chmod 644 podman-inspect.json
         # Create a special file in the workspace if this index uses file-based configs
         CONFIGS_QUERY='.[0].Labels."operators.operatorframework.io.index.configs.v1"'
         jq -e "$CONFIGS_QUERY" podman-inspect.json && touch $FBC_FILE

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/inspect-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/inspect-image.yml
@@ -10,7 +10,7 @@ spec:
       default: "registry.redhat.io/rhel8/skopeo:8.7"
     - name: podman_image
       description: Podman image
-      default: "registry.redhat.io/rhel8/podman:8.7"
+      default: "registry.redhat.io/ubi9/podman:9.1.0-12"
     - name: image
       description: reference to the existing bundle image
     - name: registry
@@ -29,12 +29,9 @@ spec:
         skopeo login $(params.registry) --authfile $(workspaces.registry-credentials.path)/.dockerconfigjson \
 
         skopeo inspect docker://$(params.image) > $(workspaces.image-data.path)/skopeo.json
-
-        truncate -s 0 $(workspaces.image-data.path)/podman.json
-        chmod 664 $(workspaces.image-data.path)/podman.json
     - name: podman-inspect
       securityContext:
-        runAsUser: 1000
+        privileged: true
       image: "$(params.podman_image)"
       env:
         - name: STORAGE_DRIVER

--- a/docs/ocp-namespace-config.md
+++ b/docs/ocp-namespace-config.md
@@ -1,0 +1,24 @@
+# OpenShift namespaces configuration
+Operator pipelines are deployed and run in OpenShift Dedicated clusters.
+The deployment of all resources including pipelines, tasks, secrets and others
+is managed using Ansible playbooks. In order to be able run the ansible
+automated way the initial setup of OpenShift namespaces needs to be executed.
+This process is also automated and requires access to a cluster with the `cluster-admin`
+privileges.
+
+To initially create and configure namespaces for each environment use following script:
+
+```bash
+cd ansible
+# Store Ansible vault password in ./vault-password
+echo $VAULT_PASSWD > ./vault-password
+
+# Login to a cluster using oc
+oc login --token=$TOKEN --server=$OCP_SERVER
+
+# Trigger an automation
+./init.sh stage
+```
+
+This command triggers Ansible that automates creation of OCP namespace for
+given environment and store admin service account token into vault.

--- a/docs/release-and-rollback.md
+++ b/docs/release-and-rollback.md
@@ -1,6 +1,6 @@
 ### Release Schedule
 
-Every Tues and Thurs, except for hotfixes
+Every Monday and Wednesday, except for hotfixes.
 
 ### Hotfixes
 Hotfixes are defined as changes that need to be quickly deployed to prod, outside of the regular release schedule, to address major issues that occur in prod. Hotfixes should still follow the release criteria and process, and should be announced on the team chat so that the rest of the team is aware.
@@ -8,8 +8,8 @@ Hotfixes are defined as changes that need to be quickly deployed to prod, outsid
 
 ### Release Criteria
 * Change is submitted as a pull request on Github.
-* All checks (validations and tests) pass on the pull request. 
-* Pull request is reviewed and approved by at least one other ISV Guild member. 
+* All checks (validations and tests) pass on the pull request.
+* Pull request is reviewed and approved by at least one other ISV Guild member.
 * Change is merged into main branch.
 * A new release must be deployed to dev and qa before being deployed to stage
 * A new release must be deployed to stage in the previous scheduled release date before being deployed to prod
@@ -18,7 +18,7 @@ Hotfixes are defined as changes that need to be quickly deployed to prod, outsid
 ### Release Process
 Before deployments occur, a new container image will be built and with “latest” and the associated git commit sha, then pushed to quay.io.
 
-Dev and qa deployment will happen automatically by Github Actions every time a change is merged into the main branch. The commit sha will be passed for identify the container image used by the pipelines as part of deployments. 
+Dev and qa deployment will happen automatically by Github Actions every time a change is merged into the main branch. The commit sha will be passed for identify the container image used by the pipelines as part of deployments.
 
 During a scheduled release or hotfix, stage and prod deployment will only happen by manually triggering the “deploy-stage” and “deploy-prod” Github Actions respectively. In a scheduled release, changes that were previously deployed to dev and qa will be promoted to stage, and changes that were previously deployed to stage will be promoted to prod. The last container image used in dev and qa (identified by the git commit sha tag) will also be promoted to be used in the stage pipeline, while the container image last used in stage will be used in the prod pipeline.
 


### PR DESCRIPTION
The OpenShift pipelines 1.9 no longer allow running containers with privilege escalation. Since a subset of pipeline tasks requires the privilege escalation we need to use a custom SCC that is build on top of pipeline SCC and add the escalation.

This commit adds the custom SCC, links it with the pipeline service account and refactors ansible to be compatible with the new setup.

JIRA: ISV-3280