### PR TITLE
[ISV-3902] Add a tekton task to trigger the prow tests

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
@@ -284,12 +284,32 @@ spec:
         - name: results
           workspace: results
 
+    - name: trigger-prow-tests
+      taskRef:
+        name: trigger-prow-tests
+        kind: Task
+      runAfter:
+        - add-bundle-to-index
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: request_url
+          value: "$(params.git_pr_url)"
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
+        - name: supported_ocp_versions
+          value: "$(tasks.get-supported-versions.results.indices_ocp_versions)"
+        - name: skipped_ocp_versions
+          value: "$(tasks.get-supported-versions.results.skipped_ocp_versions)"
+
     - name: wait-prow-tests
       taskRef:
         name: wait-prow-tests
         kind: Task
       runAfter:
-        - add-bundle-to-index
+        - trigger-prow-tests
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/trigger-prow-tests.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/trigger-prow-tests.yml
@@ -1,0 +1,73 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: trigger-prow-tests
+spec:
+  params:
+    - name: pipeline_image
+      description: | 
+        The common pipeline image.
+
+    - name: request_url
+      description: |
+        The GitHub issue or pull request URL where we want to add a new
+        comment.
+
+    - name: github_token_secret_name
+      description: |
+        The name of the Kubernetes Secret that contains the GitHub token.
+      default: github
+
+    - name: github_token_secret_key
+      description: |
+        The key within the Kubernetes Secret that contains the GitHub token.
+      default: token
+
+    - name: supported_ocp_versions
+      description: |
+        Space separated list of ocp versions supported by the pipeline
+        and the bundle.
+
+    - name: skipped_ocp_versions
+      description: |
+        Space separated list of ocp versions skipped for the bundle.
+
+    - name: github_host_url
+      description: |
+        The GitHub host, adjust this if you run a GitHub enterprise.
+      default: "https://api.github.com"
+
+  steps:
+    - name: add-labels-supported-skipped-versions
+      image: "$(params.pipeline_image)"
+      env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: "$(params.github_token_secret_name)"
+              key: "$(params.github_token_secret_key)"
+      script: |
+        #! /usr/bin/env bash
+        set -e
+        
+        supported_versions=()
+        for supported_version in $(params.supported_ocp_versions)
+        do
+          supported_versions+=("ocp/$supported_version/start")
+        done
+        
+        skipped_versions=()
+        for skipped_version in $(params.skipped_ocp_versions)
+        do
+          skipped_versions+=("ocp/$skipped_version/skip")
+        done
+
+        all_versions=()
+        all_versions+=("${supported_versions[@]}" "${skipped_versions[@]}")
+      
+        github-labels \
+          --github-host-url "$(params.github_host_url)" \
+          --pull-request-url "$(params.request_url)" \
+          --add-labels "${all_versions[@]}" \
+          --remove-matching-namespace-labels

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/trigger-prow-tests.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/trigger-prow-tests.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   params:
     - name: pipeline_image
-      description: | 
+      description: |
         The common pipeline image.
 
     - name: request_url
@@ -50,13 +50,13 @@ spec:
       script: |
         #! /usr/bin/env bash
         set -e
-        
+
         supported_versions=()
         for supported_version in $(params.supported_ocp_versions)
         do
           supported_versions+=("ocp/$supported_version/start")
         done
-        
+
         skipped_versions=()
         for skipped_version in $(params.skipped_ocp_versions)
         do
@@ -65,7 +65,7 @@ spec:
 
         all_versions=()
         all_versions+=("${supported_versions[@]}" "${skipped_versions[@]}")
-      
+
         github-labels \
           --github-host-url "$(params.github_host_url)" \
           --pull-request-url "$(params.request_url)" \

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/trigger-prow-tests.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/trigger-prow-tests.yml
@@ -11,8 +11,9 @@ spec:
 
     - name: request_url
       description: |
-        The GitHub issue or pull request URL where we want to add a new
-        comment.
+        The GitHub pull request URL where we want to add a labels
+        indicating which openshift versions should be included
+        and which versions should be skipped for prow operator testing.
 
     - name: github_token_secret_name
       description: |


### PR DESCRIPTION
Tekton task reusing versions parsed by get-supported-versions previous task and labeling PR for subsequent prow test execution or skipping.

Tested here: https://github.com/redhat-openshift-ecosystem/community-operators-pipeline-preprod/pull/35