### PR TITLE
Increase community release pipeline volume

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/community-release-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-release-pipeline-trigger.yml
@@ -113,7 +113,7 @@
                             - ReadWriteOnce
                           resources:
                             requests:
-                              storage: 100Mi
+                              storage: 5Gi
                     - name: results
                       volumeClaimTemplate:
                         spec:


### PR DESCRIPTION
The volume is not big enough to clone a production git repository. 5Gi make it the same as hosted pipelines.