### PR TITLE
Remove re-trigger label on pipeline startup

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
@@ -120,6 +120,8 @@ spec:
           value: "$(params.github_token_secret_key)"
         - name: add_labels
           value: "$(context.pipeline.name)/started"
+        - name: remove_labels
+          value: "pipeline/trigger-hosted"
         - name: remove-matching-namespace-labels
           value: "true"
 

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
@@ -86,6 +86,8 @@ spec:
           value: "$(params.github_token_secret_key)"
         - name: add_labels
           value: "$(context.pipeline.name)/started"
+        - name: remove_labels
+          value: "pipeline/trigger-release"
         - name: remove-matching-namespace-labels
           value: "true"
 

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -168,6 +168,8 @@ spec:
           value: "$(params.github_token_secret_key)"
         - name: add_labels
           value: "$(context.pipeline.name)/started"
+        - name: remove_labels
+          value: "pipeline/trigger-hosted"
         - name: remove-matching-namespace-labels
           value: "true"
 

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -102,6 +102,8 @@ spec:
           value: "$(params.github_token_secret_key)"
         - name: add_labels
           value: "$(context.pipeline.name)/started"
+        - name: remove_labels
+          value: "pipeline/trigger-release"
         - name: remove-matching-namespace-labels
           value: "true"
 

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/github_labels.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/github_labels.yml
@@ -19,13 +19,13 @@ spec:
 
     - name: add_labels
       description: |
-        The actual comment to add or the filename containing comment to post.
+        List of labels that will be added to a pull request.
       type: string
       default: ""
 
     - name: remove_labels
       description: |
-        The actual comment to add or the filename containing comment to post.
+        List of labels that will be removed from a pull request.
       type: string
       default: ""
 
@@ -61,11 +61,11 @@ spec:
 
         EXTRA_ARGS=""
         if [[ ! -z "$(params.add_labels)" ]]; then
-          EXTRA_ARGS+=" --add-label $(params.add_labels)"
+          EXTRA_ARGS+=" --add-labels $(params.add_labels)"
         fi
 
         if [[ ! -z "$(params.remove_labels)" ]]; then
-          EXTRA_ARGS+=" --remove-label $(params.remove_labels)"
+          EXTRA_ARGS+=" --remove-labels $(params.remove_labels)"
         fi
 
         if [[ "$(params.remove-matching-namespace-labels)" == "true" ]]; then


### PR DESCRIPTION
When a pipeline starts it removes the label that started the pipeline run. This way we can trigger a pipeline multiple times if needed and the label would not be blocking the retrigger mechanism.

JIRA: ISV-4326