### PR TITLE
[ISV-4596] Single PR can update only one operator within catalogs

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/parse-repo-changes.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/parse-repo-changes.yml
@@ -59,49 +59,17 @@ spec:
           --output-file /tmp/changes.json \
           --verbose
 
-        function fail() {
-            echo "ERROR: $*"
-            exit 1
-        }
+        operator_name="$(jq -r '.operator_name' </tmp/changes.json)"
+        echo -n $operator_name > "$(results.added_operator.path)"
 
-        jq -e '.extra_files|length==0' </tmp/changes.json \
-            || fail "The PR affects non-operator files"
-        jq -e '.affected_operators|length<=1' </tmp/changes.json \
-            || fail "The PR affects more than one operator"
-        jq -e '.modified_bundles|length==0' </tmp/changes.json \
-            || fail "The PR modifies existing bundles"
-        jq -e '.deleted_bundles|length==0' </tmp/changes.json \
-            || fail "The PR deletes existing bundles"
-        jq -e '.added_bundles|length<=1' </tmp/changes.json \
-            || fail "The PR affects more than one bundle"
+        bundle_version="$(jq -r '.bundle_version' </tmp/changes.json)"
+        echo -n $bundle_version > "$(results.added_bundle.path)"
 
-        if jq -e '.added_bundles|length==1' </tmp/changes.json ; then
-            operator_name="$(jq -r '.added_bundles[0] | split("/")[0]' </tmp/changes.json)"
-            bundle_version="$(jq -r '.added_bundles[0] | split("/")[1]' </tmp/changes.json)"
-        elif jq -e '.affected_operators|length==1' </tmp/changes.json ; then
-            # no bundle was added (i.e.: only ci.yaml was added/modified/deleted)
-            operator_name="$(jq -r '.affected_operators[0]' </tmp/changes.json)"
-            bundle_version=""
-        else
-            # No operator has been modified
-            operator_name=""
-            bundle_version=""
-        fi
+        operator_path="$(jq -r '.operator_path' </tmp/changes.json)"
+        echo -n $operator_path > "$(results.operator_path.path)"
 
-        echo -n "$operator_name" >$(results.added_operator.path)
-        echo -n "$bundle_version" >$(results.added_bundle.path)
-
-        if [ -n "${operator_name}" ] ; then
-            echo -n "operators/${operator_name}" >"$(results.operator_path.path)"
-        else
-            echo -n >"$(results.operator_path.path)"
-        fi
-
-        if [ -n "${bundle_version}" ] ; then
-            echo -n "operators/${operator_name}/${bundle_version}" >"$(results.bundle_path.path)"
-        else
-            echo -n >"$(results.bundle_path.path)"
-        fi
+        bundle_path="$(jq -r '.bundle_path' </tmp/changes.json)"
+        echo -n $bundle_path > "$(results.bundle_path.path)"
 
         affected_catalogs="$(jq -r '.affected_catalogs | join(",")' </tmp/changes.json)"
         echo -n $affected_catalogs > "$(results.affected_catalogs.path)"

--- a/operator-pipeline-images/operatorcert/entrypoints/detect_changed_operators.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/detect_changed_operators.py
@@ -249,17 +249,17 @@ def _validate_result(result: dict[str, list[str]]) -> None:
     message = ""
 
     if len(extra_files := result.get("extra_files", [])) > 0:
-        message += f"The PR affects non-operator files: {sorted(extra_files)} "
+        message += f"The PR affects non-operator files: {sorted(extra_files)}\n"
     if len(affected_operators := result.get("affected_operators", [])) > 1:
         message += (
-            f"The PR affects more than one operator: {sorted(affected_operators)} "
+            f"The PR affects more than one operator: {sorted(affected_operators)}\n"
         )
     if len(modified_bundles := result.get("modified_bundles", [])) > 0:
-        message += f"The PR modifies existing bundles: {sorted(modified_bundles)} "
+        message += f"The PR modifies existing bundles: {sorted(modified_bundles)}\n"
     if len(deleted_bundles := result.get("deleted_bundles", [])) > 0:
-        message += f"The PR deletes existing bundles: {sorted(deleted_bundles)} "
+        message += f"The PR deletes existing bundles: {sorted(deleted_bundles)}\n"
     if len(added_bundles := result.get("added_bundles", [])) > 1:
-        message += f"The PR affects more than one bundle: {sorted(added_bundles)} "
+        message += f"The PR affects more than one bundle: {sorted(added_bundles)}\n"
 
     catalog_operators = sorted(
         list(
@@ -573,9 +573,7 @@ def detect_changes(
         "extra_files": list(non_operator_files),
     }
 
-    _validate_result(result)
-
-    return _update_result(result)
+    return result
 
 
 def main() -> None:
@@ -597,6 +595,12 @@ def main() -> None:
     base_repo = OperatorRepo(args.base_repo_path)
 
     result = detect_changes(head_repo, base_repo, args.pr_url)
+
+    # raise exception if the result is invalid
+    _validate_result(result)
+
+    # calculate additional result fields
+    result = _update_result(result)
 
     if args.output_file:
         with args.output_file.open(mode="w", encoding="utf-8") as output_file:

--- a/operator-pipeline-images/tests/entrypoints/test_detect_changed_operators.py
+++ b/operator-pipeline-images/tests/entrypoints/test_detect_changed_operators.py
@@ -34,7 +34,7 @@ from operator_repo import Repo
     # 32e0f85 Add operator-e2e/0.0.101
     # 6a75661 Add operator-e2e/0.0.100
     # db1a066 Empty repo
-    "head_commit, base_commit, expected, exceptions",
+    "head_commit, base_commit, expected",
     [
         (
             "6a75661",
@@ -59,12 +59,7 @@ from operator_repo import Repo
                 "added_catalogs": [],
                 "modified_catalogs": [],
                 "deleted_catalogs": [],
-                "operator_name": "operator-e2e",
-                "bundle_version": "0.0.100",
-                "operator_path": "operators/operator-e2e",
-                "bundle_path": "operators/operator-e2e/0.0.100",
             },
-            None,
         ),
         (
             "32e0f85",
@@ -89,12 +84,7 @@ from operator_repo import Repo
                 "added_catalogs": [],
                 "modified_catalogs": [],
                 "deleted_catalogs": [],
-                "operator_name": "operator-e2e",
-                "bundle_version": "0.0.101",
-                "operator_path": "operators/operator-e2e",
-                "bundle_path": "operators/operator-e2e/0.0.101",
             },
-            None,
         ),
         (
             "6626c9a",
@@ -102,11 +92,28 @@ from operator_repo import Repo
             # Add operator-e2e/0.0.101
             # Add operator-e2e/0.0.100
             "6a75661",
-            None,
-            "The PR affects more than one operator: "
-            "['operator-clone-e2e', 'operator-e2e'] "
-            "The PR affects more than one bundle: "
-            "['operator-clone-e2e/0.0.100', 'operator-e2e/0.0.101'] ",
+            {
+                "extra_files": [],
+                "affected_operators": ["operator-e2e", "operator-clone-e2e"],
+                "added_operators": ["operator-clone-e2e"],
+                "modified_operators": ["operator-e2e"],
+                "deleted_operators": [],
+                "affected_bundles": [
+                    "operator-e2e/0.0.101",
+                    "operator-clone-e2e/0.0.100",
+                ],
+                "added_bundles": ["operator-e2e/0.0.101", "operator-clone-e2e/0.0.100"],
+                "modified_bundles": [],
+                "deleted_bundles": [],
+                "affected_catalog_operators": [],
+                "added_catalog_operators": [],
+                "modified_catalog_operators": [],
+                "deleted_catalog_operators": [],
+                "affected_catalogs": [],
+                "added_catalogs": [],
+                "modified_catalogs": [],
+                "deleted_catalogs": [],
+            },
         ),
         (
             "2d55a2e",
@@ -115,13 +122,31 @@ from operator_repo import Repo
             # Modify operator-clone-e2e/0.0.100
             # Add operator-clone-e2e/0.0.100
             "6626c9a",
-            None,
-            "The PR affects non-operator files: "
-            "['empty.txt', 'operators/empty.txt'] "
-            "The PR affects more than one operator: "
-            "['operator-clone-e2e', 'operator-e2e'] "
-            "The PR modifies existing bundles: "
-            "['operator-clone-e2e/0.0.100', 'operator-e2e/0.0.101'] ",
+            {
+                "extra_files": ["empty.txt", "operators/empty.txt"],
+                "affected_operators": ["operator-e2e", "operator-clone-e2e"],
+                "added_operators": [],
+                "modified_operators": ["operator-e2e", "operator-clone-e2e"],
+                "deleted_operators": [],
+                "affected_bundles": [
+                    "operator-e2e/0.0.101",
+                    "operator-clone-e2e/0.0.100",
+                ],
+                "added_bundles": [],
+                "modified_bundles": [
+                    "operator-e2e/0.0.101",
+                    "operator-clone-e2e/0.0.100",
+                ],
+                "deleted_bundles": [],
+                "affected_catalog_operators": [],
+                "added_catalog_operators": [],
+                "modified_catalog_operators": [],
+                "deleted_catalog_operators": [],
+                "affected_catalogs": [],
+                "added_catalogs": [],
+                "modified_catalogs": [],
+                "deleted_catalogs": [],
+            },
         ),
         (
             "2c06647",
@@ -129,9 +154,25 @@ from operator_repo import Repo
             # Remove operator-e2e/0.0.101
             # Add extra files
             "2d55a2e",
-            None,
-            "The PR affects non-operator files: ['empty.txt', 'operators/empty.txt'] "
-            "The PR deletes existing bundles: ['operator-e2e/0.0.101'] ",
+            {
+                "extra_files": ["empty.txt", "operators/empty.txt"],
+                "affected_operators": ["operator-e2e"],
+                "added_operators": [],
+                "modified_operators": ["operator-e2e"],
+                "deleted_operators": [],
+                "affected_bundles": ["operator-e2e/0.0.101"],
+                "added_bundles": [],
+                "modified_bundles": [],
+                "deleted_bundles": ["operator-e2e/0.0.101"],
+                "affected_catalog_operators": [],
+                "added_catalog_operators": [],
+                "modified_catalog_operators": [],
+                "deleted_catalog_operators": [],
+                "affected_catalogs": [],
+                "added_catalogs": [],
+                "modified_catalogs": [],
+                "deleted_catalogs": [],
+            },
         ),
         (
             "a5501e2",
@@ -156,20 +197,32 @@ from operator_repo import Repo
                 "added_catalogs": [],
                 "modified_catalogs": [],
                 "deleted_catalogs": [],
-                "operator_name": "operator-clone-e2e",
-                "bundle_version": "",
-                "operator_path": "operators/operator-clone-e2e",
-                "bundle_path": "",
             },
-            None,
         ),
         (
             "2e9eae2",
             # Remove operator-clone-e2e
             # Add ci.yaml to operator-clone-e2e
             "a5501e2",
-            None,
-            "The PR deletes existing bundles: ['operator-clone-e2e/0.0.100'] ",
+            {
+                "extra_files": [],
+                "affected_operators": ["operator-clone-e2e"],
+                "added_operators": [],
+                "modified_operators": [],
+                "deleted_operators": ["operator-clone-e2e"],
+                "affected_bundles": ["operator-clone-e2e/0.0.100"],
+                "added_bundles": [],
+                "modified_bundles": [],
+                "deleted_bundles": ["operator-clone-e2e/0.0.100"],
+                "affected_catalog_operators": [],
+                "added_catalog_operators": [],
+                "modified_catalog_operators": [],
+                "deleted_catalog_operators": [],
+                "affected_catalogs": [],
+                "added_catalogs": [],
+                "modified_catalogs": [],
+                "deleted_catalogs": [],
+            },
         ),
         (
             "c8d3509f",
@@ -193,12 +246,7 @@ from operator_repo import Repo
                 "added_catalogs": ["v4.15"],
                 "modified_catalogs": [],
                 "deleted_catalogs": [],
-                "operator_name": "",
-                "bundle_version": "",
-                "operator_path": "",
-                "bundle_path": "",
             },
-            None,
         ),
         (
             "4db21de1",
@@ -222,12 +270,7 @@ from operator_repo import Repo
                 "added_catalogs": [],
                 "modified_catalogs": ["v4.15"],
                 "deleted_catalogs": [],
-                "operator_name": "",
-                "bundle_version": "",
-                "operator_path": "",
-                "bundle_path": "",
             },
-            None,
         ),
         (
             "ff7cdcd6",
@@ -251,12 +294,7 @@ from operator_repo import Repo
                 "added_catalogs": [],
                 "modified_catalogs": ["v4.15"],
                 "deleted_catalogs": [],
-                "operator_name": "",
-                "bundle_version": "",
-                "operator_path": "",
-                "bundle_path": "",
             },
-            None,
         ),
         (
             "85009570",
@@ -280,12 +318,7 @@ from operator_repo import Repo
                 "added_catalogs": [],
                 "modified_catalogs": ["v4.15"],
                 "deleted_catalogs": [],
-                "operator_name": "",
-                "bundle_version": "",
-                "operator_path": "",
-                "bundle_path": "",
             },
-            None,
         ),
         (
             "1ca2aa12",
@@ -309,12 +342,7 @@ from operator_repo import Repo
                 "added_catalogs": [],
                 "modified_catalogs": [],
                 "deleted_catalogs": ["v4.15"],
-                "operator_name": "",
-                "bundle_version": "",
-                "operator_path": "",
-                "bundle_path": "",
             },
-            None,
         ),
         (
             "ff7cdcd",
@@ -322,9 +350,25 @@ from operator_repo import Repo
             # Add v4.15/operator-2
             # Empty repo
             "c8d3509",
-            None,
-            "The PR affects more than one catalog operator: "
-            "['operator-1', 'operator-2']",
+            {
+                "affected_operators": [],
+                "added_operators": [],
+                "modified_operators": [],
+                "deleted_operators": [],
+                "affected_bundles": [],
+                "added_bundles": [],
+                "modified_bundles": [],
+                "deleted_bundles": [],
+                "affected_catalogs": ["v4.15"],
+                "added_catalogs": [],
+                "modified_catalogs": ["v4.15"],
+                "deleted_catalogs": [],
+                "affected_catalog_operators": ["v4.15/operator-1", "v4.15/operator-2"],
+                "added_catalog_operators": ["v4.15/operator-2"],
+                "modified_catalog_operators": ["v4.15/operator-1"],
+                "deleted_catalog_operators": [],
+                "extra_files": [],
+            },
         ),
     ],
     indirect=False,
@@ -351,7 +395,6 @@ def test_detect_changes(
     head_commit: str,
     base_commit: str,
     expected: Any,
-    exceptions: Any,
 ) -> None:
     data_dir = pathlib.Path(__file__).parent.parent.resolve() / "data"
     tar = tarfile.open(str(data_dir / "test-repo.tar"))
@@ -375,27 +418,19 @@ def test_detect_changes(
     }
     mock_affected_files.return_value = affected_files
 
-    if exceptions:
-        with pytest.raises(ValidationError) as exc:
-            detect_changed_operators.detect_changes(
-                Repo(after_dir),
-                Repo(before_dir),
-                "https://example.com/foo/bar/pull/1",
-            )
-        assert str(exc.value) == exceptions
-    else:
-        result = detect_changed_operators.detect_changes(
-            Repo(after_dir),
-            Repo(before_dir),
-            "https://example.com/foo/bar/pull/1",
-        )
-
-        for key in set(result.keys()) | set(expected.keys()):
-            assert sorted(result[key]) == sorted(
-                expected[key]
-            ), f"Invalid value for {key}: expected {expected[key]} but {result[key]} was returned"
+    result = detect_changed_operators.detect_changes(
+        Repo(after_dir),
+        Repo(before_dir),
+        "https://example.com/foo/bar/pull/1",
+    )
+    print(result)
+    for key in set(result.keys()) | set(expected.keys()):
+        assert sorted(result[key]) == sorted(
+            expected[key]
+        ), f"Invalid value for {key}: expected {expected[key]} but {result[key]} was returned"
 
 
+@patch("operatorcert.entrypoints.detect_changed_operators._update_result")
 @patch("operatorcert.entrypoints.detect_changed_operators.OperatorRepo")
 @patch("operatorcert.entrypoints.detect_changed_operators.detect_changes")
 @patch("operatorcert.entrypoints.detect_changed_operators.setup_logger")
@@ -403,6 +438,7 @@ def test_detect_changed_operators_main(
     mock_logger: MagicMock,
     mock_detect: MagicMock,
     mock_repo: MagicMock,
+    mock_update: MagicMock,
     capsys: Any,
     tmpdir: Any,
 ) -> None:
@@ -412,7 +448,9 @@ def test_detect_changed_operators_main(
         "--base-repo-path=/tmp/base-repo",
         "--pr-url=https://example.com/foo/bar/pull/1",
     ]
-    mock_detect.return_value = {"foo": ["bar"]}
+    return_value = {"foo": ["bar"]}
+    mock_detect.return_value = return_value
+    mock_update.return_value = return_value
     repo_head = MagicMock()
     repo_base = MagicMock()
     mock_repo.side_effect = [repo_head, repo_base, repo_head, repo_base]
@@ -428,6 +466,7 @@ def test_detect_changed_operators_main(
 
     mock_logger.reset_mock()
     mock_detect.reset_mock()
+    mock_update.reset_mock()
 
     out_file = tmpdir / "out.json"
     out_file_name = str(out_file)
@@ -439,7 +478,9 @@ def test_detect_changed_operators_main(
         f"--output-file={out_file_name}",
         "--verbose",
     ]
-    mock_detect.return_value = {"bar": ["baz"]}
+    return_value = {"bar": ["baz"]}
+    mock_detect.return_value = return_value
+    mock_update.return_value = return_value
     with patch("sys.argv", args):
         detect_changed_operators.main()
     mock_detect.assert_called_once_with(
@@ -520,3 +561,102 @@ def test_github_pr_affected_files_invalid_url(
 ) -> None:
     with pytest.raises(ValueError):
         github_pr_affected_files("http://example.com/invalid/url")
+
+
+@pytest.mark.parametrize(
+    "result, valid, message",
+    [
+        pytest.param(
+            {
+                "extra_files": ["empty.txt", "operators/empty.txt"],
+                "affected_operators": ["operator-e2e", "operator-clone-e2e"],
+                "modified_bundles": ["operator-e2e/0.0.101"],
+                "deleted_bundles": ["operator-clone-e2e/0.0.100"],
+                "added_bundles": ["operator-e2e/0.0.101", "operator-clone-e2e/0.0.100"],
+                "affected_catalog_operators": ["v4.15/operator-1", "v4.15/operator-2"],
+            },
+            False,
+            "The PR affects non-operator files: ['empty.txt', 'operators/empty.txt']\n"
+            "The PR affects more than one operator: ['operator-clone-e2e', 'operator-e2e']\n"
+            "The PR modifies existing bundles: ['operator-e2e/0.0.101']\n"
+            "The PR deletes existing bundles: ['operator-clone-e2e/0.0.100']\n"
+            "The PR affects more than one bundle: ['operator-clone-e2e/0.0.100', 'operator-e2e/0.0.101']\n"
+            "The PR affects more than one catalog operator: ['operator-1', 'operator-2']",
+            id="Invalid changes detected",
+        ),
+        pytest.param(
+            {
+                "extra_files": [],
+                "affected_operators": ["operator-e2e"],
+                "modified_bundles": [],
+                "deleted_bundles": [],
+                "added_bundles": ["operator-e2e/0.0.101"],
+                "affected_catalog_operators": ["v4.15/operator-1", "v4.16/operator-1"],
+            },
+            True,
+            None,
+            id="Valid result",
+        ),
+    ],
+)
+def test__validate_result(result: dict[str, Any], valid: bool, message: str) -> None:
+    if valid:
+        detect_changed_operators._validate_result(result)
+    else:
+        with pytest.raises(ValidationError) as exc:
+            detect_changed_operators._validate_result(result)
+        assert str(exc.value) == message
+
+
+@pytest.mark.parametrize(
+    "result, expected",
+    [
+        pytest.param(
+            {
+                "added_bundles": ["operator-e2e/0.0.101"],
+                "affected_operators": ["operator-e2e"],
+            },
+            {
+                "added_bundles": ["operator-e2e/0.0.101"],
+                "affected_operators": ["operator-e2e"],
+                "operator_name": "operator-e2e",
+                "bundle_version": "0.0.101",
+                "operator_path": "operators/operator-e2e",
+                "bundle_path": "operators/operator-e2e/0.0.101",
+            },
+            id="Bundle is added",
+        ),
+        pytest.param(
+            {
+                "added_bundles": [],
+                "affected_operators": ["operator-e2e"],
+            },
+            {
+                "added_bundles": [],
+                "affected_operators": ["operator-e2e"],
+                "operator_name": "operator-e2e",
+                "bundle_version": "",
+                "operator_path": "operators/operator-e2e",
+                "bundle_path": "",
+            },
+            id="Operator is updated",
+        ),
+        pytest.param(
+            {
+                "added_bundles": [],
+                "affected_operators": [],
+            },
+            {
+                "added_bundles": [],
+                "affected_operators": [],
+                "operator_name": "",
+                "bundle_version": "",
+                "operator_path": "",
+                "bundle_path": "",
+            },
+            id="No bundle added or operator affected",
+        ),
+    ],
+)
+def test__update_result(result: dict[str, Any], expected: dict[str, Any]) -> None:
+    assert detect_changed_operators._update_result(result) == expected

--- a/operator-pipeline-images/tests/entrypoints/test_detect_changed_operators.py
+++ b/operator-pipeline-images/tests/entrypoints/test_detect_changed_operators.py
@@ -423,7 +423,7 @@ def test_detect_changes(
         Repo(before_dir),
         "https://example.com/foo/bar/pull/1",
     )
-    print(result)
+
     for key in set(result.keys()) | set(expected.keys()):
         assert sorted(result[key]) == sorted(
             expected[key]

--- a/pdm.lock
+++ b/pdm.lock
@@ -32,19 +32,18 @@ files = [
 
 [[package]]
 name = "bandit"
-version = "1.7.5"
-requires_python = ">=3.7"
+version = "1.7.7"
+requires_python = ">=3.8"
 summary = "Security oriented static analyser for python code."
 dependencies = [
-    "GitPython>=1.0.1",
     "PyYAML>=5.3.1",
     "colorama>=0.3.9; platform_system == \"Windows\"",
     "rich",
     "stevedore>=1.20.0",
 ]
 files = [
-    {file = "bandit-1.7.5-py3-none-any.whl", hash = "sha256:75665181dc1e0096369112541a056c59d1c5f66f9bb74a8d686c3c362b83f549"},
-    {file = "bandit-1.7.5.tar.gz", hash = "sha256:bdfc739baa03b880c2d15d0431b31c658ffc348e907fe197e54e0389dd59e11e"},
+    {file = "bandit-1.7.7-py3-none-any.whl", hash = "sha256:17e60786a7ea3c9ec84569fd5aee09936d116cb0cb43151023258340dbffb7ed"},
+    {file = "bandit-1.7.7.tar.gz", hash = "sha256:527906bec6088cb499aae31bc962864b4e77569e9d529ee51df3a93b4b8ab28a"},
 ]
 
 [[package]]

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,8 @@ groups = operatorcert-dev
 commands = pytest -v \
        --cov {[vars]OPERATOR_MODULE} \
        --cov-report term-missing \
-       --cov-fail-under 100
+       --cov-fail-under 100 \
+       {posargs}
 
 [testenv:black]
 groups = operatorcert-dev


### PR DESCRIPTION
- validation logic moved from Bash to Python and refactored, so the fail message lists all detected issues in the fail (exception) message
- all conditionals also moved to Python script, Bash only reads the output from json

JIRA: ISV-4596