### PR TITLE
Updated typo for default in tekton task merge-pr

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
@@ -19,7 +19,7 @@ spec:
       default: token
     - name: force_merge
       description: The boolean which will indicate when to ignore the verification of ci.yaml file.
-      deafult: "false"
+      default: "false"
   workspaces:
     - name: source
   results:


### PR DESCRIPTION
Tekton task `merge-pr` in `ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml` has typo in `default` for parameter `force_merge`.

Signed by : [apal@redhat.com](mailto:apal@redhat.com)