### PR TITLE
Fix role name after refactoring

### DIFF
--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -5,7 +5,7 @@
     - ../vaults/{{ env }}/secret-vars.yml
     - ../vaults/{{ env }}/ocp-token.yml
   roles:
-    - operator-pipeline
+    - operator_pipeline
     - nginx_proxy
   environment:
     K8S_AUTH_API_KEY: '{{ ocp_token }}'

--- a/pdm.lock
+++ b/pdm.lock
@@ -306,8 +306,8 @@ name = "operator-repo"
 version = "0.1.0"
 requires_python = ">=3.9"
 git = "https://github.com/mporrato/operator-repo.git"
-ref = "v0.1.0"
-revision = "cca14ff23b7360c5bf8992f93a67a1499ea3a325"
+ref = "v0.1.1"
+revision = "2037e34ebff35d6c5247217a0611d615b9bbd8df"
 summary = "Library and utilities to handle repositories of kubernetes operators"
 dependencies = [
     "pyyaml>=6.0.1",
@@ -682,7 +682,7 @@ summary = "Backported and Experimental Type Hints for Python 3.7+"
 
 [[package]]
 name = "urllib3"
-version = "2.0.4"
+version = "2.0.7"
 requires_python = ">=3.7"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
 
@@ -741,7 +741,7 @@ dependencies = [
 lock_version = "4.2"
 cross_platform = true
 groups = ["default", "operatorcert", "operatorcert-dev", "tox"]
-content_hash = "sha256:9a7f70840e200a60f31cb9737770f1357326fa9501440ba83fc47ccb4b29dc05"
+content_hash = "sha256:e5621c373fad13eae81529342bfa554b477d93174eed95c9c20de0c7b3644184"
 
 [metadata.files]
 "argcomplete 3.1.1" = [
@@ -1502,9 +1502,9 @@ content_hash = "sha256:9a7f70840e200a60f31cb9737770f1357326fa9501440ba83fc47ccb4
     {url = "https://files.pythonhosted.org/packages/3c/8b/0111dd7d6c1478bf83baa1cab85c686426c7a6274119aceb2bd9d35395ad/typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
     {url = "https://files.pythonhosted.org/packages/ec/6b/63cc3df74987c36fe26157ee12e09e8f9db4de771e0f3404263117e75b95/typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
 ]
-"urllib3 2.0.4" = [
-    {url = "https://files.pythonhosted.org/packages/31/ab/46bec149bbd71a4467a3063ac22f4486ecd2ceb70ae8c70d5d8e4c2a7946/urllib3-2.0.4.tar.gz", hash = "sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11"},
-    {url = "https://files.pythonhosted.org/packages/9b/81/62fd61001fa4b9d0df6e31d47ff49cfa9de4af03adecf339c7bc30656b37/urllib3-2.0.4-py3-none-any.whl", hash = "sha256:de7df1803967d2c2a98e4b11bb7d6bd9210474c46e8a0401514e3a42a75ebde4"},
+"urllib3 2.0.7" = [
+    {url = "https://files.pythonhosted.org/packages/af/47/b215df9f71b4fdba1025fc05a77db2ad243fa0926755a52c5e71659f4e3c/urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
+    {url = "https://files.pythonhosted.org/packages/d2/b2/b157855192a68541a91ba7b2bbcb91f1b4faa51f8bae38d8005c034be524/urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
 ]
 "virtualenv 20.24.2" = [
     {url = "https://files.pythonhosted.org/packages/14/19/e266f07cf55155d5f45170bbe08c486d8a9a9ae17bc8983acb1c019a8dd4/virtualenv-20.24.2-py3-none-any.whl", hash = "sha256:43a3052be36080548bdee0b42919c88072037d50d56c28bd3f853cbe92b953ff"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,9 @@ operatorcert = [
     "PyGithub>=1.59.0",
     "GitPython>=3.1.37",
     "semver>=3.0.1",
-    "operator-repo@git+https://github.com/mporrato/operator-repo.git@v0.1.0",
     "openshift-client>=1.0.19",
+    "operator-repo @ git+https://github.com/mporrato/operator-repo.git@v0.1.1",
+    "urllib3>=2.0.7",
 ]
 
 [tool.pdm.dev-dependencies]


### PR DESCRIPTION
The role name uses underscore instead of the dash. This caused the role execution was skipped from the playbook.