### PR TITLE
[ISV-4530] Fix static result comment rendering issue

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/report-static-tests-results.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/report-static-tests-results.yml
@@ -58,7 +58,7 @@ spec:
         echo >>$MESSAGE_FILE
         echo '|Status|Check|Message|' >>$MESSAGE_FILE
         echo '|:----:|:----|:------|' >>$MESSAGE_FILE
-        jq -r '(.outputs//[])[]|"|\(.type)|\(.check)|\(.message)|"' \
+        jq -r '(.outputs//[])[]|"|\(.type)|\(.check)|\(.message|gsub("\n";" "))|"' \
           <$JSON_RESULTS_FILE >>$MESSAGE_FILE
         echo >>$MESSAGE_FILE
         # Replace status words with corresponding symbols


### PR DESCRIPTION
`operator-sdk bundle validate` can return multi-line error messages that break the rendering of the result table in the comment added by the bot to the PR.

This patch just strips any line break from the error messages when building the markdown table.

Example comments: [without the fix](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/3975#issuecomment-1924414561) and [with the fix](https://github.com/redhat-openshift-ecosystem/community-operators-pipeline-preprod/pull/229#issuecomment-1954305913).