### PR TITLE
updating preflight trigger to be able to use new 4.14 cluster pool

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
@@ -10,7 +10,7 @@ spec:
       default: "quay.io/opdev/preflight-trigger:stable"
     - name: preflight_trigger_environment
       description: Which openshift-ci step-registry steps and ProwJob templates to use. Can be one of [preprod, prod]
-    - default: '4.13'
+    - default: '4.14'
       name: ocp_version
       type: string
     - default: trace
@@ -106,7 +106,7 @@ spec:
           fi
 
           # This is the maximum version supported by openshift-ci
-          DPTP_VER="4.13"
+          DPTP_VER="4.14"
           CP_VER="$(params.ocp_version)"
 
           if [ "$(printf '%s\n' "$DPTP_VER" "$CP_VER" | sort -V | head -n1)" == "$DPTP_VER" ]; then
@@ -164,7 +164,7 @@ spec:
               exit 0
           fi
 
-          DPTP_VER="4.13"
+          DPTP_VER="4.14"
           CP_VER="$(params.ocp_version)"
 
           if [ "$(printf '%s\n' "$DPTP_VER" "$CP_VER" | sort -V | head -n1)" == "$DPTP_VER" ]; then


### PR DESCRIPTION
- Enabling preflight-trigger to be able to use 4.14 cluster pool