### PR TITLE
Separate role binding for each namespace

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/operator-pipeline-service-account.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-pipeline-service-account.yml
@@ -35,7 +35,7 @@
       apiVersion: rbac.authorization.k8s.io/v1
       kind: ClusterRoleBinding
       metadata:
-        name: "{{ service_account_name }}-{{ item }}"
+        name: "{{ service_account_name }}-{{ oc_namespace }}-{{ item }}"
       roleRef:
         kind: ClusterRole
         name: "{{ item }}"

--- a/ansible/roles/operator-pipeline/templates/openshift/openshift-pipeline-sa-scc-role-bindings.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/openshift-pipeline-sa-scc-role-bindings.yml
@@ -2,7 +2,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: "system:openshift:scc:pipelines-custom-scc"
+  name: "pipeline-{{ oc_namespace }}-pipelines-custom-scc"
 subjects:
   - kind: ServiceAccount
     name: pipeline


### PR DESCRIPTION
The role-binding needs to be created with unique name given by namespaces. The original hardcoded name caused that different environments always overwrite the bindings and we were loosing roles after each re-deployment.

JIRA: ISV-3396