### PR TITLE
updating preflight task to v1.7.1

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:1532360a9f1cf6ee3529813490163c5521e94ead3ce6f5b15f97f7fb6e176012
+      default: quay.io/redhat-isv/preflight-test@sha256:742066031982c36e77164889c08e03413c0a119a25825c1cca2753796835ed32
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
moving to 1.7.1 for preflight task

```
╰─○ crane digest quay.io/redhat-isv/preflight-test:1.7.0
sha256:1532360a9f1cf6ee3529813490163c5521e94ead3ce6f5b15f97f7fb6e176012
╰─○ crane digest quay.io/redhat-isv/preflight-test:1.7.1
sha256:742066031982c36e77164889c08e03413c0a119a25825c1cca2753796835ed32
```