### PR TITLE
Ignore static checks if PR labels is applied

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
@@ -277,10 +277,16 @@ spec:
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
+        - name: pull_request_url
+          value: "$(params.git_pr_url)"
         - name: operator_name
           value: "$(tasks.detect-changes.results.added_operator)"
         - name: bundle_version
           value: "$(tasks.detect-changes.results.added_bundle)"
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
       workspaces:
         - name: source
           workspace: repository

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/run-static-tests.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/run-static-tests.yml
@@ -10,11 +10,22 @@ spec:
     - name: pipeline_image
       description: The common pipeline image.
 
+    - name: pull_request_url
+      description: URL to Github pull request with a new bundle submission.
+
     - name: operator_name
       description: Name of the operator under test.
 
     - name: bundle_version
       description: Version of the bundle under test.
+
+    - name: github_token_secret_key
+      description: The key within the Kubernetes Secret that contains the GitHub token.
+      default: token
+
+    - name: github_token_secret_name
+      description: The name of the Kubernetes Secret that contains the GitHub token.
+      default: github
 
   results:
     - name: messages_count
@@ -34,15 +45,34 @@ spec:
     - name: run-suite
       image: "$(params.pipeline_image)"
       workingDir: $(workspaces.source.path)
+      env:
+        - name: GH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.github_token_secret_name)
+              key: $(params.github_token_secret_key)
       script: |
         #!/usr/bin/env bash
         set -xe
 
+        EXTRA_ARGS=""
+
+        # Get labels from the pull request
+        gh pr view "$(params.pull_request_url)" --json labels > labels.json
+
+        # Following command filters out labels that start with prefix and merge them to single string separated by comma
+        SKIP_TESTS=`jq -r '.labels[] | select(.name | startswith("tests/skip")) | .name' labels.json | paste -sd "," |sed 's/tests\/skip\///g'`
+
+        if [[ $SKIP_TESTS != "" ]]; then
+          echo "Following tests are skipped: $SKIP_TESTS"
+          EXTRA_ARGS+=" --skip-tests $SKIP_TESTS"
+        fi
+
         JSON_RESULTS_FILE="$(workspaces.output.path)/static-test-results.json"
 
-        static-tests --verbose                                  \
-          --output-file "$JSON_RESULTS_FILE"                    \
-          --repo-path "$(workspaces.source.path)"               \
+        static-tests --verbose \
+          --output-file "$JSON_RESULTS_FILE" \
+          --repo-path "$(workspaces.source.path)" $EXTRA_ARGS \
           "$(params.operator_name)" "$(params.bundle_version)"
 
         jq . <$JSON_RESULTS_FILE

--- a/operator-pipeline-images/tests/entrypoints/test_static_tests.py
+++ b/operator-pipeline-images/tests/entrypoints/test_static_tests.py
@@ -80,7 +80,7 @@ def test_static_tests_main(
     with patch("sys.argv", args):
         static_tests.main()
     mock_check_bundle.assert_called_once_with(
-        "/tmp/repo", "test-operator", "0.0.1", "operatorcert.static_tests.community"
+        "/tmp/repo", "test-operator", "0.0.1", "operatorcert.static_tests.community", []
     )
     assert capsys.readouterr().out.strip() == '{"foo": ["bar"]}'
     mock_logger.assert_called_once_with(level="INFO")
@@ -93,6 +93,7 @@ def test_static_tests_main(
     args = [
         "static-tests",
         "--repo-path=/tmp/other_repo",
+        "--skip-tests=check_123,check_456",
         "other-test-operator",
         "0.0.2",
         "--suite=other_suite",
@@ -103,7 +104,11 @@ def test_static_tests_main(
     with patch("sys.argv", args):
         static_tests.main()
     mock_check_bundle.assert_called_once_with(
-        "/tmp/other_repo", "other-test-operator", "0.0.2", "other_suite"
+        "/tmp/other_repo",
+        "other-test-operator",
+        "0.0.2",
+        "other_suite",
+        ["check_123", "check_456"],
     )
     assert out_file.read().strip() == '{"bar": ["baz"]}'
     mock_logger.assert_called_once_with(level="DEBUG")


### PR DESCRIPTION
The static checks can be skipped using labels on the PR. If a label is set on the PR a check given by the PR label name is skipped.

JIRA: ISV-4205