### PR TITLE
Fix line endings in the author_is_reviewer output of get-ci-reviewer

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/get-ci-reviewer.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/get-ci-reviewer.yml
@@ -43,10 +43,10 @@ spec:
         echo "Getting reviewers from the ci.yaml ..."
         if [ ! -e "$CI" ]; then
           echo >$(results.list_reviewers.path)
-          echo false >$(results.author_is_reviewer.path)
+          echo -n false >$(results.author_is_reviewer.path)
         else
           yq -r '(.reviewers//[])[]' $CI >$(results.list_reviewers.path)
-          yq -r ".reviewers//[]|index(\"$(params.git_username)\") != null" $CI >$(results.author_is_reviewer.path)
+          yq -r ".reviewers//[]|index(\"$(params.git_username)\") != null" $CI | tr -d '\r\n' >$(results.author_is_reviewer.path)
         fi
     - name: approve-pull-request
       env:


### PR DESCRIPTION
The end of line marker in the `author_is_reviewer` output causes the condition in [mege-pr](https://github.com/redhat-openshift-ecosystem/operator-pipelines/blob/862a3fcd5f0b565cef1a4a1f2ff00e1cf8364070/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml#L393) to be always false and therefore the auto-merge never happens.