### PR TITLE
Fix static check by adding missing argument

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -522,10 +522,16 @@ spec:
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
+        - name: pull_request_url
+          value: "$(params.git_pr_url)"
         - name: operator_name
           value: "$(tasks.bundle-path-validation.results.package_name)"
         - name: bundle_version
           value: "$(tasks.bundle-path-validation.results.bundle_version)"
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
         - name: test_suite
           value: "operatorcert.static_tests.isv"
       workspaces:


### PR DESCRIPTION
The static check task has a required arguments that were missing in the isv hosted pipeline. This commit adds missing arguments and fixes the pipeline.