### PR TITLE
Revert PR title version semver regex

### DIFF
--- a/operator-pipeline-images/operatorcert/__init__.py
+++ b/operator-pipeline-images/operatorcert/__init__.py
@@ -261,20 +261,14 @@ def parse_pr_title(pr_title: str) -> Tuple[str, str]:
     If yes, extract the Bundle name and version.
     """
     # Verify if PR title follows convention- it should contain the bundle name and version.
-    regex = rf"^operator ([a-zA-Z0-9-]+) \(([0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9-.]*)\)$"
+    # Any non- empty string without whitespaces makes a valid version.
+    regex = rf"^operator ([a-zA-Z0-9-]+) \(([^\s]+)\)$"
     regex_pattern = re.compile(regex)
-    err_msg = f"Pull request title {pr_title} does not follow the regex 'operator <operator_name> (<version>)"
-
-    # Check <version> for prefix 'v' failure case and include additional error context
-    regex_v = rf"^operator ([a-zA-Z0-9-]+) \((v[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9-.]*)\)$"
-    regex_pattern_v = re.compile(regex_v)
-    err_msg_v = f" where <version> does not contain prefix 'v'"
-
-    if regex_pattern_v.match(pr_title):
-        err_msg = err_msg + err_msg_v
 
     if not regex_pattern.match(pr_title):
-        raise ValueError(err_msg)
+        raise ValueError(
+            f"Pull request title {pr_title} does not follow the regex 'operator <operator_name> (<version>)"
+        )
 
     matching = regex_pattern.search(pr_title)
     bundle_name = matching.group(1)

--- a/operator-pipeline-images/tests/test_operatorcert.py
+++ b/operator-pipeline-images/tests/test_operatorcert.py
@@ -269,26 +269,13 @@ def test_verify_changed_files_location(wrong_change: str):
     "pr_title, is_valid, name, version",
     [
         ("operator operator-test123 (1.0.1)", True, "operator-test123", "1.0.1"),
-        ("operator operator-test123 (1.0.1-8)", True, "operator-test123", "1.0.1-8"),
-        (
-            "operator operator-test123 (1.0.1-8.0)",
-            True,
-            "operator-test123",
-            "1.0.1-8.0",
-        ),
-        (
-            "operator operator-test123 (1.0.1-rc.1.0)",
-            True,
-            "operator-test123",
-            "1.0.1-rc.1.0",
-        ),
         ("operator OPERATOR (1.0.1-ok)", True, "OPERATOR", "1.0.1-ok"),
         ("operator operator-test123 (1.0.1) aa", False, "", ""),
         ("operator  (1.0.1)", False, "", ""),
         ("operator-test123 (1.0.1)", False, "", ""),
-        ("operator operator-test123 (v1.0.1)", False, "", ""),
+        ("operator-test123 (1.0.1)", False, "", ""),
         ("operator oper@tor-test123 (1.0.1)", False, "", ""),
-        ("operator operator-test123 (1)", False, "operator-test123", "1"),
+        ("operator operator-test123 (1)", True, "operator-test123", "1"),
     ],
 )
 def test_parse_pr_title(pr_title: str, is_valid: bool, name: str, version: str):


### PR DESCRIPTION
Reverts #464 and #467

The PR title version validation introduced in #464 was meant to resolve ISVISSUE-420 and bring the PR title, bundle directory, and operator version (from the CSV.yaml) into alignment.

It was a simplified regex meant to enforce a rough semantic version in the PR title. This caused issues for another partner, where dots were used in the PR title version's suffix (which, are also semver-compliant). PR #467 was introduced to fix this bug.

The partner is still facing certification issues, specifically failing the PR title validation check of the hosted-pipeline, and this is occurring before errors/results get posted to the partner API.

Thus, the aforementioned PR's should be rolled back until further notice.