### PR TITLE
[ISV-4438] Improve static check of metadata.anotations.alm-examples

### DIFF
--- a/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
+++ b/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
@@ -181,7 +181,6 @@ def check_required_fields(bundle: Bundle) -> Iterator[CheckResult]:
         ("metadata.annotations.createdAt", validate_timestamp, False),
         ("metadata.annotations.repository", re.compile(r"https?://.+"), False),
         ("metadata.annotations.support", re.compile(r".{3,}", re.DOTALL), False),
-        ("metadata.annotations.alm-examples", re.compile(r".{30,}", re.DOTALL), True),
         ("metadata.annotations.description", re.compile(r".{10,}", re.DOTALL), False),
         ("spec.displayName", re.compile(r".{3,50}"), True),
         ("spec.description", re.compile(r".{20,}", re.DOTALL), True),

--- a/operator-pipeline-images/tests/static_tests/community/test_bundle.py
+++ b/operator-pipeline-images/tests/static_tests/community/test_bundle.py
@@ -129,7 +129,6 @@ def _make_nested_dict(path: str, value: Any) -> Dict[str, Any]:
             "metadata.annotations.createdAt": ("", "warning", "invalid"),
             "metadata.annotations.repository": ("", "warning", "invalid"),
             "metadata.annotations.support": ("", "warning", "invalid"),
-            "metadata.annotations.alm-examples": ("", "failure", "invalid"),
             "metadata.annotations.description": ("", "warning", "invalid"),
             "spec.displayName": ("", "failure", "invalid"),
             "spec.description": ("", "failure", "invalid"),
@@ -161,11 +160,6 @@ def _make_nested_dict(path: str, value: Any) -> Dict[str, Any]:
             "metadata.annotations.support": (
                 "Accusamus quidem quam enim dolor.",
                 "warning",
-                "valid",
-            ),
-            "metadata.annotations.alm-examples": (
-                "Accusamus quidem quam enim dolor.",
-                "failure",
                 "valid",
             ),
             "metadata.annotations.description": (


### PR DESCRIPTION
The current implementation of `check_required_fields()` performs a very simple check of the `metadata.anotations.alm-examples` field that does not prevent the submission of a bundle with an incorrect alm-examples (for example when it does not contain a valid json list) and, in cases where the operator does not provide any CRD, it returns a false positive.

Since this check is already performed by `operator-sdk bundle validate` checks, we can remove the field check from `check_required_fields()` and let operator-sdk do the validation.