### PR TITLE
Re-trigger pipelines using labels

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/community-pipeline-event-listener.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-pipeline-event-listener.yml
@@ -20,7 +20,7 @@
             serviceAccountName: pipeline
             triggers:
               # run community hosted pipeline on PR opened, reopened, synchronized
-              - name: github-community-pull-request-listener
+              - name: github-community-pull-request-listener-hosted
                 interceptors:
                   - ref:
                       name: "github"
@@ -50,7 +50,7 @@
                 template:
                   ref: community-operator-hosted-pipeline-trigger-template
               # run community release pipeline on merged PR
-              - name: github-community-pull-request-listener
+              - name: github-community-pull-request-listener-release
                 interceptors:
                   - ref:
                       name: "github"
@@ -75,6 +75,66 @@
                             && body.pull_request.base.ref == "{{ branch }}"
                             && body.pull_request.merged == true
                             && extensions.changed_files.matches("operators/")
+                          )
+                bindings:
+                  - ref: community-operator-release-pipeline-trigger-binding
+                template:
+                  ref: community-operator-release-pipeline-trigger-template
+
+              # Run community hosted pipeline on pipeline/trigger-hosted label
+              - name: github-community-label-listener-hosted
+                interceptors:
+                  - ref:
+                      name: "github"
+                    params:
+                      - name: "secretRef"
+                        value:
+                          secretName: github-webhook-secret
+                          secretKey: webhook-secret
+                      - name: "eventTypes"
+                        value: ["pull_request"]
+                      - name: "addChangedFiles"
+                        value:
+                          enabled: true
+                  - ref:
+                      name: cel
+                    params:
+                      - name: filter
+                        value: >-
+                          (
+                            body.action == "labeled"
+                            && body.label.name == "pipeline/trigger-hosted"
+                            && body.pull_request.base.ref == "{{ branch }}"
+                          )
+                bindings:
+                  - ref: community-operator-hosted-pipeline-trigger-binding
+                template:
+                  ref: community-operator-hosted-pipeline-trigger-template
+
+              # Run community release pipeline on pipeline/trigger-release label
+              - name: github-community-label-listener-release
+                interceptors:
+                  - ref:
+                      name: "github"
+                    params:
+                      - name: "secretRef"
+                        value:
+                          secretName: github-webhook-secret
+                          secretKey: webhook-secret
+                      - name: "eventTypes"
+                        value: ["pull_request"]
+                      - name: "addChangedFiles"
+                        value:
+                          enabled: true
+                  - ref:
+                      name: cel
+                    params:
+                      - name: filter
+                        value: >-
+                          (
+                            body.action == "labeled"
+                            && body.label.name == "pipeline/trigger-release"
+                            && body.pull_request.base.ref == "{{ branch }}"
                           )
                 bindings:
                   - ref: community-operator-release-pipeline-trigger-binding

--- a/ansible/roles/operator-pipeline/tasks/operator-pipeline-event-listener.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-pipeline-event-listener.yml
@@ -20,7 +20,7 @@
             serviceAccountName: pipeline
             triggers:
               # run Hosted pipeline on PR opened, reopened, synchronized
-              - name: github-pull-request-listener
+              - name: github-pull-request-listener-hosted
                 interceptors:
                   - github:
                       secretRef:
@@ -40,7 +40,7 @@
                 template:
                   ref: operator-hosted-pipeline-trigger-template
               # run Hosted pipeline on PR labeled with label "pipeline/trigger-hosted"
-              - name: github-label-listener
+              - name: github-label-listener-hosted
                 interceptors:
                   - github:
                       secretRef:
@@ -60,7 +60,7 @@
                 template:
                   ref: operator-hosted-pipeline-trigger-template
               # run Release pipeline on merged PR
-              - name: github-pull-request-listener
+              - name: github-pull-request-listener-release
                 interceptors:
                   - github:
                       secretRef:
@@ -82,7 +82,7 @@
                 template:
                   ref: operator-release-pipeline-trigger-template
               # run Release pipeline on PR labeled with label "pipeline/trigger-release"
-              - name: github-label-listener
+              - name: github-label-listener-release
                 interceptors:
                   - github:
                       secretRef:


### PR DESCRIPTION
The label re-trigger mechanism is reused for community pipelines and each pipeline can be triggered by corresponding label on PR.

JIRA: ISV-4145