### PR TITLE
Bugfix: Read config should not create a config if missing

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/read-config.yaml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/read-config.yaml
@@ -32,8 +32,8 @@ spec:
 
         if [ ! -f "$CONFIG_PATH" ]; then
             echo "Config file $CONFIG_PATH does not exist."
-            # The config is not present - let's make an empty config
-            echo "---" > $CONFIG_PATH
+            echo -n "replaces" | tee $(results.upgrade-graph-mode.path)
+            exit 0
         fi
 
         cat $CONFIG_PATH


### PR DESCRIPTION
The read config task created a ci config in case of missing. This feature cause an unexpected behaviour and followup tasks failed because of that. This time the read config returns a default value but doesn't create an empty config file.

JIRA: ISV-4330