### PR TITLE
Increase nginx proxy replica count

### DIFF
--- a/ansible/inventory/group_vars/operator-pipeline-prod.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-prod.yml
@@ -29,3 +29,4 @@ redhat_marketplace_index: registry.redhat.io/redhat/redhat-marketplace-index
 community_signing_umb_client_name: community-operator-signing-pipeline
 community_signing_pipeline_url: "{{ community_signing_pipeline_name }}-tekton-{{ env }}.apps.pipelines-prod.ijdb.p1.openshiftapps.com"
 nginx_proxy_url: "{{ community_signing_pipeline_name }}-{{ env }}.apps.pipelines-prod.ijdb.p1.openshiftapps.com"
+nginx_proxy_replicas: 2


### PR DESCRIPTION
The nginx proxy is found to be low on resources. Increasing the replica count to 2 to avoid single point of failure.