### PR TITLE
updating preflight task to use preflight v1.6.11

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:1ea7e8a892b39a187a99b1a3e084276b206a8fb797e440becbd5dcebba65fe3c
+      default: quay.io/redhat-isv/preflight-test@sha256:d990cbe8fb0db4dff0f7609403992f273f07d55f89dc7d2f046eb8f9c3e48110
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
Updating preflight tasks to latest release

```
⎈ |N/A:default)╭─acornett at acornett-mac in ~/go/src/github.com/acornett21/operator-pipelines on update_preflight_sha✘✘✘
╰─± crane digest quay.io/redhat-isv/preflight-test:1.6.8
sha256:1ea7e8a892b39a187a99b1a3e084276b206a8fb797e440becbd5dcebba65fe3c
(⎈ |N/A:default)╭─acornett at acornett-mac in ~/go/src/github.com/acornett21/operator-pipelines on update_preflight_sha✘✘✘
╰─± crane digest quay.io/redhat-isv/preflight-test:1.6.11
sha256:d990cbe8fb0db4dff0f7609403992f273f07d55f89dc7d2f046eb8f9c3e48110
```