### PR TITLE
[ISV-3980] detect-changed-operators handles incorrectly rebased PRs

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
@@ -91,6 +91,7 @@ spec:
         - name: env
           value: $(params.env)
 
+    # Clone the repository contents from the PR branch
     - name: clone-repository
       taskRef:
         name: git-clone
@@ -102,8 +103,6 @@ spec:
           value: "$(params.git_fork_url)"
         - name: revision
           value: "$(params.git_pr_branch)"
-        - name: depth
-          value: 25
         - name: gitInitImage
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
       workspaces:
@@ -113,12 +112,33 @@ spec:
         - name: ssh-directory
           workspace: ssh-dir
 
+    # Clone the repository contents from the base branch
+    - name: clone-repository-base
+      taskRef:
+        name: git-clone
+        kind: Task
+      runAfter:
+        - clone-repository
+      params:
+        - name: url
+          value: "$(params.git_fork_url)"
+        - name: revision
+          value: "$(params.git_commit_base)"
+        - name: gitInitImage
+          value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
+      workspaces:
+        - name: output
+          workspace: repository
+          subPath: base
+        - name: ssh-directory
+          workspace: ssh-dir
+
     - name: detect-changes
       taskRef:
         name: parse-repo-changes
         kind: Task
       runAfter:
-        - clone-repository
+        - clone-repository-base
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
@@ -126,10 +146,19 @@ spec:
           value: "$(params.git_commit)"
         - name: base_commit
           value: "$(params.git_commit_base)"
+        - name: request_url
+          value: "$(params.git_pr_url)"
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
       workspaces:
-        - name: repo
+        - name: pr
           workspace: repository
           subPath: src
+        - name: base
+          workspace: repository
+          subPath: base
 
     # parse ci.yaml file and look for the reviewer and or author of the PR
     - name: get-ci-reviewer

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/parse-repo-changes.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/parse-repo-changes.yml
@@ -10,6 +10,15 @@ spec:
       description: Commit ID of the head of the PR
     - name: base_commit
       description: Commit ID of the base of the PR
+    - name: request_url
+      description: URL of the GitHub pull request we want to check
+      type: string
+    - name: github_token_secret_name
+      description: Name of the Kubernetes Secret that contains the GitHub token
+      default: github
+    - name: github_token_secret_key
+      description: Key within the Kubernetes Secret that contains the GitHub token
+      default: token
   results:
     - name: added_operator
       description: >
@@ -20,23 +29,28 @@ spec:
           New bundle version that have been added.
           Bundle version is in the format "bundle_version".
   workspaces:
-    - name: repo
-      description: Local repo clone
+    - name: pr
+      description: Clone of the repo at the PR head
+    - name: base
+      description: Clone of the repo at head of the base branch
   steps:
     - name: parse-repo-changes
       image: "$(params.pipeline_image)"
+      env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.github_token_secret_name)
+              key: $(params.github_token_secret_key)
       script: |
         #! /usr/bin/env bash
         set -xe
 
-        cd "$(workspaces.repo.path)"
-        git config --global --add safe.directory "$(workspaces.repo.path)"
-
         detect-changed-operators \
-          --repo-path="$(workspaces.repo.path)" \
-          --head-commit="$(params.head_commit)" \
-          --base-commit="$(params.base_commit)" \
-          --output-file /tmp/changes.json       \
+          --repo-path="$(workspaces.pr.path)" \
+          --base-repo-path="$(workspaces.base.path)" \
+          --pr-url="$(params.request_url)" \
+          --output-file /tmp/changes.json \
           --verbose
 
         function fail() {

--- a/operator-pipeline-images/operatorcert/entrypoints/detect_changed_operators.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/detect_changed_operators.py
@@ -2,12 +2,13 @@
 import argparse
 import json
 import logging
+import os
 import pathlib
-import tempfile
+import re
 from typing import Tuple, Optional, Set, Dict, List
-from git.repo import Repo as GitRepo
 from operator_repo import Repo as OperatorRepo
 
+from github import Auth, Github
 from operatorcert.logger import setup_logger
 
 LOGGER = logging.getLogger("operator-cert")
@@ -25,36 +26,104 @@ def setup_argparser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--repo-path",
+        type=pathlib.Path,
         help="Path to the root of the local clone of the repo",
         required=True,
     )
     parser.add_argument(
-        "--head-commit", help="Commit ID for the head of the PR", required=True
+        "--base-repo-path",
+        type=pathlib.Path,
+        help="Path to the root of the local clone of the base branch of the PR",
+        required=True,
     )
     parser.add_argument(
-        "--base-commit", help="Commit ID for the base of the PR", required=True
+        "--pr-url",
+        type=str,
+        help="URL of the corresponding pull request",
+        required=True,
     )
     parser.add_argument(
-        "--output-file", help="Path to a json file where results will be stored"
+        "--output-file",
+        type=pathlib.Path,
+        help="Path to a json file where results will be stored",
     )
     parser.add_argument("--verbose", action="store_true", help="Verbose output")
 
     return parser
 
 
-def detect_changed_operators(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
-    repo_path: str,
-    head_commit: str,
-    base_commit: str,
+def github_pr_affected_files(pr_url: str) -> set[str]:
+    """
+    Return the names of all files affected by the given pull request.
+    Will talk to the Github API authenticating using the token in the
+    GITHUB_TOKEN environment variable or using an unauthenticated request
+    if the GITHUB_TOKEN variable is not set.
+    Args:
+        pr_url: URL of the pull request
+
+    Returns:
+        A set containing the names of all the affected files
+    """
+    pr_url_re = re.compile(
+        r"https?://[^/]+/(?P<namespace>[^/]+)/(?P<reponame>[^/]+)/pull/(?P<pr_number>[0-9]+)"
+    )
+    pr_url_match = pr_url_re.match(pr_url)
+    if pr_url_match is None:
+        raise ValueError(f"Invalid pull request URL: {pr_url}")
+    repo_namespace = pr_url_match.group("namespace")
+    repo_name = pr_url_match.group("reponame")
+    pr_number = int(pr_url_match.group("pr_number"))
+    gh_token = os.environ.get("GITHUB_TOKEN")
+    if gh_token:
+        gh_auth = Auth.Token(gh_token)
+        github = Github(auth=gh_auth)
+    else:
+        github = Github()
+    gh_repo = github.get_repo(f"{repo_namespace}/{repo_name}")
+    gh_pr = gh_repo.get_pull(pr_number)
+    # Extract all unique names of changed files in the PR
+    return {x.filename for x in gh_pr.get_files()}
+
+
+def _find_owner(path: str) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Given a relative file name within an operator repo, return a pair
+    (operator_name, bundle_version) indicating what bundle the file belongs to.
+    If the file is outside a bundle directory, the returned bundle_version will
+    be None.
+    If the file is outside an operator directory, both operator_name and
+    bundle_version will be None.
+    Args:
+        path: Path to the file
+    Returns:
+        (operator_name, bundle_version) Operator/bundle the files belongs to
+    """
+    # split the relative filename into a tuple of individual components
+    filename_parts = pathlib.Path(path).parts
+    if len(filename_parts) < 3 or filename_parts[0] != "operators":
+        # path is outside an operator directory
+        return None, None
+    _, detected_operator_name, detected_bundle_version, *rest = filename_parts
+    if len(rest) < 1:
+        # inside an operator but not in a bundle (i.e.: the ci.yaml file)
+        return detected_operator_name, None
+    return detected_operator_name, detected_bundle_version
+
+
+def detect_changed_operators(  # pylint: disable=too-many-locals,too-many-branches
+    repo_path: pathlib.Path,
+    base_path: pathlib.Path,
+    pr_url: str,
 ) -> Dict[str, List[str]]:
     """
-    Given an operator repository and a pair of commits, returns a dictionary
-    containing information on what operators and bundles have been affected
-    by the changes and how.
+    Given two snapshots of an operator repository returns a dictionary
+    containing information on what operators and bundles have changed and how.
     Args:
-        repo_path: Path to the root of the operator repository
-        head_commit: Latest commit ID
-        base_commit: Commit ID the changes were based upon
+        repo_path: Path to the root of the snapshot of the operator repository
+            after the changes
+        base_path: Path to the root of the snapshot of the operator repository
+            before the changes
+        pr_url: URL of the corresponding GitHub pull request
 
     Returns:
         A dictionary containing the following fields:
@@ -78,123 +147,76 @@ def detect_changed_operators(  # pylint: disable=too-many-locals,too-many-branch
                 by the changes
     """
 
-    def _find_owner(path: str) -> Tuple[Optional[str], Optional[str]]:
-        """
-        Given a relative file name within an operator repo, return a pair
-        (operator_name, bundle_version) indicating what bundle the file belongs to.
-        If the file is outside a bundle directory, the returned bundle_version will
-        be None.
-        If the file is outside an operator directory, both operator_name and
-        bundle_version will be None.
-        Args:
-            path: Path to the file
-        Returns:
-            (operator_name, bundle_version) Operator/bundle the files belongs to
-        """
-        # split the relative filename into a tuple of individual components
-        filename_parts = pathlib.Path(path).parts
-        if len(filename_parts) < 3 or filename_parts[0] != "operators":
-            # path is outside an operator directory
-            return None, None
-        _, detected_operator_name, detected_bundle_version, *rest = filename_parts
-        if len(rest) < 1:
-            # inside an operator but not in a bundle (i.e.: the ci.yaml file)
-            return detected_operator_name, None
-        return detected_operator_name, detected_bundle_version
-
     LOGGER.debug("Detecting changes in repo at %s", repo_path)
 
-    with tempfile.TemporaryDirectory() as repo_clone_path:
-        # Phase 1: using the diff between PR head and base, detect which bundles
-        # have been affected by the PR
+    # Phase 1: using the diff between PR head and base, detect which bundles
+    # have been affected by the PR
 
-        git_repo_head = GitRepo(repo_path)
-        # Ensure the head commit is checked out (mostly needed for tests)
-        git_repo_head.head.reference = git_repo_head.create_head(  # type: ignore
-            "pr_head", head_commit, force=True
-        )
-        git_repo_head.head.reset(index=True, working_tree=True)
-        # Make a temporary clone of the repo and check out the base commit
-        git_repo_base = git_repo_head.clone(repo_clone_path)
-        git_repo_base.create_head("pr_head", head_commit, force=True)
-        git_repo_base.head.reference = git_repo_base.create_head(  # type: ignore
-            "pr_base", base_commit, force=True
-        )
-        git_repo_base.head.reset(index=True, working_tree=True)
+    affected_files = github_pr_affected_files(pr_url)
 
-        # Extract all unique names of changed files between pr_base and pr_head, including
-        # previous names for renamed files
-        affected_files = {
-            y
-            for x in git_repo_base.heads.pr_base.commit.diff("pr_head")
-            for y in (x.a_path, x.b_path)
-            if y
-            is not None  # According to the GitPython docs, a_path and b_path can be None
-        }
+    LOGGER.debug("Affected files: %s", affected_files)
 
-        LOGGER.debug("Affected files: %s", affected_files)
+    non_operator_files: Set[str] = set()
+    all_affected_bundles: Dict[str, Set[Optional[str]]] = {}
 
-        non_operator_files: Set[str] = set()
-        all_affected_bundles: Dict[str, Set[Optional[str]]] = {}
+    for filename in affected_files:
+        operator_name, bundle_version = _find_owner(filename)
+        if operator_name is None:
+            non_operator_files.add(filename)
+        else:
+            all_affected_bundles.setdefault(operator_name, set()).add(
+                # This is None for files within an operator but outside
+                # a bundle (i.e.: ci.yaml)
+                bundle_version
+            )
 
-        for filename in affected_files:
-            operator_name, bundle_version = _find_owner(filename)
-            if operator_name is None:
-                non_operator_files.add(filename)
+    LOGGER.debug("Affected bundles: %s", all_affected_bundles)
+    LOGGER.debug("Files not belonging to an operator: %s", non_operator_files)
+
+    # Phase 2: Now that we know which operators and bundles have changed, determine exactly
+    # what was added, modified or removed
+
+    added_operators: Set[str] = set()
+    modified_operators: Set[str] = set()
+    deleted_operators: Set[str] = set()
+    added_bundles: Set[Tuple[str, str]] = set()
+    modified_bundles: Set[Tuple[str, str]] = set()
+    deleted_bundles: Set[Tuple[str, str]] = set()
+
+    head_repo = OperatorRepo(repo_path)
+    base_repo = OperatorRepo(base_path)
+
+    for (  # pylint: disable=too-many-nested-blocks
+        operator_name,
+        operator_bundles,
+    ) in all_affected_bundles.items():
+        base_operator = None
+        head_operator = None
+        if head_repo.has(operator_name):
+            head_operator = head_repo.operator(operator_name)
+            if base_repo.has(operator_name):
+                base_operator = base_repo.operator(operator_name)
+                modified_operators.add(operator_name)
             else:
-                all_affected_bundles.setdefault(operator_name, set()).add(
-                    # This is None for files within an operator but outside
-                    # a bundle (i.e.: ci.yaml)
-                    bundle_version
-                )
-
-        LOGGER.debug("Affected bundles: %s", all_affected_bundles)
-        LOGGER.debug("Files not belonging to an operator: %s", non_operator_files)
-
-        # Phase 2: Now that we know which operators and bundles have changed, determine exactly
-        # what was added, modified or removed
-
-        added_operators: Set[str] = set()
-        modified_operators: Set[str] = set()
-        deleted_operators: Set[str] = set()
-        added_bundles: Set[Tuple[str, str]] = set()
-        modified_bundles: Set[Tuple[str, str]] = set()
-        deleted_bundles: Set[Tuple[str, str]] = set()
-
-        head_repo = OperatorRepo(repo_path)
-        base_repo = OperatorRepo(repo_clone_path)
-
-        for (  # pylint: disable=too-many-nested-blocks
-            operator_name,
-            operator_bundles,
-        ) in all_affected_bundles.items():
-            base_operator = None
-            head_operator = None
-            if head_repo.has(operator_name):
-                head_operator = head_repo.operator(operator_name)
-                if base_repo.has(operator_name):
-                    base_operator = base_repo.operator(operator_name)
-                    modified_operators.add(operator_name)
+                added_operators.add(operator_name)
+        else:
+            deleted_operators.add(operator_name)
+        for bundle_version in operator_bundles:
+            if bundle_version is not None:
+                if head_operator is None:
+                    # The operator is not present in the new commit, therefore
+                    # all of its bundles must have been removed too
+                    deleted_bundles.add((operator_name, bundle_version))
                 else:
-                    added_operators.add(operator_name)
-            else:
-                deleted_operators.add(operator_name)
-            for bundle_version in operator_bundles:
-                if bundle_version is not None:
-                    if head_operator is None:
-                        # The operator is not present in the new commit, therefore
-                        # all of its bundles must have been removed too
-                        deleted_bundles.add((operator_name, bundle_version))
-                    else:
-                        if head_operator.has(bundle_version):
-                            if base_operator is not None and base_operator.has(
-                                bundle_version
-                            ):
-                                modified_bundles.add((operator_name, bundle_version))
-                            else:
-                                added_bundles.add((operator_name, bundle_version))
+                    if head_operator.has(bundle_version):
+                        if base_operator is not None and base_operator.has(
+                            bundle_version
+                        ):
+                            modified_bundles.add((operator_name, bundle_version))
                         else:
-                            deleted_bundles.add((operator_name, bundle_version))
+                            added_bundles.add((operator_name, bundle_version))
+                    else:
+                        deleted_bundles.add((operator_name, bundle_version))
 
     LOGGER.debug("Added operators: %s", added_operators)
     LOGGER.debug("Modified operators: %s", modified_operators)
@@ -237,12 +259,12 @@ def main() -> None:
     # Logic
     result = detect_changed_operators(
         args.repo_path,
-        args.head_commit,
-        args.base_commit,
+        args.base_repo_path,
+        args.pr_url,
     )
 
     if args.output_file:
-        with open(args.output_file, "w", encoding="utf-8") as output_file:
+        with args.output_file.open(mode="w", encoding="utf-8") as output_file:
             json.dump(result, output_file)
     else:
         print(json.dumps(result))


### PR DESCRIPTION
The detect-changed-operators entry point now uses the github api to get the list of affected files instead of checking out the head of the base branch from the local clone.