### PR TITLE
Add a check for updateGraph values in config

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -23,7 +23,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pdm sync -dG operator-pipelines-dev
           pdm sync -dG tox
 
       - name: Run Tests

--- a/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
+++ b/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
@@ -145,7 +145,11 @@ def check_dangling_bundles(bundle: Bundle) -> Iterator[CheckResult]:
     for channel in sorted(all_channels):
         channel_bundles = operator.channel_bundles(channel)
         channel_head = operator.head(channel)
-        graph = operator.update_graph(channel)
+        try:
+            graph = operator.update_graph(channel)
+        except NotImplementedError as exc:
+            yield Fail(str(exc))
+            return
         dangling_bundles = {
             x for x in channel_bundles if x not in graph and x != channel_head
         }
@@ -175,7 +179,11 @@ def check_upgrade_graph_loop(bundle: Bundle) -> Iterator[CheckResult]:
         visited: List[Bundle] = []
         try:
             channel_bundles = operator.channel_bundles(channel)
-            graph = operator.update_graph(channel)
+            try:
+                graph = operator.update_graph(channel)
+            except NotImplementedError as exc:
+                yield Fail(str(exc))
+                return
             follow_graph(graph, channel_bundles[0], visited)
         except GraphLoopException as exc:
             yield Fail(str(exc))

--- a/operator-pipeline-images/operatorcert/static_tests/community/operator.py
+++ b/operator-pipeline-images/operatorcert/static_tests/community/operator.py
@@ -9,7 +9,7 @@
 from collections.abc import Iterator
 
 from operator_repo import Operator
-from operator_repo.checks import CheckResult, Fail
+from operator_repo.checks import CheckResult, Fail, Warn
 
 
 def check_operator_name(operator: Operator) -> Iterator[CheckResult]:
@@ -17,3 +17,19 @@ def check_operator_name(operator: Operator) -> Iterator[CheckResult]:
     names = {bundle.csv_operator_name for bundle in operator}
     if len(names) > 1:
         yield Fail(f"Bundles use multiple operator names: {names}")
+
+
+def check_ci_upgrade_graph(operator: Operator) -> Iterator[CheckResult]:
+    """Ensure the operator has a valid upgrade graph for ci.yaml"""
+    upgrade_graph = operator.config.get("updateGraph")
+    if not upgrade_graph:
+        yield Warn(
+            "The 'updateGraph' option is missing in ci.yaml. "
+            "The default upgrade graph 'replaces-mode' will be used."
+        )
+    else:
+        allowed_graphs = ["replaces-mode", "semver-mode"]
+        if upgrade_graph not in allowed_graphs:
+            yield Fail(
+                f"The 'updateGraph' option in ci.yaml must be one of {allowed_graphs}"
+            )

--- a/operator-pipeline-images/tests/static_tests/community/test_operator.py
+++ b/operator-pipeline-images/tests/static_tests/community/test_operator.py
@@ -1,9 +1,15 @@
 from pathlib import Path
+from typing import Any
 
+import pytest
+import yaml
 from operator_repo import Repo
-
-from operatorcert.static_tests.community.operator import check_operator_name
-from tests.utils import create_files, bundle_files
+from operator_repo.checks import Fail, Warn
+from operatorcert.static_tests.community.operator import (
+    check_ci_upgrade_graph,
+    check_operator_name,
+)
+from tests.utils import bundle_files, create_files
 
 
 def test_check_operator_name(tmp_path: Path) -> None:
@@ -20,3 +26,54 @@ def test_check_operator_name(tmp_path: Path) -> None:
         ),
     )
     assert [x.kind for x in check_operator_name(operator)] == ["failure"]
+
+
+@pytest.mark.parametrize(
+    "graph_mode, expected",
+    [
+        pytest.param(
+            "",
+            {
+                Warn(
+                    "The 'updateGraph' option is missing in ci.yaml. The default upgrade graph 'replaces-mode' will be used."
+                )
+            },
+            id="empty",
+        ),
+        pytest.param(
+            "replaces-mode",
+            set(),
+            id="replaces",
+        ),
+        pytest.param(
+            "semver-mode",
+            set(),
+            id="semver",
+        ),
+        pytest.param(
+            "unknown-mode",
+            {
+                Fail(
+                    "The 'updateGraph' option in ci.yaml must be one of ['replaces-mode', 'semver-mode']",
+                )
+            },
+            id="unknown",
+        ),
+    ],
+)
+def test_check_ci_upgrade_graph(graph_mode: str, expected: Any, tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files(
+            "test-operator",
+            "0.0.1",
+            other_files={
+                "operators/test-operator/ci.yaml": {"updateGraph": graph_mode}
+            },
+        ),
+    )
+    repo = Repo(tmp_path)
+    operator = repo.operator("test-operator")
+    result = check_ci_upgrade_graph(operator)
+
+    assert set(result) == expected


### PR DESCRIPTION
The new check verifies that only allowed values are used in the config for updateGraph field and in case the value is missing the Warning is raised with an info that a default is used.

JIRA: ISV-4197