### PR TITLE
Add hints to a pipeline summary about pipeline restart

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
@@ -632,6 +632,12 @@ spec:
           value: "$(context.pipelineRun.name)"
         - name: upload_pipeline_logs
           value: "true"
+        - name: comment_suffix
+          value: |
+
+            ## Troubleshooting
+
+            Run \`/pipeline restart community-hosted-pipeline\` in case of pipeline failure to restart a pipeline.
       workspaces:
         - name: output
           workspace: results

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
@@ -474,6 +474,12 @@ spec:
           value: "$(context.pipelineRun.name)"
         - name: upload_pipeline_logs
           value: "true"
+        - name: comment_suffix
+          value: |
+
+            ## Troubleshooting
+
+            Run \`/pipeline restart community-release-pipeline\` in case of pipeline failure to restart a pipeline.
       workspaces:
         - name: output
           workspace: results

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -1201,6 +1201,8 @@ spec:
             ## Troubleshooting
 
             Please refer to the [troubleshooting guide](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md).
+
+            Run \`/pipeline restart operator-hosted-pipeline\` in case of pipeline failure to restart a pipeline.
       workspaces:
         - name: output
           workspace: results

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -789,6 +789,14 @@ spec:
           value: "$(params.github_token_secret_key)"
         - name: pipelinerun
           value: "$(context.pipelineRun.name)"
+        - name: comment_suffix
+          value: |
+
+            ## Troubleshooting
+
+            Please refer to the [troubleshooting guide](https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md).
+
+            Run \`/pipeline restart operator-release-pipeline\` in case of pipeline failure to restart a pipeline.
       workspaces:
         - name: output
           workspace: results


### PR DESCRIPTION
The user is now informed about how to restart a pipeline in case of failure. The comment is added to the pipeline summary with an PR command that reboots failed pipeline.

JIRA: ISV-4301