### PR TITLE
Fix global variable usage

### DIFF
--- a/operator-pipeline-images/tests/entrypoints/test_request_signature.py
+++ b/operator-pipeline-images/tests/entrypoints/test_request_signature.py
@@ -22,11 +22,10 @@ def create_test_umb_client() -> UmbClient:
 def test_process_message_match(mock_exit: MagicMock) -> None:
     mock_request_id = "request123"
     request_signature.request_ids = [mock_request_id]
-    request_signature.result_file = "signing_response.json"
     mock_open = mock.mock_open()
     mock_msg = {"msg": {"request_id": mock_request_id}}
     with mock.patch("builtins.open", mock_open):
-        request_signature.process_message(json.dumps(mock_msg))
+        request_signature.process_message(json.dumps(mock_msg), "signing_response.json")
 
     mock_open.assert_called_once_with(
         f"{mock_request_id}-signing_response.json", "w", encoding="utf-8"
@@ -39,7 +38,7 @@ def test_process_message_no_match() -> None:
     mock_open = mock.mock_open()
     mock_msg = {"msg": {"request_id": "no-match"}}
     with mock.patch("builtins.open", mock_open):
-        request_signature.process_message(json.dumps(mock_msg))
+        request_signature.process_message(json.dumps(mock_msg), "signing_response.json")
 
     mock_open.assert_not_called()
 


### PR DESCRIPTION
The combination of global variable and variable shadowing caused a race condition that was only reproducible in containers. This commit removes the both anti-patterns and fixes the issue.