### PR TITLE
Enhanced regex and err msg for PR title validation

### DIFF
--- a/operator-pipeline-images/operatorcert/__init__.py
+++ b/operator-pipeline-images/operatorcert/__init__.py
@@ -261,13 +261,21 @@ def parse_pr_title(pr_title: str) -> Tuple[str, str]:
     If yes, extract the Bundle name and version.
     """
     # Verify if PR title follows convention- it should contain the bundle name and version.
-    # Any non- empty string without whitespaces makes a valid version.
-    regex = rf"^operator ([a-zA-Z0-9-]+) \(([^\s]+)\)$"
+    regex = rf"^operator ([a-zA-Z0-9-]+) \(([0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9-]*)\)$"
     regex_pattern = re.compile(regex)
+    err_msg = f"Pull request title {pr_title} does not follow the regex 'operator <operator_name> (<version>)"
+
+    # Check <version> for prefix 'v'
+    regex_v = rf"^operator ([a-zA-Z0-9-]+) \((v[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9-]*)\)$"
+    regex_pattern_v = re.compile(regex_v)
+    err_msg_v = f" where <version> does not contain prefix 'v'"
+
+    if regex_pattern_v.match(pr_title):
+        err_msg = err_msg + err_msg_v
 
     if not regex_pattern.match(pr_title):
         raise ValueError(
-            f"Pull request title {pr_title} does not follow the regex 'operator <operator_name> (<version>)"
+                err_msg
         )
 
     matching = regex_pattern.search(pr_title)

--- a/operator-pipeline-images/operatorcert/__init__.py
+++ b/operator-pipeline-images/operatorcert/__init__.py
@@ -265,7 +265,7 @@ def parse_pr_title(pr_title: str) -> Tuple[str, str]:
     regex_pattern = re.compile(regex)
     err_msg = f"Pull request title {pr_title} does not follow the regex 'operator <operator_name> (<version>)"
 
-    # Check <version> for prefix 'v'
+    # Check <version> for prefix 'v' failure case and include additional error context
     regex_v = rf"^operator ([a-zA-Z0-9-]+) \((v[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9-]*)\)$"
     regex_pattern_v = re.compile(regex_v)
     err_msg_v = f" where <version> does not contain prefix 'v'"
@@ -274,9 +274,7 @@ def parse_pr_title(pr_title: str) -> Tuple[str, str]:
         err_msg = err_msg + err_msg_v
 
     if not regex_pattern.match(pr_title):
-        raise ValueError(
-                err_msg
-        )
+        raise ValueError(err_msg)
 
     matching = regex_pattern.search(pr_title)
     bundle_name = matching.group(1)

--- a/operator-pipeline-images/tests/test_operatorcert.py
+++ b/operator-pipeline-images/tests/test_operatorcert.py
@@ -273,9 +273,9 @@ def test_verify_changed_files_location(wrong_change: str):
         ("operator operator-test123 (1.0.1) aa", False, "", ""),
         ("operator  (1.0.1)", False, "", ""),
         ("operator-test123 (1.0.1)", False, "", ""),
-        ("operator-test123 (1.0.1)", False, "", ""),
+        ("operator operator-test123 (v1.0.1)", False, "", ""),
         ("operator oper@tor-test123 (1.0.1)", False, "", ""),
-        ("operator operator-test123 (1)", True, "operator-test123", "1"),
+        ("operator operator-test123 (1)", False, "operator-test123", "1"),
     ],
 )
 def test_parse_pr_title(pr_title: str, is_valid: bool, name: str, version: str):


### PR DESCRIPTION
Fixes ISVISSUE-420

Summary:
* The standard regex for PR title validation now checks for a simplified semantic version string (accepting only hyphenated build tags)
* There is a specific check for prefix "v" in the semver portion of a PR title that provides additional error info

Update 1:
* There was one duplicate test case that I changed to validate that a
  prefixed version such as (v1.0.1) would fail.
* There was another test case with a non-semantic version of (1) that is
  no longer valid with this new code

Update 2:
* Correct linting error due to new code in parse_pr_title function
* Elaborate in comment that the new code is for a specific failure case

