### PR TITLE
updating preflight task to use preflight v1.6.6

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:f79ee6d71b8c1edef8424aeb860aeb4946cd6eb4a1b153d1bb0ffcc0c70a7074
+      default: quay.io/redhat-isv/preflight-test@sha256:b20c771f2179cdbc2a4e824baea8c3b5a912d78b8f2152b597cce7993ec93d93
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
Updating preflight task to latest preflight release sha

```
(⎈ |N/A:default)╭─acornett at acornett-mac in ~/go/src/github.com/acornett21/operator-pipelines on update_preflight_sha✘✘✘
╰─± crane digest quay.io/redhat-isv/preflight-test:1.6.3
sha256:f79ee6d71b8c1edef8424aeb860aeb4946cd6eb4a1b153d1bb0ffcc0c70a7074
(⎈ |N/A:default)╭─acornett at acornett-mac in ~/go/src/github.com/acornett21/operator-pipelines on update_preflight_sha✘✘✘
╰─± crane digest quay.io/redhat-isv/preflight-test:1.6.6
sha256:b20c771f2179cdbc2a4e824baea8c3b5a912d78b8f2152b597cce7993ec93d93
```