### PR TITLE
[ISV-3562] Upgrade base image to Fedora 38 and bump dependencies

### DIFF
--- a/operator-pipeline-images/Dockerfile
+++ b/operator-pipeline-images/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:36
+FROM registry.fedoraproject.org/fedora:38
 
 LABEL description="Cli tools for operator certification pipeline"
 LABEL summary="This image contains tools required for operator bundle certification pipeline."

--- a/operator-pipeline-images/requirements.txt
+++ b/operator-pipeline-images/requirements.txt
@@ -1,10 +1,10 @@
-python-magic==0.4.24
-pyyaml==5.4.1
+python-magic==0.4.27
+pyyaml==6.0
 requests==2.31.0
-yq==2.12.2
+yq==3.2.2
 giturlparse==0.10.0
 html2text==2020.1.16
-requests_kerberos==0.12.0
+requests_kerberos==0.14.0
 python-dateutil==2.8.2
-humanize==3.12.0
+humanize==4.7.0
 stomp.py==8.0.1

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps = -r operator-pipeline-images/requirements-dev.txt
 commands = black .
 
 [testenv:yamllint]
-basepython = python3
+basepython = python3.11
 deps = -r operator-pipeline-images/requirements-dev.txt
 files =
     .


### PR DESCRIPTION
New image with updated dependencies successfully tested in stage cluster.