### PR TITLE
Merge PR if no bundle is added and ci.yaml is updated

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
@@ -598,14 +598,18 @@ spec:
           subPath: preflight-trigger
           workspace: results
 
+  finally:
     # merge PR
     - name: merge-pr
       when:
         - input: "$(tasks.get-ci-reviewer.results.author_is_reviewer)"
           operator: in
           values: ["true"]
-      runAfter:
-        - evaluate-preflight-result
+        - input: "$(tasks.status)"
+          operator: in
+          values:
+            - Succeeded
+            - Completed
       taskRef:
         name: merge-pr
       params:
@@ -625,8 +629,6 @@ spec:
         - name: source
           workspace: repository
           subPath: src
-
-  finally:
 
     - name: set-github-passed-label
       when:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
@@ -30,8 +30,10 @@ spec:
       image: "$(params.pipeline_image)"
       workingDir: $(workspaces.source.path)
       script: |
-        if [ "$force_merge" = "true" ]; then
-          echo true >$(results.bool_merge.path)
+        if [ "$(params.force_merge)" = "true" ]; then
+          echo true > $(results.bool_merge.path)
+        elif [[ "$(params.bundle_path)" == "" ]]; then
+          echo true > $(results.bool_merge.path)
         else
           PKG_PATH=$(dirname $(realpath $(params.bundle_path)))
           CI_FILE_PATH="$PKG_PATH/ci.yaml"


### PR DESCRIPTION
Due to a Tekton limitation, we can't execute a merge task if any previous tasks have been skipped. This usually happens when no bundle is added and ci.yaml file is updated. Until Tekton enables this workflow I am temporarily moving the merge task into finally section.

The issue has been created in Tekton upstream to fix this issue https://github.com/tektoncd/pipeline/issues/7680

JIRA: ISV-4476