### PR TITLE
Use IIB to build ISV temporary index images

### DIFF
--- a/ansible/inventory/group_vars/operator-pipeline-prod.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-prod.yml
@@ -3,7 +3,13 @@ env: prod
 ocp_host: https://api.pipelines-prod.ijdb.p1.openshiftapps.com:6443
 branch: main
 operator_pipeline_webhook_secret: ../../vaults/prod/github-webhook-secret-prod.txt
-kerberos_keytab: ../../vaults/prod/operatorpipelines.keytab
+
+# TODO: change path to keytabs once keytabs are available
+kerberos_keytab_isv: ../../vaults/prod/operatorpipelines.keytab
+kerberos_keytab_isv_pending: ../../vaults/prod/operatorpipelines.keytab
+kerberos_keytab_community: ../../vaults/prod/operatorpipelines.keytab
+kerberos_keytab_community_pending: ../../vaults/prod/operatorpipelines.keytab
+
 preflight_trigger_environment: prod
 
 operator_pipeline_release_namespace: redhat-isv-operators

--- a/ansible/inventory/group_vars/operator-pipeline.yml
+++ b/ansible/inventory/group_vars/operator-pipeline.yml
@@ -12,7 +12,7 @@ ci_min_version: 0.0.0
 operator_pipeline_image_repo: quay.io/redhat-isv/operator-pipelines-images
 operator_pipeline_image_tag: latest
 operator_pipeline_image_pull_spec: "{{ operator_pipeline_image_repo }}:{{ operator_pipeline_image_tag }}"
-operator_pipeline_pending_namespace: "{{ oc_namespace }}"
+operator_pipeline_pending_namespace: "operator-pipeline-{{ env }}"
 
 tekton_pruner_keep: 10
 
@@ -43,7 +43,11 @@ operator_pipeline_gpg_passphrase_path: ../../vaults/{{ env }}/operator-pipeline-
 operator_pipeline_url: "https://operator-pipeline-{{ oc_namespace }}.apps.pipelines-stage.0ce8.p1.openshiftapps.com"
 operator_pipeline_webhook_secret: ../../vaults/common/github-webhook-secret-preprod.txt
 
-kerberos_keytab: ../../vaults/common/nonprod-operatorpipelines.keytab
+# TODO: change path to keytabs once keytabs are available
+kerberos_keytab_isv: ../../vaults/common/nonprod-operatorpipelines.keytab
+kerberos_keytab_isv_pending: ../../vaults/common/nonprod-operatorpipelines.keytab
+kerberos_keytab_community: ../../vaults/common/nonprod-operatorpipelines.keytab
+kerberos_keytab_community_pending: ../../vaults/common/nonprod-operatorpipelines.keytab
 
 pipelines_metrics_endpoint: http://pipeline-metrics.pipeline-metrics-nonprod
 

--- a/ansible/roles/operator-pipeline/tasks/pipeline-secrets.yml
+++ b/ansible/roles/operator-pipeline/tasks/pipeline-secrets.yml
@@ -187,7 +187,10 @@
           suffix: "{{ suffix }}"
           env: "{{ env }}"
       data:
-        krb5.keytab: "{{ lookup('file', kerberos_keytab, rstrip=False) | b64encode }}"
+        krb5-isv.keytab: "{{ lookup('file', kerberos_keytab_isv, rstrip=False) | b64encode }}"
+        krb5-isv-pending.keytab: "{{ lookup('file', kerberos_keytab_isv_pending, rstrip=False) | b64encode }}"
+        krb5-community.keytab: "{{ lookup('file', kerberos_keytab_community, rstrip=False) | b64encode }}"
+        krb5-community-pending.keytab: "{{ lookup('file', kerberos_keytab_community_pending, rstrip=False) | b64encode }}"
 
 - name: Create Operator pipeline IIB quay credentials secret
   no_log: true

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
@@ -42,8 +42,7 @@ spec:
     - name: kerberos_keytab_secret_key
       description: >-
         The key within the Kubernetes Secret that contains the kerberos keytab for submitting IIB builds.
-      default: krb5.keytab
-
+      default: krb5-community-pending.keytab
     - name: quay_oauth_secret_name
       default: community-quay-oauth-token
 

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
@@ -53,7 +53,7 @@ spec:
     - name: kerberos_keytab_secret_key
       description: >-
         The key within the Kubernetes Secret that contains the kerberos keytab for submitting IIB builds.
-      default: krb5.keytab
+      default: krb5-community.keytab
 
     - name: signing_pub_secret_name
       description: The name of the Kubernetes Secret that contains the public key for verifying signatures.

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -8,94 +8,140 @@ spec:
     # When adding a new param, make sure to also add it to the webhook in
     # operator-hosted-pipeline-trigger.yml if possible
     - name: git_pr_branch
+
     - name: git_pr_title
+
     - name: git_pr_url
+
     - name: git_fork_url
+
     - name: git_repo_url
+
     - name: git_username
+
     - name: git_commit
+
     - name: git_base_branch
       description: Name of the base branch. e.g. "main"
+
     - name: pr_head_label
+
     - name: env
       description: Which environment to run in. Can be one of [dev, qa, stage, prod]
       default: "prod"
+
     - name: preflight_min_version
+
     - name: preflight_trigger_environment
       description: Which openshift-ci step-registry steps and ProwJob templates to use. Can be one of [preprod, prod]
       default: "prod"
+
     - name: ci_min_version
+
     - name: registry
       description: Must be some variety of quay registry.
       default: quay.io
+
     - name: image_namespace
       default: $(context.pipelineRun.namespace)
       description: The namespace/organization all built images will be pushed to.
+
     - name: ignore_publishing_checklist
       default: "false"
       description: Ignore the results of the publishing checklist
+
     - name: pipeline_image
       description: An image of operator-pipeline-images.
       default: "quay.io/redhat-isv/operator-pipelines-images:released"
       # Kubernetes secrets related params, usually with default values
+
     - name: github_token_secret_name
       description: The name of the Kubernetes Secret that contains the GitHub token.
       default: github-bot-token
+
     - name: github_token_secret_key
       description: The key within the Kubernetes Secret that contains the GitHub token.
       default: github_bot_token
+
     - name: quay_oauth_secret_name
       default: quay-oauth-token
+
     - name: quay_oauth_secret_key
       default: token
+
     - name: hydra_secret_name
       description: Kubernetes secret name that contains the Hydra credentials.
       default: hydra-credentials
+
     - name: hydra_secret_sso_client_id_key
       description: |
         The key within the Kubernetes secret that contains Hydra SSO client ID.
       default: sso_client_id
+
     - name: hydra_secret_sso_client_secret_key
       description: |
         The key within the Kubernetes secret that contains the Hydra SSO password.
       default: sso_client_secret
+
     - name: hydra_sso_token_url
       description: SSO URL.
       default: https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token
+
     - name: pyxis_ssl_secret_name
       description: Kubernetes secret name that contains the Pyxis SSL files.
       default: operator-pipeline-api-certs
+
     - name: pyxis_ssl_cert_secret_key
       description: The key within the Kubernetes secret that contains the Pyxis SSL cert.
       default: operator-pipeline.pem
+
     - name: pyxis_ssl_key_secret_key
       description: The key within the Kubernetes secret that contains the Pyxis SSL key.
       default: operator-pipeline.key
+
+    - name: kerberos_keytab_secret_name
+      description: >-
+        The name of the Kubernetes Secret that contains the kerberos keytab for submitting IIB builds.
+      default: kerberos-keytab
+
+    - name: kerberos_keytab_secret_key
+      description: >-
+        The key within the Kubernetes Secret that contains the kerberos keytab for submitting IIB builds.
+      default: krb5-isv-pending.keytab
+
     - name: prow_kubeconfig_secret_name
       description: The name of the Kubernetes Secret that contains the prow kubeconfig for preflight tests.
       default: prow-kubeconfig
+
     - name: prow_kubeconfig_secret_key
       description: The key within the Kubernetes Secret that contains the prow kubeconfig for preflight tests.
       default: kubeconfig
+
     - name: preflight_decryption_key_secret_name
       description: The name of the Kubernetes Secret that contains the gpg decryption key.
       default: preflight-decryption-key
+
     - name: preflight_decryption_private_key_secret_key
       description: The key within the Kubernetes Secret that contains the gpg private key.
       default: private
+
     - name: preflight_decryption_public_key_secret_key
       description: The key within the Kubernetes Secret that contains the gpg public key.
       default: public
+
     - name: gpg_secret_name
       description: >-
         The name of the Kubernetes Secret that contains the GPG private key that is used for decryption of user's tokens.
       default: isv-gpg-key
+
     - name: gpg_key_secret_key
       description: The key within the Kubernetes Secret that contains the gpg key.
       default: operator-pipeline-gpg.key
+
     - name: gpg_passphrase_secret_key
       description: The key within the Kubernetes Secret that contains the gpg passphrase.
       default: operator-pipeline-gpg.passphrase
+
     - name: metrics_endpoint
       description: Prometheus metrics endpoint
       default: http://pipeline-metrics.pipeline-metrics-prod
@@ -587,50 +633,41 @@ spec:
         - name: oauth_secret_key
           value: "$(params.quay_oauth_secret_key)"
 
-    # Index image contains a record of bundle images from which
-    # manifests could be extract in order to install an operator.
-    - name: generate-index
+
+    # Build new temporary index using IIB
+    - name: add-bundle-to-index
       runAfter:
-        - build-bundle
+        - make-bundle-repo-public
       taskRef:
-        name: generate-index
+        name: add-bundle-to-index
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
-        - name: bundle_image
-          value: *bundleImage
-        - name: from_index
+        - name: index_images
           value: "$(tasks.get-supported-versions.results.max_supported_index)"
+        - name: bundle_pullspec
+          value: *bundleImage
+        - name: environment
+          value: "$(params.env)"
+        - name: kerberos_keytab_secret_name
+          value: "$(params.kerberos_keytab_secret_name)"
+        - name: kerberos_keytab_secret_key
+          value: "$(params.kerberos_keytab_secret_key)"
+        - name: index-image-destination
+          value: &tempIndexRepo "$(params.registry)/$(params.image_namespace)/$(tasks.validate-pr-title.results.operator_name)-index"
+        - name: index-image-destination-tag-suffix
+          value: "-$(params.git_commit)"
+        - name: iib_url
+          value: "$(tasks.set-env.results.iib_url)"
       workspaces:
-        - name: output
-          workspace: repository
-          subPath: index
         - name: credentials
-          # Do not use registry-credentials-all. Project creds may replace quay.io push creds.
           workspace: registry-credentials
-
-    - name: build-index
-      runAfter:
-        - generate-index
-      taskRef:
-        name: buildah
-        kind: Task
-      params:
-        - name: IMAGE
-          value: &bundleIndexImage "$(params.registry)/$(params.image_namespace)/$(tasks.validate-pr-title.results.operator_name)-index:$(tasks.validate-pr-title.results.bundle_version)"
-        - name: DOCKERFILE
-          value: "$(tasks.generate-index.results.index_dockerfile)"
-      workspaces:
-        - name: source
-          workspace: repository
-          subPath: index
-        - name: credentials
-          # Do not use registry-credentials-all. Project creds may replace quay.io push creds.
-          workspace: registry-credentials
+        - name: results
+          workspace: results
 
     - name: make-index-repo-public
       runAfter:
-        - build-index
+        - add-bundle-to-index
       taskRef:
         name: set-quay-repo-visibility
       params:
@@ -693,7 +730,7 @@ spec:
           value: operator
         - name: bundle_index_image
           value: >-
-            $(params.registry)/$(params.image_namespace)/$(tasks.validate-pr-title.results.operator_name)-index:$(tasks.validate-pr-title.results.bundle_version)
+            $(params.registry)/$(params.image_namespace)/$(tasks.validate-pr-title.results.operator_name)-index:v$(tasks.get-supported-versions.results.max_supported_ocp_version)-$(params.git_commit)
         - name: bundle_image
           value: >-
             $(params.registry)/$(params.image_namespace)/$(tasks.validate-pr-title.results.operator_name):$(tasks.validate-pr-title.results.bundle_version)

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -71,7 +71,7 @@ spec:
     - name: kerberos_keytab_secret_key
       description: >-
         The key within the Kubernetes Secret that contains the kerberos keytab for submitting IIB builds.
-      default: krb5.keytab
+      default: krb5-isv.keytab
     - name: signing_pub_secret_name
       description: The name of the Kubernetes Secret that contains the public key for verifying signatures.
       default: signing-pub-key


### PR DESCRIPTION
The IIB is now part of isv hosted pipeline and builds temporary index images with a new bundle.

The kerberos for IIB is also configured as a separate keytab for each pipeline.

Note: one TODO will be removed once we have a new kerberos account and IIB gives us permission.

JIRA: ISV-4097