### PR TITLE
Add operator sdk static checks for community

### DIFF
--- a/operator-pipeline-images/Dockerfile
+++ b/operator-pipeline-images/Dockerfile
@@ -45,12 +45,12 @@ RUN dnf update -y && \
 COPY operator-pipeline-images/config/krb5.conf /etc/krb5.conf
 
 # Install oc, opm and operator-sdk CLI
-RUN curl -LO https://github.com/operator-framework/operator-registry/releases/download/v1.26.2/linux-${ARCH}-opm && \
+RUN curl -LO https://github.com/operator-framework/operator-registry/releases/download/v1.29.0/linux-${ARCH}-opm && \
     chmod +x linux-${ARCH}-opm && \
     mv linux-${ARCH}-opm /usr/local/bin/opm && \
-    curl -LO https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/latest-4.10/openshift-client-linux.tar.gz && \
+    curl -LO https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/stable-4.13/openshift-client-linux.tar.gz && \
     tar xzvf openshift-client-linux.tar.gz -C /usr/local/bin oc && \
-    curl -LO https://github.com/operator-framework/operator-sdk/releases/download/v1.31.0/operator-sdk_linux_${ARCH} && \
+    curl -LO https://github.com/operator-framework/operator-sdk/releases/download/v1.32.0/operator-sdk_linux_${ARCH} && \
     chmod +x operator-sdk_linux_${ARCH} && \
     mv operator-sdk_linux_${ARCH} /usr/local/bin/operator-sdk
 

--- a/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
+++ b/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
@@ -34,8 +34,10 @@ class GraphLoopException(Exception):
     """
 
 
-def check_osdk_bundle_validate(bundle: Bundle) -> Iterator[CheckResult]:
-    """Run `operator-sdk bundle validate` using operatorhub settings"""
+def run_operator_sdk_bundle_validate(
+    bundle: Bundle, test_suite_selector: str
+) -> Iterator[CheckResult]:
+    """Run `operator-sdk bundle validate` using given test suite settings"""
     cmd = [
         "operator-sdk",
         "bundle",
@@ -44,7 +46,7 @@ def check_osdk_bundle_validate(bundle: Bundle) -> Iterator[CheckResult]:
         "json-alpha1",
         bundle.root,
         "--select-optional",
-        "name=operatorhub",
+        test_suite_selector,
     ]
     sdk_result = json.loads(
         subprocess.run(
@@ -58,6 +60,18 @@ def check_osdk_bundle_validate(bundle: Bundle) -> Iterator[CheckResult]:
             yield Fail(output_message)
         else:
             yield Warn(output_message)
+
+
+def check_osdk_bundle_validate_operatorhub(bundle: Bundle) -> Iterator[CheckResult]:
+    """Run `operator-sdk bundle validate` using operatorhub settings"""
+    yield from run_operator_sdk_bundle_validate(bundle, "name=operatorhub")
+
+
+def check_osdk_bundle_validate_operator_framework(
+    bundle: Bundle,
+) -> Iterator[CheckResult]:
+    """Run `operator-sdk bundle validate` using operatorframework settings"""
+    yield from run_operator_sdk_bundle_validate(bundle, "suite=operatorframework")
 
 
 def check_required_fields(bundle: Bundle) -> Iterator[CheckResult]:


### PR DESCRIPTION
The new test suite for operator sdk was added. The old community pipeline also includes a community test suite but the current version of sdk marks it as deprecated and it will be removed in upcoming release.

JIRA: ISV-3785