### PR TITLE
updating preflight task to v1.8.0

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:685b2e2e3bd0cd2d93db22a84a3be609fc82e16c6670a9ceaf076ac4fa3d19b3
+      default: quay.io/redhat-isv/preflight-test@sha256:357120656118f87affca8b1355a3ae481fdc0597a24defb8b45d6da05960cb5a
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
Updating to 1.8.0

```
11:56:46 ~/code/go/src/github.com/redhat-openshift-ecosystem/operator-pipelines
 ❱ crane digest quay.io/redhat-isv/preflight-test:1.8.0
sha256:357120656118f87affca8b1355a3ae481fdc0597a24defb8b45d6da05960cb5a
```

From version 1.7.2

```
11:56:15 ~/code/go/src/github.com/redhat-openshift-ecosystem/operator-pipelines
 ❱ crane digest quay.io/redhat-isv/preflight-test:1.7.2
sha256:685b2e2e3bd0cd2d93db22a84a3be609fc82e16c6670a9ceaf076ac4fa3d19b3
```