### PR TITLE
Fix cert-project-check task

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/cert-project-check.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/cert-project-check.yml
@@ -25,7 +25,7 @@ spec:
 
         CI_FILE_PATH="$PKG_PATH/ci.yaml"
 
-        CERT_PROJECT_ID=$(cat $CI_FILE_PATH | yq -r '.cert_project_id')
+        CERT_PROJECT_ID=$(cat $CI_FILE_PATH | yq -r '.cert_project_id | select (.!=null)')
 
         if [ -z $CERT_PROJECT_ID ]; then
           echo "Certification project ID is missing in ci.yaml file (cert_project_id)"


### PR DESCRIPTION
When the project is missing in the ci.yaml file the error message was not raised and process continued with a project ID set to "null".

This commit fixes the check to detect the empty project id in config.