### PR TITLE
[ISV-3498] Create an end-to-end test for the community operator pipeline

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,7 +12,7 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
 
 jobs:
-  run-integration-tests:
+  integration-tests-certified-operators:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,21 +27,25 @@ jobs:
           # Install python dependencies
           pip install --user openshift pygithub
 
-          echo ${{ secrets.VAULT_PASSWORD }} > $HOME/.vault-password
+          echo "${{ secrets.VAULT_PASSWORD }}" > "$HOME"/.vault-password
 
-          mkdir -p $HOME/.kube
+          # secret used also in hosted pipeline for enabling
+          # access to cluster for tkn command log accessing
+          mkdir -p "$HOME"/.kube
           ansible-vault decrypt \
-            --vault-password-file $HOME/.vault-password \
-            --output $HOME/.kube/config \
+            --vault-password-file "$HOME"/.vault-password \
+            --output "$HOME"/.kube/config \
             ansible/vaults/integration-tests/ci-pipeline-kubeconfig
 
-          mkdir -p $HOME/.ssh
+          # secret used also in hosted pipeline for enabling
+          # cloning of the repository
+          mkdir -p "$HOME"/.ssh
           ansible-vault decrypt \
-            --vault-password-file $HOME/.vault-password \
-            --output $HOME/.ssh/id_rsa \
+            --vault-password-file "$HOME"/.vault-password \
+            --output "$HOME"/.ssh/id_rsa \
             ansible/vaults/integration-tests/ci-pipeline-github-ssh-key
 
-      - name: Run the integration tests ansible playbook
+      - name: Run the certified operators integration tests ansible playbook
         uses: dawidd6/action-ansible-playbook@v2
         with:
           playbook: playbooks/operator-pipeline-integration-tests.yml
@@ -51,6 +55,54 @@ jobs:
           options: |
             -i inventory/operator-pipeline-integration-tests
             -e "oc_namespace=integration-tests-${{ github.run_number }}-${{ github.run_attempt }}"
+            -e "operator_bundle_version=0.1.${{ github.run_number }}-${{ github.run_attempt }}"
+            -e "operator_pipeline_image_tag=${{ github.sha }}"
+            -e "suffix=${{ steps.prepare.outputs.suffix }}"
+            -v
+
+  integration-tests-community-operators:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare
+        id: prepare
+        run: |
+          echo "suffix=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: Install dependencies
+        run: |
+          # Install python dependencies
+          pip install --user openshift pygithub
+
+          echo "${{ secrets.VAULT_PASSWORD }}" > "$HOME"/.vault-password
+
+          # secret used also in hosted pipeline for enabling
+          # access to cluster for tkn command log accessing
+          mkdir -p "$HOME"/.kube
+          ansible-vault decrypt \
+            --vault-password-file "$HOME"/.vault-password \
+            --output "$HOME"/.kube/config \
+            ansible/vaults/integration-tests/ci-pipeline-kubeconfig
+
+          # secret used also in hosted pipeline for enabling
+          # cloning of the repository
+          mkdir -p "$HOME"/.ssh
+          ansible-vault decrypt \
+            --vault-password-file "$HOME"/.vault-password \
+            --output "$HOME"/.ssh/id_rsa \
+            ansible/vaults/integration-tests/ci-pipeline-github-ssh-key
+
+      - name: Run the community operators integration tests ansible playbook
+        uses: dawidd6/action-ansible-playbook@v2
+        with:
+          playbook: playbooks/community-operators-integration-tests.yaml
+          directory: ./ansible
+          requirements: playbooks/requirements.yml
+          vault_password: ${{secrets.VAULT_PASSWORD}}
+          options: |
+            -i inventory/operator-pipeline-integration-tests
+            -e "oc_namespace=integration-tests-community-${{ github.run_number }}-${{ github.run_attempt }}"
             -e "operator_bundle_version=0.1.${{ github.run_number }}-${{ github.run_attempt }}"
             -e "operator_pipeline_image_tag=${{ github.sha }}"
             -e "suffix=${{ steps.prepare.outputs.suffix }}"

--- a/ansible/playbooks/community-operators-integration-tests.yaml
+++ b/ansible/playbooks/community-operators-integration-tests.yaml
@@ -1,0 +1,126 @@
+---
+- name: Execute integration tests
+  hosts: all
+  vars_files:
+    - ../vaults/{{ env }}/secret-vars.yml
+    - ../vaults/{{ env }}/ocp-token.yml
+  vars:
+    # Customized defaults for the test-e2e-community-operator package
+    git_upstream_repo: redhat-openshift-ecosystem/operator-pipelines-test
+    git_repo_url: "git@github.com:{{ git_upstream_repo }}.git"
+    git_upstream_branch: "{{ branch }}"
+    git_bundle_branch: "{{ branch }}-{{ operator_package_name }}-{{ operator_bundle_version }}"
+    src_operator_git_branch: e2e-community-test-operator
+    src_operator_bundle_version: 0.0.8
+    operator_package_name: test-e2e-community-operator
+    operator_pipeline_url: "https://community-operator-pipeline-{{ oc_namespace }}.apps.pipelines-stage.0ce8.p1.openshiftapps.com"
+    git_base_branch: community  # contains config.yaml containing pointer to community-operators index
+  environment:
+    K8S_AUTH_API_KEY: '{{ ocp_token }}'
+    K8S_AUTH_HOST: '{{ ocp_host }}'
+
+  tasks:
+    - block:
+        - name: Install CLI tools
+          tags:
+            - prepare-tools
+            - test-community-hosted-pipeline
+            - test-community-release-pipeline
+          include_role:
+            name: integration-tests
+            tasks_from: tools
+            apply:
+              tags:
+                - prepare-tools
+                - test-community-hosted-pipeline
+                - test-community-release-pipeline
+
+        - name: Deploy operator pipelines
+          tags:
+            - deploy-operator-pipelines
+          include_role:
+            name: operator-pipeline
+            apply:
+              tags:
+                - deploy-operator-pipelines
+
+        - name: Prepare integration test data
+          tags:
+            - prepare-test-data
+          include_role:
+            name: integration-tests
+            tasks_from: test_data
+            apply:
+              tags:
+                - prepare-test-data
+
+        - name: Prepare ci.yaml in target branch
+          tags:
+            - prepare-test-data
+          include_role:
+            name: integration-tests
+            tasks_from: prepare_ci_file
+            apply:
+              tags:
+                - prepare-test-data
+
+        - name: Open pull request to trigger hosted pipeline
+          tags:
+            - open-pull-request
+          include_role:
+            name: integration-tests
+            tasks_from: open_pull_request
+            apply:
+              tags:
+                - open-pull-request
+
+        - name: Verify the Community hosted pipeline run succeeds
+          tags:
+            - test-community-hosted-pipeline
+          vars:
+            pipeline_name: community-hosted-pipeline
+          include_role:
+            name: integration-tests
+            tasks_from: check_pipeline_run
+            apply:
+              tags:
+                - test-community-hosted-pipeline
+
+        - name: Verify the Community release pipeline run succeeds
+          tags:
+            - test-community-release-pipeline
+          vars:
+            pipeline_name: community-release-pipeline
+          include_role:
+            name: integration-tests
+            tasks_from: check_pipeline_run
+            apply:
+              tags:
+                - test-community-release-pipeline
+      ignore_errors: yes  # Enabling integration tests errors in ISV-4242
+      always:
+        - name: Cleanup test data
+          tags:
+            - clean
+            - clean-test-data
+          include_role:
+            name: integration-tests
+            tasks_from: clean
+            apply:
+              tags:
+                - clean
+                - clean-test-data
+
+        - name: Cleanup operator pipeline
+          tags:
+            - clean
+            - clean-deployment
+          include_role:
+            name: operator-pipeline
+            apply:
+              tags:
+                - clean
+                - clean-deployment
+          vars:
+            namespace_state: absent
+            github_webhook_state: absent

--- a/ansible/roles/integration-tests/tasks/check_pipeline_run.yml
+++ b/ansible/roles/integration-tests/tasks/check_pipeline_run.yml
@@ -12,6 +12,9 @@
           - "tekton.dev/pipeline={{ pipeline_name }}"
           - "suffix={{ suffix }}"
       register: pipeline_run
+      until: pipeline_run.resources | length > 0
+      retries: 5
+      delay: 5
       failed_when: pipeline_run.resources | length == 0
 
     - name: "Follow the {{ pipeline_name }} run logs"

--- a/ansible/roles/integration-tests/tasks/open_pull_request.yaml
+++ b/ansible/roles/integration-tests/tasks/open_pull_request.yaml
@@ -1,0 +1,21 @@
+---
+- name: Create a pull request
+  uri:
+    url: "https://api.github.com/repos/{{ git_upstream_repo }}/pulls"
+    method: POST
+    status_code: 201
+    headers:
+      Authorization: "token {{ ci_pipeline_github_personal_access_token }}"
+      Accept: application/vnd.github.v3+json
+    body_format: json
+    body:
+      title: "operator {{ operator_package_name }} ({{ operator_bundle_version }})"
+      body: E2e test for community operators
+      head: "{{ git_bundle_branch }}"
+      base: "{{ git_upstream_branch }}"
+  register: pr_response
+  no_log: true
+
+- name: Display PR response
+  debug:
+    var: pr_response

--- a/ansible/roles/integration-tests/tasks/prepare_ci_file.yaml
+++ b/ansible/roles/integration-tests/tasks/prepare_ci_file.yaml
@@ -1,0 +1,25 @@
+---
+- include_tasks: tasks/clone.yml
+
+- name: Prepare ci.yaml in target branch
+  tags:
+    - prepare-bundle
+  shell: |
+    UPSTREAM_BRANCH="{{ git_upstream_branch }}"
+    OPERATOR_PACKAGE_NAME="{{ operator_package_name }}"
+    SRC_BRANCH="{{ src_operator_git_branch }}"
+
+    git config user.name 'rh-operator-bundle-test-e2e'
+    git config user.email 'exd-guild-isv+operators-test-e2e@redhat.com'
+
+    git checkout "$UPSTREAM_BRANCH"
+
+    # Fetch the ci.yaml from SRC_BRANCH and place it in the working directory
+    git checkout "origin/$SRC_BRANCH" -- "operators/$OPERATOR_PACKAGE_NAME/ci.yaml"
+
+    git add "operators/$OPERATOR_PACKAGE_NAME/ci.yaml"
+    git commit -m "Copied ci.yaml from $SRC_BRANCH"
+    git push origin "$UPSTREAM_BRANCH"
+  args:
+    executable: /bin/bash
+    chdir: "{{ git_temp_dir.path }}"

--- a/ansible/roles/operator-pipeline/tasks/community-pipeline-event-listener.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-pipeline-event-listener.yml
@@ -34,6 +34,9 @@
                       - name: "addChangedFiles"
                         value:
                           enabled: true
+                          personalAccessToken:
+                            secretName: github-bot-token
+                            secretKey: github_bot_token
                   - ref:
                       name: cel
                     params:
@@ -64,6 +67,9 @@
                       - name: "addChangedFiles"
                         value:
                           enabled: true
+                          personalAccessToken:
+                            secretName: github-bot-token
+                            secretKey: github_bot_token
                   - ref:
                       name: cel
                     params:
@@ -96,6 +102,9 @@
                       - name: "addChangedFiles"
                         value:
                           enabled: true
+                          personalAccessToken:
+                            secretName: github-bot-token
+                            secretKey: github_bot_token
                   - ref:
                       name: cel
                     params:
@@ -126,6 +135,9 @@
                       - name: "addChangedFiles"
                         value:
                           enabled: true
+                          personalAccessToken:
+                            secretName: github-bot-token
+                            secretKey: github_bot_token
                   - ref:
                       name: cel
                     params:

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -359,6 +359,10 @@ spec:
           value: "$(tasks.get-cert-project-related-data.results.github_usernames)"
         - name: operator_name
           value: "$(tasks.validate-pr-title.results.operator_name)"
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
       workspaces:
         - name: source
           workspace: repository
@@ -525,6 +529,10 @@ spec:
           value: $(params.git_repo_url)
         - name: base_branch
           value: $(params.git_base_branch)
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
 
     # Build images- bundle and index and push them to registry.
     # Those steps are also a part of the CI pipeline.

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env-community.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/set-env-community.yml
@@ -30,7 +30,7 @@ spec:
         #! /usr/bin/env bash
         set -xe
         ENV="$(params.env)"
-        if ! [[ "$ENV" =~ ^(prod|stage|qa|dev)$ ]]; then
+        if ! [[ "$ENV" =~ ^(prod|stage|qa|dev|integration-tests)$ ]]; then
           echo "Unknown environment."
           exit 1
         fi

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/submission-validation.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/submission-validation.yml
@@ -15,12 +15,28 @@ spec:
       description: List of accounts with permissions allowing operator submission
     - name: operator_name
       description: name of the submitted operator
+
+    - name: github_token_secret_name
+      description: |
+        The name of the Kubernetes Secret that contains the GitHub token.
+      default: github-bot-token
+
+    - name: github_token_secret_key
+      description: |
+        The key within the Kubernetes Secret that contains the GitHub token.
+      default: github_bot_token
   workspaces:
     - name: source
   steps:
     - name: submission-validation
       workingDir: $(workspaces.source.path)
       image: "$(params.pipeline_image)"
+      env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: "$(params.github_token_secret_name)"
+              key: "$(params.github_token_secret_key)"
       script: |
         #! /usr/bin/env bash
         set -xe

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/verify-changed-directories.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/verify-changed-directories.yml
@@ -12,9 +12,25 @@ spec:
     - name: git_repo_url
     - name: base_branch
       default: main
+
+    - name: github_token_secret_name
+      description: |
+        The name of the Kubernetes Secret that contains the GitHub token.
+      default: github-bot-token
+
+    - name: github_token_secret_key
+      description: |
+        The key within the Kubernetes Secret that contains the GitHub token.
+      default: github_bot_token
   steps:
     - name: verify-changed-directories
       image: "$(params.pipeline_image)"
+      env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: "$(params.github_token_secret_name)"
+              key: "$(params.github_token_secret_key)"
       script: |
         #! /usr/bin/env bash
         set -xe

--- a/operator-pipeline-images/operatorcert/__init__.py
+++ b/operator-pipeline-images/operatorcert/__init__.py
@@ -251,7 +251,7 @@ def get_files_added_in_pr(
         f"https://api.github.com/repos/{organization}/{repository}"
         f"/compare/{base_branch}...{pr_head_label}"
     )
-    comparison = github.get(compare_changes_url, auth_required=False)
+    comparison = github.get(compare_changes_url, auth_required=True)
 
     added_files = []
     modified_files = []
@@ -370,7 +370,7 @@ def verify_pr_uniqueness(
 
     for repo in available_repositories:
         # List the open PRs in the given repositories,
-        pull_requests = github.get(base_url + repo + "/pulls", auth_required=False)
+        pull_requests = github.get(base_url + repo + "/pulls", auth_required=True)
 
         # find duplicates
         duplicate_prs = []

--- a/operator-pipeline-images/tests/test_operatorcert.py
+++ b/operator-pipeline-images/tests/test_operatorcert.py
@@ -208,7 +208,7 @@ def test_get_files_added_in_pr(mock_get: MagicMock) -> None:
     )
     mock_get.assert_called_with(
         "https://api.github.com/repos/rh/operator-repo/compare/main...user:fixup",
-        auth_required=False,
+        auth_required=True,
     )
     assert files == ["first", "second"]
 
@@ -226,7 +226,7 @@ def test_get_files_added_in_pr_changed_files(mock_get: MagicMock) -> None:
         operatorcert.get_files_added_in_pr("rh", "operator-repo", "main", "user:fixup")
     mock_get.assert_called_with(
         "https://api.github.com/repos/rh/operator-repo/compare/main...user:fixup",
-        auth_required=False,
+        auth_required=True,
     )
 
 
@@ -244,7 +244,7 @@ def test_get_files_added_in_pr_changed_ci_yaml(mock_get: MagicMock) -> None:
 
     mock_get.assert_called_with(
         "https://api.github.com/repos/rh/operator-repo/compare/main...user:fixup",
-        auth_required=False,
+        auth_required=True,
     )
 
     assert files == ["ci.yaml"]
@@ -356,8 +356,8 @@ def test_verify_pr_uniqueness(mock_get: MagicMock) -> None:
     mock_get.side_effect = pr_rsp
 
     assert mock_get.call_args_list == [
-        call("https://api.github.com/repos/org1/repo_a/pulls", auth_required=False),
-        call("https://api.github.com/repos/org2/repo_b/pulls", auth_required=False),
+        call("https://api.github.com/repos/org1/repo_a/pulls", auth_required=True),
+        call("https://api.github.com/repos/org2/repo_b/pulls", auth_required=True),
     ]
 
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
E2e testing logic implementation.

Change-log:
- [operator test data] Community operator data for testing: https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/tree/e2e-community-test-operator/operators/test-e2e-community-operator.
- Custom base branch (main for certified operators logic) bearing config.yaml with pointer to community-operators index has been created and referenced in community-operators-integration-tests playbook; https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/blob/community/config.yaml
- Prow tasks were disconnected from community hosted pipeline for the sake of of current design changes. Complete clean-up will be done separately in [ISV-4143].
- Community event listener interceptor [ISV-4140] and two certified operator tasks (submission-validation and verify-changed-directories) [ISV-4196] requests were parameterized with github authentication token to avoid github API rate limiting. This had to be done within this PR enabling effective development.

Deprecated:
- [CLOSED] Prow job configuration: https://github.com/openshift/release/pull/44011 - closed because of current design changes (using preflight instead own prow solution). 
- [REMOVED] Temp base branch for prow PR test: https://github.com/redhat-openshift-ecosystem/community-operators-pipeline-preprod/compare/integration-tests-community-operators - removed, all testing data and testing-PR-execution-env delegated to operator-pipelines-test repository.
- Whole integration tests logic is now running on PR but also after merging PR as previously. Community tests and certified operator tests are running in parallel, but within different branches and ocp namespaces. Delegated to ISV-4199 due to bloated scope of this task and security concerns.
