### PR TITLE
[ISV-4091] Align release pipeline to the new version of detect-changes

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
@@ -102,7 +102,7 @@ spec:
         - name: url
           value: "$(params.git_fork_url)"
         - name: revision
-          value: "$(params.git_pr_branch)"
+          value: "$(params.git_commit)"
         - name: gitInitImage
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
       workspaces:
@@ -121,7 +121,7 @@ spec:
         - clone-repository
       params:
         - name: url
-          value: "$(params.git_fork_url)"
+          value: "$(params.git_repo_url)"
         - name: revision
           value: "$(params.git_commit_base)"
         - name: gitInitImage

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
@@ -104,7 +104,7 @@ spec:
         - name: env
           value: $(params.env)
 
-    # clone repository
+    # Clone the repository contents from the PR branch
     - name: clone-repository
       taskRef:
         name: git-clone
@@ -113,11 +113,9 @@ spec:
         - set-env-community
       params:
         - name: url
-          value: $(params.git_repo_url)
+          value: "$(params.git_repo_url)"
         - name: revision
-          value: $(params.git_base_branch)
-        - name: depth
-          value: 25
+          value: "$(params.git_commit)"
         - name: gitInitImage
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
       workspaces:
@@ -127,24 +125,53 @@ spec:
         - name: ssh-directory
           workspace: ssh-dir
 
-    # detect changed operators
+    # Clone the repository contents from the base branch
+    - name: clone-repository-base
+      taskRef:
+        name: git-clone
+        kind: Task
+      runAfter:
+        - clone-repository
+      params:
+        - name: url
+          value: "$(params.git_repo_url)"
+        - name: revision
+          value: "$(params.git_commit_base)"
+        - name: gitInitImage
+          value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
+      workspaces:
+        - name: output
+          workspace: repository
+          subPath: base
+        - name: ssh-directory
+          workspace: ssh-dir
+
     - name: detect-changes
       taskRef:
         name: parse-repo-changes
         kind: Task
       runAfter:
-        - clone-repository
+        - clone-repository-base
       params:
         - name: pipeline_image
-          value: $(params.pipeline_image)
+          value: "$(params.pipeline_image)"
         - name: head_commit
-          value: $(params.git_commit)
+          value: "$(params.git_commit)"
         - name: base_commit
-          value: $(params.git_commit_base)
+          value: "$(params.git_commit_base)"
+        - name: request_url
+          value: "$(params.git_pr_url)"
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
       workspaces:
-        - name: repo
+        - name: pr
           workspace: repository
           subPath: src
+        - name: base
+          workspace: repository
+          subPath: base
 
     - name: read-config
       taskRef:


### PR DESCRIPTION
This fixes the usage of the detect-changes task in the release pipeline that I forgot to update when fixing the task behaviour.
Also update the input arguments of the git-clone tasks to be more specific and use the commit sha instead of the pr branch ref.