### PR TITLE
Set github PR title with operator name and version

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
@@ -204,13 +204,38 @@ spec:
           workspace: repository
           subPath: base
 
+    - name: set-github-pr-title
+      taskRef:
+        name: set-github-pr-title
+        kind: Task
+      runAfter:
+        - detect-changes
+      when:
+        - input: "$(tasks.detect-changes.results.added_bundle)"
+          operator: notin
+          values: [""]
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: pull_request_url
+          value: "$(params.git_pr_url)"
+        - name: operator_name
+          value: "$(tasks.detect-changes.results.added_operator)"
+        - name: bundle_version
+          value: "$(tasks.detect-changes.results.added_bundle)"
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
+
+
     # parse ci.yaml file and look for the reviewer and or author of the PR
     - name: get-ci-reviewer
       taskRef:
         name: get-ci-reviewer
         kind: Task
       runAfter:
-        - detect-changes
+        - set-github-pr-title
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/set-github-pr-title.yaml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/set-github-pr-title.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: set-github-pr-title
+spec:
+  params:
+    - name: pipeline_image
+      description: The common pipeline image.
+
+    - name: pull_request_url
+      description: URL to Github pull request with a new bundle submission.
+
+    - name: operator_name
+      description: A name of the operator that is added in a PR
+
+    - name: bundle_version
+      description: A version of the operator bundle that is added in a PR
+
+    - name: github_token_secret_name
+      description: The name of the Kubernetes Secret that contains the GitHub token.
+      default: github
+
+    - name: github_token_secret_key
+      description: The key within the Kubernetes Secret that contains the GitHub token.
+      default: token
+  steps:
+    - name: set-github-status
+      image: "$(params.pipeline_image)"
+      env:
+        - name: GH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.github_token_secret_name)
+              key: $(params.github_token_secret_key)
+      script: |
+        #! /usr/bin/env bash
+        set -ex
+
+        if [[ $(params.bundle_version) == "" ]]; then
+          echo "No bundles has been added"
+          exit 0
+        fi
+
+        gh pr edit --title "operator $(params.operator_name) ($(params.bundle_version))" "$(params.pull_request_url)"


### PR DESCRIPTION
The community hosted operator pipeline sets PR title based on an added operator. All PR titles will be formatted with operator name and version.

JIRA: ISV-4262