### PR TITLE
[ISV-4331] Share all preflight artifacts with community users

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/evaluate-preflight-result.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/evaluate-preflight-result.yml
@@ -79,34 +79,26 @@ spec:
 
         preflight-result-filter \
           --test-results "$(params.preflight_result_file_path)" \
-          --output-file $RESULT_FILE_FILTERED $EXTRA_ARGS \
+          --output-file "$RESULT_FILE_FILTERED" $EXTRA_ARGS \
           --verbose
 
 
         echo "Posting GitHub comment to issue (or PR) $(params.request_url)"
 
-        FILES="$RESULT_FILE_FILTERED $(params.preflight_log_file_path)"
-
-        if [ -f "$(params.preflight_artifacts_output_dir)/preflight.stdout" ]; then
-            FILES+=" $(params.preflight_artifacts_output_dir)/preflight.stdout"
-        fi
-
-        if [ -f "$(params.preflight_artifacts_output_dir)/preflight.stderr" ]; then
-            FILES+=" $(params.preflight_artifacts_output_dir)/preflight.stderr"
-        fi
-
         create-github-gist \
           --pull-request-url "$(params.request_url)" \
-          --input-file $FILES \
-          --comment-prefix "Test artifacts: "
+          --comment-prefix "Test artifacts: " \
+          "$RESULT_FILE_FILTERED" \
+          "$(params.preflight_log_file_path)" \
+          "$(params.preflight_artifacts_output_dir)"
 
         # Did the tests pass?
         echo "Checking preflight test status"
-        CHECK_RESULTS=$(cat community-results.json | jq -r '.passed')
+        CHECK_RESULTS=$(jq -r '.passed' <"$RESULT_FILE_FILTERED")
         if [ $CHECK_RESULTS = "false" ]; then
           echo "Not all preflight tests passed."
-          cat community-results.json
-          echo "\n"
+          cat "$RESULT_FILE_FILTERED"
+          echo
 
           echo -n "failure" | tee $(results.test_result.path)
           exit 1

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
@@ -93,8 +93,8 @@ spec:
 
           PR_NAME="$(params.pipelinerun)"
           create-github-gist \
-            --input-file $PR_NAME/$(params.pipelinerun).log \
-            --output-file $PR_NAME/gits_output.json
+            --output-file "$PR_NAME/gits_output.json" \
+            "$PR_NAME/$(params.pipelinerun).log"
 
           echo "Logs have been successfully uploaded"
         fi

--- a/operator-pipeline-images/tests/entrypoints/test_create_github_gist.py
+++ b/operator-pipeline-images/tests/entrypoints/test_create_github_gist.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, patch, call
@@ -8,6 +9,7 @@ from operatorcert.entrypoints.create_github_gist import (
     setup_argparser,
     share_github_gist,
 )
+from tests.utils import create_files
 
 
 @patch("operatorcert.entrypoints.create_github_gist.json.dump")
@@ -24,21 +26,22 @@ def test_main(
     mock_share_github_gist: MagicMock,
     mock_json_dump: MagicMock,
     monkeypatch: Any,
+    tmp_path: Path,
 ) -> None:
+    create_files(tmp_path, {"some_file": "foo"})
     args = MagicMock()
-    args.input_file = ["some_file"]
-    args.output_file = "tmp/output.json"
+    args.input_path = [tmp_path / "some_file"]
+    args.output_file = tmp_path / "output.json"
     args.pull_request_url = "https://github.com/foo/bar/pull/123"
     args.comment_prefix = "prefix:"
     mock_setup_argparser.return_value.parse_args.return_value = args
 
-    mock_open = mock.mock_open(read_data="foo")
-
     monkeypatch.setenv("GITHUB_TOKEN", "foo_api_token")
-    with mock.patch("builtins.open", mock_open):
-        main()
+    main()
 
-    mock_create_github_gist.assert_called_once_with(mock_github(), ["some_file"])
+    mock_create_github_gist.assert_called_once_with(
+        mock_github(), [tmp_path / "some_file"]
+    )
     mock_share_github_gist.assert_called_once_with(
         mock_github(), "foo/bar", 123, mock_create_github_gist.return_value, "prefix:"
     )
@@ -48,22 +51,38 @@ def test_main(
 
 
 @patch("operatorcert.entrypoints.create_github_gist.InputFileContent")
-def test_create_github_gist(mock_input_file_content: MagicMock) -> None:
-    mock_open = mock.mock_open(read_data="foo")
+def test_create_github_gist(
+    mock_input_file_content: MagicMock,
+    tmp_path: Path,
+) -> None:
+    create_files(
+        tmp_path,
+        {
+            "some_file": "foo",
+            "file2": "bar",
+            "subdir/nested/file3": "baz",
+            "subdir/nested/file4": "qux",
+        },
+    )
     mock_github = MagicMock()
 
     github_user = MagicMock()
     mock_github.get_user.return_value = github_user
     github_user.create_gist.return_value = MagicMock(html_url="some_url")
-    with mock.patch("builtins.open", mock_open):
-        resp = create_github_gist(mock_github, ["some_file", "file2"])
+    resp = create_github_gist(
+        mock_github, [tmp_path / "some_file", tmp_path / "file2", tmp_path / "subdir"]
+    )
 
-    mock_input_file_content.assert_has_calls([call("foo"), call("foo")])
+    mock_input_file_content.assert_has_calls(
+        [call("foo"), call("bar"), call("baz"), call("qux")]
+    )
     github_user.create_gist.assert_called_once_with(
         True,
         {
             "some_file": mock_input_file_content.return_value,
             "file2": mock_input_file_content.return_value,
+            "nested/file3": mock_input_file_content.return_value,
+            "nested/file4": mock_input_file_content.return_value,
         },
     )
     assert resp == github_user.create_gist.return_value

--- a/operator-pipeline-images/tests/entrypoints/test_create_github_gist.py
+++ b/operator-pipeline-images/tests/entrypoints/test_create_github_gist.py
@@ -74,7 +74,8 @@ def test_create_github_gist(
     )
 
     mock_input_file_content.assert_has_calls(
-        [call("foo"), call("bar"), call("baz"), call("qux")]
+        [call("foo"), call("bar"), call("baz"), call("qux")],
+        any_order=True,
     )
     github_user.create_gist.assert_called_once_with(
         True,


### PR DESCRIPTION
`create_github_gist` now accepts directories as input in addition to individual files.

For each directory specified as input, all files contained in that subtree are included in the gist using the name of the file relative to the specified directory. Behaviour for individual files remains the same.

The `--input-file` flag is now an argument instead, to allow the use of shell globbing if needed, and was renamed to `input_path` for clarity.

Example output [here](https://github.com/redhat-openshift-ecosystem/community-operators-pipeline-preprod/pull/208#issuecomment-1893550999).
