### PR TITLE
[ISV-3553] replace deprecated set-output and update dependencies

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build Image
         id: build-image

--- a/.github/workflows/build-multi-arch-image.yml
+++ b/.github/workflows/build-multi-arch-image.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: add checkout action...
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install qemu dependency
         run: |

--- a/.github/workflows/build-signing-bundle.yml
+++ b/.github/workflows/build-signing-bundle.yml
@@ -19,7 +19,7 @@ jobs:
       bundle_image: ${{ steps.push-bundle.outputs.pullspec }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install tekton CLI
         id: install-deps

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - id: prepare
         run: |
-          echo "::set-output name=short_sha::${GITHUB_SHA::7}"
+          echo "short_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
   deploy-dev:
     runs-on: ubuntu-latest
@@ -31,7 +31,7 @@ jobs:
     env:
       SHORT_SHA: ${{needs.prepare-env.outputs.short_sha}}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           pip install --user openshift
@@ -58,7 +58,7 @@ jobs:
     env:
       SHORT_SHA: ${{needs.prepare-env.outputs.short_sha}}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           pip install --user openshift
@@ -86,7 +86,7 @@ jobs:
       - deploy-qa
       - deploy-dev
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           pip install --user openshift
@@ -113,7 +113,7 @@ jobs:
       - prepare-env
       - deploy-stage
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           pip install --user openshift
@@ -136,21 +136,21 @@ jobs:
     needs:
       - deploy-prod
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Bump version and push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v5.6
+        uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create a GitHub release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.tag_version.outputs.new_tag }}
-          release_name: Release ${{ steps.tag_version.outputs.new_tag }}
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
 
       - name: Log in to Quay.io

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,12 +15,12 @@ jobs:
   run-integration-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Prepare
         id: prepare
         run: |
-          echo "::set-output name=suffix::${GITHUB_SHA::7}"
+          echo "suffix=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -13,7 +13,7 @@ jobs:
     name: Run unit tests and linters
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: fedora-python/tox-github-action@v0.4
         with:
           tox_env: black,test,yamllint


### PR DESCRIPTION
- deprecated `set-output` replaced with environment files
- non-maintained action `actions/create-release` replaced with `ncipollo/release-action` and successfully tested in forked repository
- all actions updated to the latest version (needed for Node 12 deprecation)