### PR TITLE
[ISV-3366] Ignore deleted package lock objects

### DIFF
--- a/operator-pipeline-images/operatorcert/entrypoints/reserve_operator_name.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/reserve_operator_name.py
@@ -41,7 +41,8 @@ def check_operator_name_registered_for_association(args: Any) -> None:
     rsp = pyxis.get(
         urljoin(
             args.pyxis_url,
-            f"v1/operators/packages?filter=association=={args.association}",
+            "v1/operators/packages?"
+            f"filter=association=={args.association};deleted!=true",
         )
     )
 
@@ -79,7 +80,8 @@ def check_operator_name(args: Any) -> None:
     rsp = pyxis.get(
         urljoin(
             args.pyxis_url,
-            f"v1/operators/packages?filter=package_name=={args.operator_name}",
+            "v1/operators/packages?"
+            f"filter=package_name=={args.operator_name};deleted!=true",
         )
     )
 


### PR DESCRIPTION
When searching for existing package lock ignore object with deleted flag set to true. The deleted flag was recently added to be able reuse package multiple times.