### PR TITLE
Allow skipping preflight tests using PR labels

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/evaluate-preflight-result.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/evaluate-preflight-result.yml
@@ -62,11 +62,24 @@ spec:
         #! /usr/bin/env bash
         set -e -o pipefail
 
+        EXTRA_ARGS=""
+
+        # Get labels from the pull request
+        gh pr view "$(params.request_url)" --json labels > labels.json
+
+        # Following command filters out labels that start with prefix and merge them to single string separated by comma
+        SKIP_TESTS=`jq -r '.labels[] | select(.name | startswith("tests/skip")) | .name' labels.json | paste -sd "," |sed 's/tests\/skip\///g'`
+
+        if [[ $SKIP_TESTS != "" ]]; then
+          echo "Following tests are skipped: $SKIP_TESTS"
+          EXTRA_ARGS+=" --skip-tests $SKIP_TESTS"
+        fi
+
         RESULT_FILE_FILTERED=community-results.json
 
         preflight-result-filter \
           --test-results "$(params.preflight_result_file_path)" \
-          --output-file $RESULT_FILE_FILTERED \
+          --output-file $RESULT_FILE_FILTERED $EXTRA_ARGS \
           --verbose
 
 

--- a/operator-pipeline-images/operatorcert/entrypoints/static_tests.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/static_tests.py
@@ -7,19 +7,9 @@ from typing import Any, Dict, List, Optional
 from operator_repo import Repo
 from operator_repo.checks import Fail, run_suite
 from operatorcert.logger import setup_logger
+from operatorcert.utils import SplitArgs
 
 LOGGER = logging.getLogger("operator-cert")
-
-
-class SplitArgs(argparse.Action):
-    """
-    Split comma separated list of arguments into a list
-    """
-
-    def __call__(
-        self, parser: Any, namespace: Any, values: Any, option_string: Any = None
-    ) -> None:
-        setattr(namespace, self.dest, values.split(","))
 
 
 def setup_argparser() -> argparse.ArgumentParser:

--- a/operator-pipeline-images/operatorcert/utils.py
+++ b/operator-pipeline-images/operatorcert/utils.py
@@ -1,4 +1,5 @@
 """Utility functions for operator certification."""
+import argparse
 import json
 import logging
 import os
@@ -99,3 +100,14 @@ def add_session_retries(
     adapter = HTTPAdapter(max_retries=retries)
     session.mount("http://", adapter)
     session.mount("https://", adapter)
+
+
+class SplitArgs(argparse.Action):
+    """
+    Split comma separated list of arguments into a list
+    """
+
+    def __call__(
+        self, parser: Any, namespace: Any, values: Any, option_string: Any = None
+    ) -> None:
+        setattr(namespace, self.dest, values.split(","))

--- a/operator-pipeline-images/tests/entrypoints/test_preflight_result_filter.py
+++ b/operator-pipeline-images/tests/entrypoints/test_preflight_result_filter.py
@@ -24,6 +24,7 @@ def test_main(
     args = MagicMock()
     args.test_results = "some_file"
     args.output_file = "tmp/output.json"
+    args.skip_tests = ["foo"]
     mock_setup_argparser.return_value.parse_args.return_value = args
     mock_parse_and_evaluate_results.return_value = {"foo": "bar"}
     mock_open = mock.mock_open(read_data="{}")
@@ -31,7 +32,7 @@ def test_main(
     with mock.patch("builtins.open", mock_open):
         main()
 
-    mock_parse_and_evaluate_results.assert_called_once_with({})
+    mock_parse_and_evaluate_results.assert_called_once_with({}, ["foo"])
     mock_json_dump.assert_called_once_with({"foo": "bar"}, ANY, indent=2)
 
 


### PR DESCRIPTION
By adding a label to a PR in format tests/skip/{test_name} admins can skip certain tests and make it optional.

JIRA: ISV-4316