### PR TITLE
Parse update graph mode and pass it to IIB in release pipeline

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
@@ -310,8 +310,6 @@ spec:
           value: "-$(params.git_commit)"
         - name: upgrade-graph-mode
           value: "$(tasks.read-config.results.upgrade-graph-mode)"
-        # Production IIB instance doesn't support the upgrade path feature yet.
-        # TODO: switch it to PROD when the feature is available
         - name: iib_url
           value: "$(tasks.set-env-community.results.iib_url)"
       workspaces:

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
@@ -144,10 +144,26 @@ spec:
           workspace: repository
           subPath: src
 
+    - name: read-config
+      taskRef:
+        name: read-config
+        kind: Task
+      runAfter:
+        - detect-changes
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: operator_path
+          value: &addedOperatorPath "operators/$(tasks.detect-changes.results.added_operator)"
+      workspaces:
+        - name: source
+          workspace: repository
+          subPath: src
+
     # get supported versions
     - name: get-supported-versions
       runAfter:
-        - detect-changes
+        - read-config
       taskRef:
         name: get-supported-versions
       params:
@@ -175,7 +191,7 @@ spec:
     # call IIB to add the bundle to index
     - name: add-bundle-to-index
       runAfter:
-        - get-supported-versions
+        - acquire-lease
       taskRef:
         name: add-bundle-to-index
       params:
@@ -193,10 +209,8 @@ spec:
           value: "$(params.kerberos_keytab_secret_name)"
         - name: kerberos_keytab_secret_key
           value: "$(params.kerberos_keytab_secret_key)"
-        - name: index-image-destination
-          value: "$(params.registry)/$(params.image_namespace)/catalog"
-        - name: index-image-destination-tag-suffix
-          value: "-$(params.git_head_sha)"
+        - name: upgrade-graph-mode
+          value: "$(tasks.read-config.results.upgrade-graph-mode)"
       workspaces:
         - name: credentials
           workspace: registry-credentials


### PR DESCRIPTION
The update graph mode is parsed from the operator configuration and is passed to IIB build in release pipeline.

There are also other modification and fixes that haven't been caught during a review:
 - acquire lease is now correctly place in task dependency diagram
 - The add bundle to index in release pipeline doesn't need to copy output to a Quay repository - there is an other task responsible for this process

JIRA: ISV-3838