### PR TITLE
Enable community integration tests

### DIFF
--- a/ansible/playbooks/community-operators-integration-tests.yaml
+++ b/ansible/playbooks/community-operators-integration-tests.yaml
@@ -97,7 +97,7 @@
             apply:
               tags:
                 - test-community-release-pipeline
-      ignore_errors: yes  # Enabling integration tests errors in ISV-4242
+
       always:
         - name: Cleanup test data
           tags:


### PR DESCRIPTION
The community integration tests are now enable and failure of the test will block releases.

JIRA: ISV-4242