### PR TITLE
updating preflight task to v1.7.0

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:d990cbe8fb0db4dff0f7609403992f273f07d55f89dc7d2f046eb8f9c3e48110
+      default: quay.io/redhat-isv/preflight-test@sha256:1532360a9f1cf6ee3529813490163c5521e94ead3ce6f5b15f97f7fb6e176012
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
- Moving preflight to the latest release

```
~
╰─○ crane digest quay.io/redhat-isv/preflight-test:1.6.11                  
sha256:d990cbe8fb0db4dff0f7609403992f273f07d55f89dc7d2f046eb8f9c3e48110
~
╰─○ crane digest quay.io/redhat-isv/preflight-test:1.7.0 
sha256:1532360a9f1cf6ee3529813490163c5521e94ead3ce6f5b15f97f7fb6e176012
```