### PR TITLE
[ISV-3500] add missing tasks to community release pipeline

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/community-release-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-release-pipeline-trigger.yml
@@ -30,12 +30,16 @@
                 value: $(body.pull_request.merge_commit_sha)
               - name: git_commit_base
                 value: $(body.pull_request.base.sha)
+              - name: git_head_sha
+                value: $(body.pull_request.head.sha)
               - name: env
                 value: "{{ env }}"
               - name: pipeline_image
                 value: "{{ operator_pipeline_image_pull_spec }}"
               - name: metrics_endpoint
                 value: "{{ pipelines_metrics_endpoint }}"
+              - name: image_namespace
+                value: "{{ community_operator_pipeline_pending_namespace }}"
 
     - name: Create Community release pipeline Trigger Binding
       k8s:
@@ -59,9 +63,11 @@
               - name: git_username
               - name: git_commit
               - name: git_commit_base
+              - name: git_head_sha
               - name: env
               - name: pipeline_image
               - name: metrics_endpoint
+              - name: image_namespace
             resourcetemplates:
               - apiVersion: tekton.dev/v1beta1
                 kind: PipelineRun
@@ -94,12 +100,16 @@
                       value: $(tt.params.git_commit)
                     - name: git_commit_base
                       value: $(tt.params.git_commit_base)
+                    - name: git_head_sha
+                      value: $(tt.params.git_head_sha)
                     - name: env
                       value: $(tt.params.env)
                     - name: pipeline_image
                       value: $(tt.params.pipeline_image)
                     - name: metrics_endpoint
                       value: $(tt.params.metrics_endpoint)
+                    - name: image_namespace
+                      value: $(tt.params.image_namespace)
                   workspaces:
                     - name: repository
                       volumeClaimTemplate:
@@ -117,3 +127,6 @@
                           resources:
                             requests:
                               storage: 100Mi
+                    - name: registry-credentials
+                      secret:
+                        secretName: community-hosted-pipeline-registry-auth-secret

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
@@ -80,12 +80,23 @@ spec:
         - name: remove-matching-namespace-labels
           value: "true"
 
+    # set environment
+    - name: set-env-community
+      runAfter:
+        - set-github-started-label
+      taskRef:
+        name: set-env-community
+        kind: Task
+      params:
+        - name: env
+          value: $(params.env)
+
     - name: clone-repository
       taskRef:
         name: git-clone
         kind: Task
       runAfter:
-        - set-github-started-label
+        - set-env-community
       params:
         - name: url
           value: "$(params.git_fork_url)"
@@ -302,7 +313,7 @@ spec:
         # Production IIB instance doesn't support the upgrade path feature yet.
         # TODO: switch it to PROD when the feature is available
         - name: iib_url
-          value: https://iib.stage.engineering.redhat.com
+          value: "$(tasks.set-env-community.results.iib_url)"
       workspaces:
         - name: credentials
           workspace: registry-credentials

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
@@ -264,20 +264,6 @@ spec:
           workspace: repository
           subPath: signing
 
-    # publish to index
-    - name: publish-to-index
-      runAfter:
-        - upload-signature
-      taskRef:
-        name: publish-to-index
-      params:
-        - name: pipeline_image
-          value: "$(params.pipeline_image)"
-        - name: index_image_paths
-          value: "$(tasks.add-bundle-to-index.results.index_image_paths)"
-        - name: environment
-          value: "$(params.env)"
-
   finally:
     # Release the acquired resource
     - name: release-lease

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
@@ -16,6 +16,10 @@ spec:
     - name: pipeline_image
       default: "quay.io/redhat-isv/operator-pipelines-images:released"
 
+    - name: image_namespace
+      default: "$(context.pipelineRun.namespace)"
+      description: The namespace/organization all built images will be pushed to.
+
     - name: github_token_secret_name
       description: The name of the Kubernetes Secret that contains the GitHub token.
       default: github-bot-token
@@ -52,6 +56,10 @@ spec:
     - name: signing_pub_secret_key
       description: The key within the Kubernetes Secret that contains the public key for verifying signatures.
       default: sig-key.pub
+
+    - name: registry
+      description: Must be some variety of quay registry.
+      default: quay.io
 
   workspaces:
     - name: repository
@@ -184,6 +192,8 @@ spec:
         - name: index-image-destination
           value: "$(params.registry)/$(params.image_namespace)/catalog"
       workspaces:
+        - name: credentials
+          workspace: registry-credentials
         - name: results
           workspace: results
 

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
@@ -15,6 +15,7 @@ spec:
     - name: env
     - name: pipeline_image
       default: "quay.io/redhat-isv/operator-pipelines-images:released"
+
     - name: github_token_secret_name
       description: The name of the Kubernetes Secret that contains the GitHub token.
       default: github-bot-token
@@ -27,11 +28,37 @@ spec:
       description: Prometheus metrics endpoint
       default: http://pipeline-metrics.pipeline-metrics-prod
 
+    - name: umb_ssl_secret_name
+      description: Kubernetes secret that contains SSL files
+      default: operator-pipeline-api-certs
+    - name: umb_ssl_cert_secret_key
+      description: Kubernetes secret that contains SSL cert
+      default: operator-pipeline.key
+    - name: umb_ssl_key_secret_key
+      description: Kubernetes secret that contains SSL key
+
+    - name: kerberos_keytab_secret_name
+      description: >-
+        The name of the Kubernetes Secret that contains the kerberos keytab for submitting IIB builds.
+      default: kerberos-keytab
+    - name: kerberos_keytab_secret_key
+      description: >-
+        The key within the Kubernetes Secret that contains the kerberos keytab for submitting IIB builds.
+      default: krb5.keytab
+
+    - name: signing_pub_secret_name
+      description: The name of the Kubernetes Secret that contains the public key for verifying signatures.
+      default: signing-pub-key
+    - name: signing_pub_secret_key
+      description: The key within the Kubernetes Secret that contains the public key for verifying signatures.
+      default: sig-key.pub
+
   workspaces:
     - name: repository
     - name: results
     - name: ssh-dir
       optional: true
+    - name: registry-credentials
   tasks:
 
     # Set a initial PR label with indication that pipeline has started
@@ -52,12 +79,24 @@ spec:
         - name: remove-matching-namespace-labels
           value: "true"
 
+    # set environment
+    - name: set-env-community
+      runAfter:
+        - set-github-started-label
+      taskRef:
+        name: set-env-community
+        kind: Task
+      params:
+        - name: env
+          value: $(params.env)
+
+    # clone repository
     - name: clone-repository
       taskRef:
         name: git-clone
         kind: Task
       runAfter:
-        - set-github-started-label
+        - set-env-community
       params:
         - name: url
           value: $(params.git_repo_url)
@@ -74,6 +113,7 @@ spec:
         - name: ssh-directory
           workspace: ssh-dir
 
+    # detect changed operators
     - name: detect-changes
       taskRef:
         name: parse-repo-changes
@@ -92,6 +132,7 @@ spec:
           workspace: repository
           subPath: src
 
+    # get supported versions
     - name: get-supported-versions
       runAfter:
         - detect-changes
@@ -118,6 +159,124 @@ spec:
           value: "$(params.pipeline_image)"
         - name: lease-name
           value: "community-pipeline"
+
+    # call IIB to add the bundle to index
+    - name: add-bundle-to-index
+      runAfter:
+        - acquire-lease
+      taskRef:
+        name: add-bundle-to-index
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: index_images
+          value: "$(tasks.get-supported-versions.results.indices)"
+        - name: bundle_pullspec
+          value: "$(params.registry)/$(params.image_namespace)/$(tasks.detect-changes.results.added_operator):$(tasks.detect-changes.results.added_bundle)-$(params.git_commit)"
+        - name: iib_url
+          value: "$(tasks.set-env-community.results.iib_url)"
+        - name: environment
+          value: "$(params.env)"
+        - name: kerberos_keytab_secret_name
+          value: "$(params.kerberos_keytab_secret_name)"
+        - name: kerberos_keytab_secret_key
+          value: "$(params.kerberos_keytab_secret_key)"
+        - name: index-image-destination
+          value: "$(params.registry)/$(params.image_namespace)/catalog"
+      workspaces:
+        - name: results
+          workspace: results
+
+    # use manifest list digests from IIB output and get the manifest digests from registry
+    - name: get-manifest-digests
+      runAfter:
+        - add-bundle-to-index
+      taskRef:
+        name: get-manifest-digests
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: index_image_paths
+          value: "$(tasks.add-bundle-to-index.results.index_image_paths)"
+        - name: environment
+          value: "$(params.env)"
+
+    # send UMB message to sign the container image
+    - name: request-signature
+      runAfter:
+        - get-manifest-digests
+      taskRef:
+        name: request-signature
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: manifest_digest
+          value: "$(tasks.get-manifest-digests.results.manifest_digests)"
+        - name: reference
+          value: "$(tasks.get-manifest-digests.results.docker_references)"
+        - name: requester
+          value: "Allda"
+        - name: sig_key_id
+          value: "$(tasks.set-env-community.results.sig_key_id)"
+        - name: sig_key_name
+          value: "$(tasks.set-env-community.results.sig_key_name)"
+        - name: umb_client_name
+          value: "$(tasks.set-env-community.results.umb_client_name)"
+        - name: umb_url
+          value: "$(tasks.set-env-community.results.umb_url)"
+        - name: umb_ssl_secret_name
+          value: "$(params.umb_ssl_secret_name)"
+        - name: umb_ssl_cert_secret_key
+          value: "$(params.umb_ssl_cert_secret_key)"
+        - name: umb_ssl_key_secret_key
+          value: "$(params.umb_ssl_key_secret_key)"
+      workspaces:
+        - name: source
+          workspace: repository
+          subPath: signing
+
+    # upload signature
+    - name: upload-signature
+      runAfter:
+        - request-signature
+      taskRef:
+        name: upload-signature
+        bundle: "quay.io/redhat-isv/tkn-signing-bundle:4692680007"
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: signature_data_file
+          value: "$(tasks.request-signature.results.signature_data_file)"
+        - name: umb_ssl_secret_name
+          value: "$(params.umb_ssl_secret_name)"
+        - name: umb_ssl_cert_secret_key
+          value: "$(params.umb_ssl_cert_secret_key)"
+        - name: umb_ssl_key_secret_key
+          value: "$(params.umb_ssl_key_secret_key)"
+        - name: signing_pub_secret_name
+          value: "$(params.signing_pub_secret_name)"
+        - name: signing_pub_secret_key
+          value: "$(params.signing_pub_secret_key)"
+        - name: verify_signature
+          value: "true"
+      workspaces:
+        - name: source
+          workspace: repository
+          subPath: signing
+
+    # publish to index
+    - name: publish-to-index
+      runAfter:
+        - upload-signature
+      taskRef:
+        name: publish-to-index
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: index_image_paths
+          value: "$(tasks.add-bundle-to-index.results.index_image_paths)"
+        - name: environment
+          value: "$(params.env)"
 
   finally:
     # Release the acquired resource

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
@@ -12,6 +12,7 @@ spec:
     - name: git_username
     - name: git_commit
     - name: git_commit_base
+    - name: git_head_sha
     - name: env
     - name: pipeline_image
       default: "quay.io/redhat-isv/operator-pipelines-images:released"
@@ -35,11 +36,14 @@ spec:
     - name: umb_ssl_secret_name
       description: Kubernetes secret that contains SSL files
       default: operator-pipeline-api-certs
+
     - name: umb_ssl_cert_secret_key
       description: Kubernetes secret that contains SSL cert
-      default: operator-pipeline.key
+      default: operator-pipeline.pem
+
     - name: umb_ssl_key_secret_key
       description: Kubernetes secret that contains SSL key
+      default: operator-pipeline.key
 
     - name: kerberos_keytab_secret_name
       description: >-
@@ -171,7 +175,7 @@ spec:
     # call IIB to add the bundle to index
     - name: add-bundle-to-index
       runAfter:
-        - acquire-lease
+        - get-supported-versions
       taskRef:
         name: add-bundle-to-index
       params:
@@ -180,7 +184,7 @@ spec:
         - name: index_images
           value: "$(tasks.get-supported-versions.results.indices)"
         - name: bundle_pullspec
-          value: "$(params.registry)/$(params.image_namespace)/$(tasks.detect-changes.results.added_operator):$(tasks.detect-changes.results.added_bundle)-$(params.git_commit)"
+          value: "$(params.registry)/$(params.image_namespace)/$(tasks.detect-changes.results.added_operator):$(tasks.detect-changes.results.added_bundle)-$(params.git_head_sha)"
         - name: iib_url
           value: "$(tasks.set-env-community.results.iib_url)"
         - name: environment
@@ -191,6 +195,8 @@ spec:
           value: "$(params.kerberos_keytab_secret_key)"
         - name: index-image-destination
           value: "$(params.registry)/$(params.image_namespace)/catalog"
+        - name: index-image-destination-tag-suffix
+          value: "-$(params.git_head_sha)"
       workspaces:
         - name: credentials
           workspace: registry-credentials
@@ -225,7 +231,7 @@ spec:
         - name: reference
           value: "$(tasks.get-manifest-digests.results.docker_references)"
         - name: requester
-          value: "Allda"
+          value: "araszka"
         - name: sig_key_id
           value: "$(tasks.set-env-community.results.sig_key_id)"
         - name: sig_key_name
@@ -257,12 +263,14 @@ spec:
           value: "$(params.pipeline_image)"
         - name: signature_data_file
           value: "$(tasks.request-signature.results.signature_data_file)"
-        - name: umb_ssl_secret_name
+        - name: pyxis_ssl_secret_name
           value: "$(params.umb_ssl_secret_name)"
-        - name: umb_ssl_cert_secret_key
+        - name: pyxis_ssl_cert_secret_key
           value: "$(params.umb_ssl_cert_secret_key)"
-        - name: umb_ssl_key_secret_key
+        - name: pyxis_ssl_key_secret_key
           value: "$(params.umb_ssl_key_secret_key)"
+        - name: pyxis_url
+          value: "$(tasks.set-env-community.results.pyxis_url)"
         - name: signing_pub_secret_name
           value: "$(params.signing_pub_secret_name)"
         - name: signing_pub_secret_key

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
@@ -19,7 +19,7 @@ spec:
       default: token
     - name: force_merge
       description: The boolean which will indicate when to ignore the verification of ci.yaml file.
-      deafult: "false"
+      default: "false"
   workspaces:
     - name: source
   results:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env-community.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env-community.yml
@@ -21,6 +21,8 @@ spec:
       description: umb host to connect to for messaging, e.g. for signing
     - name: umb_client_name
       description: Client name to connect to umb, usually a service account name
+    - name: pyxis_url
+      description: Container API URL based for selected environment
   steps:
     - name: set-env-community
       image: "$(params.ubi8_minimal_image)"
@@ -42,6 +44,7 @@ spec:
                 SIG_KEY_NAME="containerisvsign"
                 UMB_URL="umb.api.redhat.com"
                 UMB_CLIENT_NAME="operatorpipelines"
+                PYXIS_URL="https://pyxis.engineering.redhat.com"
             ;;
             stage | integration-tests)
                 IIB_URL="https://iib.stage.engineering.redhat.com"
@@ -49,6 +52,7 @@ spec:
                 SIG_KEY_NAME="redhate2etesting"
                 UMB_URL="umb.stage.api.redhat.com"
                 UMB_CLIENT_NAME="nonprod-operatorpipelines"
+                PYXIS_URL="https://pyxis.stage.engineering.redhat.com"
             ;;
         esac
 
@@ -57,3 +61,4 @@ spec:
         echo -n $SIG_KEY_NAME | tee $(results.sig_key_name.path)
         echo -n $UMB_URL | tee $(results.umb_url.path)
         echo -n $UMB_CLIENT_NAME | tee $(results.umb_client_name.path)
+        echo -n $PYXIS_URL | tee $(results.pyxis_url.path)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env-community.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env-community.yml
@@ -29,14 +29,11 @@ spec:
       script: |
         #! /usr/bin/env bash
         set -xe
-        
         ENV="$(params.env)"
-        
         if ! [[ "$ENV" =~ ^(prod|stage)$ ]]; then
           echo "Unknown environment."
           exit1
         fi
-        
         case $ENV in
             prod)
                 IIB_URL="https://iib.engineering.redhat.com"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env-community.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env-community.yml
@@ -1,0 +1,59 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: set-env-community
+spec:
+  params:
+    - name: ubi8_minimal_image
+      description: ubi8 minimal image
+      default: "registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe"
+    - name: env
+      description: Environment. One of [prod, stage]
+  results:
+    - name: iib_url
+      description: IIB URL based on selected environment
+    - name: sig_key_id
+      description: The signing key id that index image claims are signed with
+    - name: sig_key_name
+      description: The signing key name that index image claims are signed with
+    - name: umb_url
+      description: umb host to connect to for messaging, e.g. for signing
+    - name: umb_client_name
+      description: Client name to connect to umb, usually a service account name
+  steps:
+    - name: set-env-community
+      image: "$(params.ubi8_minimal_image)"
+      script: |
+        #! /usr/bin/env bash
+        set -xe
+        
+        ENV="$(params.env)"
+        
+        if ! [[ "$ENV" =~ ^(prod|stage)$ ]]; then
+          echo "Unknown environment."
+          exit1
+        fi
+        
+        case $ENV in
+            prod)
+                IIB_URL="https://iib.engineering.redhat.com"
+                SIG_KEY_ID="4096R/55A34A82 SHA-256"
+                SIG_KEY_NAME="containerisvsign"
+                UMB_URL="umb.api.redhat.com"
+                UMB_CLIENT_NAME="operatorpipelines"
+            ;;
+            stage | integration-tests)
+                IIB_URL="https://iib.stage.engineering.redhat.com"
+                SIG_KEY_ID="4096R/37036783 SHA-256"
+                SIG_KEY_NAME="redhate2etesting"
+                UMB_URL="umb.stage.api.redhat.com"
+                UMB_CLIENT_NAME="nonprod-operatorpipelines"
+            ;;
+        esac
+
+        echo -n $IIB_URL | tee $(results.iib_url.path)
+        echo -n $SIG_KEY_ID | tee $(results.sig_key_id.path)
+        echo -n $SIG_KEY_NAME | tee $(results.sig_key_name.path)
+        echo -n $UMB_URL | tee $(results.umb_url.path)
+        echo -n $UMB_CLIENT_NAME | tee $(results.umb_client_name.path)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env-community.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env-community.yml
@@ -9,7 +9,7 @@ spec:
       description: ubi8 minimal image
       default: "registry.access.redhat.com/ubi8-minimal@sha256:54ef2173bba7384dc7609e8affbae1c36f8a3ec137cacc0866116d65dd4b9afe"
     - name: env
-      description: Environment. One of [prod, stage]
+      description: Environment. One of [dev, qa, stage, prod]
   results:
     - name: iib_url
       description: IIB URL based on selected environment
@@ -30,9 +30,9 @@ spec:
         #! /usr/bin/env bash
         set -xe
         ENV="$(params.env)"
-        if ! [[ "$ENV" =~ ^(prod|stage)$ ]]; then
+        if ! [[ "$ENV" =~ ^(prod|stage|qa|dev)$ ]]; then
           echo "Unknown environment."
-          exit1
+          exit 1
         fi
         case $ENV in
             prod)
@@ -50,6 +50,22 @@ spec:
                 UMB_URL="umb.stage.api.redhat.com"
                 UMB_CLIENT_NAME="nonprod-operatorpipelines"
                 PYXIS_URL="https://pyxis.stage.engineering.redhat.com"
+            ;;
+            qa)
+                IIB_URL="https://iib.stage.engineering.redhat.com"
+                SIG_KEY_ID="4096R/37036783 SHA-256"
+                SIG_KEY_NAME="redhate2etesting"
+                UMB_URL="umb.stage.api.redhat.com"
+                UMB_CLIENT_NAME="nonprod-operatorpipelines"
+                PYXIS_URL="https://pyxis.qa.engineering.redhat.com"
+            ;;
+            dev)
+                IIB_URL="https://iib.stage.engineering.redhat.com"
+                SIG_KEY_ID="4096R/37036783 SHA-256"
+                SIG_KEY_NAME="redhate2etesting"
+                UMB_URL="umb.stage.api.redhat.com"
+                UMB_CLIENT_NAME="nonprod-operatorpipelines"
+                PYXIS_URL="https://pyxis.dev.engineering.redhat.com"
             ;;
         esac
 


### PR DESCRIPTION
pipeline was tested in my namespace end-to-end from creating PR to merging it and it went successfully from start to end -> [PR](https://github.com/redhat-openshift-ecosystem/community-operators-pipeline-preprod/pull/68)

publish-to-index was skipped due to it will be implemented by ISV-3497
