### PR TITLE
Parse supported ocp version

### DIFF
--- a/ansible/inventory/group_vars/operator-pipeline.yml
+++ b/ansible/inventory/group_vars/operator-pipeline.yml
@@ -56,7 +56,7 @@ community_signing_pipeline_route_name: "{{ community_signing_pipeline_name }}"
 community_signing_pipeline_url: "{{ community_signing_pipeline_name }}-tekton-{{ env }}.apps.pipelines-stage.0ce8.p1.openshiftapps.com"
 
 community_operator_hosted_pipeline_registry_auth_path: ../../vaults/{{ env }}/registry-auth/community-hosted-pipeline.json
-community_operator_pipeline_pending_namespace: "community-hosted-pipeline-{{ env }}"
+community_operator_pipeline_pending_namespace: "community-operator-pipeline-{{ env }}"
 
 nginx_basic_user_file_local_path: ../../vaults/common/htpasswd-nonprod
 nginx_proxy_service_url: "https://{{ community_signing_pipeline_url }}"

--- a/ansible/roles/operator-pipeline/tasks/community-hosted-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-hosted-pipeline-trigger.yml
@@ -66,6 +66,7 @@
               - name: git_commit_base
               - name: env
               - name: pipeline_image
+              - name: image_namespace
             resourcetemplates:
               - apiVersion: tekton.dev/v1beta1
                 kind: PipelineRun
@@ -104,6 +105,8 @@
                       value: $(tt.params.env)
                     - name: pipeline_image
                       value: $(tt.params.pipeline_image)
+                    - name: image_namespace
+                      value: $(tt.params.image_namespace)
                   workspaces:
                     - name: repository
                       volumeClaimTemplate:

--- a/ansible/roles/operator-pipeline/tasks/main.yml
+++ b/ansible/roles/operator-pipeline/tasks/main.yml
@@ -82,29 +82,13 @@
       with_items:
         - ../templates/openshift/pipelines/operator-ci-pipeline.yml
 
-    - name: Deploy pipeline (upstream)
-      tags:
-        - tekton-pipeline
-        - tekton-pipeline-upstream
-      k8s:
-        state: present
-        apply: true
-        namespace: "{{ oc_namespace }}"
-        definition: "{{ lookup('template', '{{ item }}') }}"
-      with_items:
-        - ../templates/upstream/pipelines/index-audit.yml
-      when:
-        - run_upstream is defined
-        - run_upstream | bool
+    - import_tasks: tasks/operator-pipeline-event-listener.yml
+    - import_tasks: tasks/community-pipeline-event-listener.yml
+    - import_tasks: tasks/operator-hosted-pipeline-trigger.yml
+    - import_tasks: tasks/operator-release-pipeline-trigger.yml
+    - import_tasks: tasks/community-hosted-pipeline-trigger.yml
+    - import_tasks: tasks/community-release-pipeline-trigger.yml
 
+    - import_tasks: tasks/community-signing.yml
 
-    - include_tasks: tasks/operator-pipeline-event-listener.yml
-    - include_tasks: tasks/community-pipeline-event-listener.yml
-    - include_tasks: tasks/operator-hosted-pipeline-trigger.yml
-    - include_tasks: tasks/operator-release-pipeline-trigger.yml
-    - include_tasks: tasks/community-hosted-pipeline-trigger.yml
-    - include_tasks: tasks/community-release-pipeline-trigger.yml
-
-    - include_tasks: tasks/community-signing.yml
-
-- include_tasks: tasks/operator-pipeline-webhooks.yml
+- import_tasks: tasks/operator-pipeline-webhooks.yml

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
@@ -125,7 +125,7 @@ spec:
         kind: Task
       params:
         - name: IMAGE
-          value: &bundleImage "$(params.registry)/community-$(params.image_namespace)/$(tasks.detect-changes.results.added_operator):$(tasks.detect-changes.results.added_bundle)"
+          value: &bundleImage "$(params.registry)/$(params.image_namespace)/$(tasks.detect-changes.results.added_operator):$(tasks.detect-changes.results.added_bundle)"
         - name: CONTEXT
           value: *addedBundlePath
       workspaces:
@@ -134,6 +134,21 @@ spec:
           subPath: src
         - name: credentials
           workspace: registry-credentials
+
+    - name: get-supported-versions
+      runAfter:
+        - build-bundle
+      taskRef:
+        name: get-supported-versions
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: bundle_path
+          value: *addedBundlePath
+      workspaces:
+        - name: source
+          workspace: repository
+          subPath: src
 
   finally:
 

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
@@ -87,6 +87,21 @@ spec:
           workspace: repository
           subPath: src
 
+    - name: get-supported-versions
+      runAfter:
+        - detect-changes
+      taskRef:
+        name: get-supported-versions
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: bundle_path
+          value: &addedBundlePath "operators/$(tasks.detect-changes.results.added_operator)/$(tasks.detect-changes.results.added_bundle)"
+      workspaces:
+        - name: source
+          workspace: repository
+          subPath: src
+
     # acquire/lease the resource to resolve the conflict of concurrent pipelineruns
     - name: acquire-lease
       runAfter:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/get-supported-versions.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/get-supported-versions.yml
@@ -11,14 +11,25 @@ spec:
   results:
     - name: max_supported_ocp_version
       description: Maximum version of OpenShift supported by this Operator
+
     - name: max_supported_index
       description: Pull spec for the index corresponding to the max OCP version
+
     - name: indices
       description: All known supported index image pull specs (space separated)
+
     - name: indices_ocp_versions
       description: All known supported OCP versions (space separated)
+
+    - name: skipped_ocp_versions
+      description: All known ocp index image pull specs not supported by the operator (space separated)
+
+    - name: skipped_ocp_indices
+      description: All known ocp version not supported by the operator (space separated)
+
     - name: max_version_indices
       description: Latest known supported OCP indices
+
     - name: ocp_version
       description: OCP version annotation of the bundle
   workspaces:
@@ -58,6 +69,16 @@ spec:
 
         echo $VERSION_INFO \
           | jq -r '.indices | map(.ocp_version) | join(" ")' \
+          | tr -d '\n\r' \
+          | tee $(results.indices_ocp_versions.path)
+
+        echo $VERSION_INFO \
+          | jq -r '.not_supported_indices | map(.path) | join(" ")' \
+          | tr -d '\n\r' \
+          | tee $(results.skipped_ocp_indices.path)
+
+        echo $VERSION_INFO \
+          | jq -r '.not_supported_indices | map(.ocp_version) | join(" ")' \
           | tr -d '\n\r' \
           | tee $(results.indices_ocp_versions.path)
 

--- a/operator-pipeline-images/operatorcert/entrypoints/ocp_version_info.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/ocp_version_info.py
@@ -17,7 +17,7 @@ def setup_argparser() -> argparse.ArgumentParser:  # pragma: no cover
     parser.add_argument("bundle_path", help="Location of operator bundle")
     parser.add_argument(
         "organization",
-        choices=("certified-operators", "redhat-marketplace"),
+        choices=("certified-operators", "redhat-marketplace", "community-operators"),
         help="Location of operator bundle",
     )
     parser.add_argument(


### PR DESCRIPTION
The OCP version range given by the operator is used to query Puxis to get list of supported ocp versions. The task from the ISV pipeline is reused and extended to also support list of versions that should be skipped.

JIRA: ISV-3834