### PR TITLE
updating the acquire-lease logic to add retries and timeouts

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/operator-release-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-release-pipeline-trigger.yml
@@ -80,7 +80,7 @@
                     git_pull_request_url: $(tt.params.git_pr_url)
                     git_pull_request_title: $(tt.params.git_pr_title)
                 spec:
-                  timeout: "1h30m0s"
+                  timeout: "4h15m0s"
                   pipelineRef:
                     name: operator-release-pipeline
                   params:

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -442,6 +442,7 @@ spec:
 
     # acquire/lease the resource to resolve the conflict of concurrent pipelineruns
     - name: acquire-lease
+      retries: 8
       runAfter:
         - publish-resources
         - get-supported-versions

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/acquire-lock.yaml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/acquire-lock.yaml
@@ -83,3 +83,4 @@ spec:
         create_lease_yaml
         # Acquire Lease
         acquire_lease
+      timeout: "0h35m0s"


### PR DESCRIPTION
### Motivation
After seeing multiple issues where the release pipeline, is affectively single threaded and only can support 1 pull request (release) per hour, I started looking to see what configurations were available. 

### Details
The below changes are based on 'napkin math' that was observed when manually having to re-run release pipelines for an entire day. These are just meant to be a conversation starter about what can/should be improved, in the release pipeline. But ultimately, I would like at least `retries` to trickle down to all tasks that could have a timeout, that yields a manual re-run.

### Why Here?
Ideally, I'd love for downstream of the release pipeline to offer higher throughput, but that doesn't seem like it will happen, so hopefully we can make some improvements here that will lead to a better quality of life for ourselves and our users.