### PR TITLE
[ISV-2905] fix difference in md5sum in ci vs hosted

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
@@ -85,7 +85,7 @@ spec:
           echo "The branch is reset to its pre-pin state because other unrelated changes may occur during the pin step and need to be undone."
           git checkout -- .
         fi
-    - name: verify-related-imagesmultiline echo
+    - name: verify-related-images
       image: "$(params.pipeline_image)"
       workingDir: $(workspaces.source.path)
       script: |

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
@@ -79,13 +79,13 @@ spec:
         if [[ $REPLACEMENT_COUNT -gt 0 ]]; then
           echo "Manifests were not pinned."
           echo -n "true" | tee $(results.dirty_flag.path)
-          echo "Branch reset to pre-pinning state."
-          git checkout -- .
         else
           echo "Manifests are pinned."
           echo -n "false" | tee $(results.dirty_flag.path)
+          echo "The branch is reset to its pre-pin state because other unrelated changes may occur during the pin step and need to be undone."
+          git checkout -- .
         fi
-    - name: verify-related-images
+    - name: verify-related-imagesmultiline echo
       image: "$(params.pipeline_image)"
       workingDir: $(workspaces.source.path)
       script: |

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
@@ -79,6 +79,8 @@ spec:
         if [[ $REPLACEMENT_COUNT -gt 0 ]]; then
           echo "Manifests were not pinned."
           echo -n "true" | tee $(results.dirty_flag.path)
+          echo "Branch reset to pre-pinning state."
+          git checkout -- .
         else
           echo "Manifests are pinned."
           echo -n "false" | tee $(results.dirty_flag.path)


### PR DESCRIPTION
Add git cleanup to `verify-pinning` step to avoid different md5sum between ci and hosted pipeline. When  digest-pinning is enabled, `relatedImages` section in csv can be reordered/changed without any actual pinning, causing md5sum difference.