### PR TITLE
ISV-4298: override default timeout values for Import *-index imagestr…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           options: |
             --inventory inventory/operator-pipeline-dev
             --extra-vars "operator_pipeline_image_tag=${{ github.sha }} suffix=${{needs.prepare-env.outputs.short_sha}}"
-            --skip-tags ci
+            --skip-tags ci,import-index-images
             --verbose
 
   deploy-qa:
@@ -72,7 +72,7 @@ jobs:
           options: |
             --inventory inventory/operator-pipeline-qa
             --extra-vars "operator_pipeline_image_tag=${{ github.sha }} suffix=${{needs.prepare-env.outputs.short_sha}}"
-            --skip-tags ci
+            --skip-tags ci,import-index-images
             --verbose
 
   deploy-stage:
@@ -100,7 +100,7 @@ jobs:
           options: |
             --inventory inventory/operator-pipeline-stage
             --extra-vars "operator_pipeline_image_tag=${{ github.sha }} suffix=${{needs.prepare-env.outputs.short_sha}}"
-            --skip-tags ci
+            --skip-tags ci,import-index-images
             --verbose
 
   deploy-prod:
@@ -127,7 +127,7 @@ jobs:
           options: |
             --inventory inventory/operator-pipeline-prod
             --extra-vars "operator_pipeline_image_tag=${{ github.sha }} suffix=${{needs.prepare-env.outputs.short_sha}}"
-            --skip-tags ci
+            --skip-tags ci,import-index-images
             --verbose
 
   release:

--- a/ansible/roles/operator-pipeline/tasks/operator-pipeline-import-index-images.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-pipeline-import-index-images.yml
@@ -11,6 +11,7 @@
     # The 'or' condition is needed to support Ansible versions < 2.13
     validate_certs: "{{ lookup('env', 'K8S_AUTH_VERIFY_SSL', default='yes') or 'yes' }}"
     status_code: 201
+    timeout: 300
     body_format: json
     headers:
       Authorization: "Bearer {{ ocp_token }}"
@@ -45,6 +46,7 @@
     # The 'or' condition is needed to support Ansible versions < 2.13
     validate_certs: "{{ lookup('env', 'K8S_AUTH_VERIFY_SSL', default='yes') or 'yes' }}"
     status_code: 201
+    timeout: 300
     body_format: json
     headers:
       Authorization: "Bearer {{ ocp_token }}"


### PR DESCRIPTION
ISV-4298: override default timeout values for Import *-index imagestream tasks, to mitigate increased response times from import request

(timeout specified as integer seconds, default is 30)