### PR TITLE
updating preflight sha to point to new release of 1.8.1

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:357120656118f87affca8b1355a3ae481fdc0597a24defb8b45d6da05960cb5a
+      default: quay.io/redhat-isv/preflight-test@sha256:6cab9ab1e3196bd5931e6ad2ed03aca94e494db470be06b258779131ec57e7aa
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
```
╭─~/go/src/github.com/acornett21/operator-pipelines
╰─± crane digest quay.io/redhat-isv/preflight-test:1.8.0
sha256:357120656118f87affca8b1355a3ae481fdc0597a24defb8b45d6da05960cb5a
╭─~/go/src/github.com/acornett21/operator-pipelines
╰─± crane digest quay.io/redhat-isv/preflight-test:1.8.1
sha256:6cab9ab1e3196bd5931e6ad2ed03aca94e494db470be06b258779131ec57e7aa
```