### PR TITLE
Unify and cleanup pipeline params

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,14 +139,12 @@ The hosted pipeline can be triggered using the tkn CLI like so:
 tkn pipeline start operator-hosted-pipeline \
   --use-param-defaults \
   --param git_pr_branch=test-PR-ok \
-  --param git_pr_title="operator kogito-operator (1.6.1-ok)" \
   --param git_pr_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/31 \
   --param git_fork_url=https://github.com/MarcinGinszt/operator-pipelines-test.git \
   --param git_repo_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
   --param git_username=foo@redhat.com \
   --param git_commit=0aeff5f71e4fc2d4990474780b56d9312554da5a \
   --param git_base_branch=main \
-  --param pr_head_label=MarcinGinszt:test-PR-ok \
   --param env=prod \
   --param preflight_min_version=0.0.0 \
   --param ci_min_version=0.0.0 \
@@ -181,7 +179,6 @@ tkn pipeline start operator-release-pipeline \
   --use-param-defaults \
   --param git_repo_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test.git \
   --param git_commit=3ffff387caac0a5b475f44c4a54fb45eebb8dd8e \
-  --param git_pr_title="operator kogito-operator (1.6.1-ok)" \
   --param git_pr_url=https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/31 \
   --param dest_image_namespace=redhat-isv-operators \
   --workspace name=repository,volumeClaimTemplateFile=templates/workspace-template.yml \

--- a/ansible/roles/operator-pipeline/tasks/community-hosted-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-hosted-pipeline-trigger.yml
@@ -20,14 +20,10 @@
             params:
               - name: git_repo_url
                 value: $(body.pull_request.base.repo.clone_url)
-              - name: git_pr_branch
-                value: $(body.pull_request.head.ref)
               - name: git_fork_url
                 value: $(body.pull_request.head.repo.clone_url)
               - name: git_pr_url
                 value: $(body.pull_request.html_url)
-              - name: git_pr_title
-                value: $(body.pull_request.title)
               - name: git_username
                 value: $(body.pull_request.user.login)
               - name: git_commit
@@ -57,10 +53,8 @@
           spec:
             params:
               - name: git_repo_url
-              - name: git_pr_branch
               - name: git_fork_url
               - name: git_pr_url
-              - name: git_pr_title
               - name: git_username
               - name: git_commit
               - name: git_commit_base
@@ -79,7 +73,6 @@
                     git_commit: $(tt.params.git_commit)
                   annotations:
                     git_pull_request_url: $(tt.params.git_pr_url)
-                    git_pull_request_title: $(tt.params.git_pr_title)
                 spec:
                   timeouts:
                     pipeline: "2h"
@@ -88,14 +81,10 @@
                   params:
                     - name: git_repo_url
                       value: $(tt.params.git_repo_url)
-                    - name: git_pr_branch
-                      value: $(tt.params.git_pr_branch)
                     - name: git_fork_url
                       value: $(tt.params.git_fork_url)
                     - name: git_pr_url
                       value: $(tt.params.git_pr_url)
-                    - name: git_pr_title
-                      value: $(tt.params.git_pr_title)
                     - name: git_username
                       value: $(tt.params.git_username)
                     - name: git_commit

--- a/ansible/roles/operator-pipeline/tasks/community-release-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-release-pipeline-trigger.yml
@@ -20,8 +20,6 @@
             params:
               - name: git_repo_url
                 value: $(body.pull_request.base.repo.clone_url)
-              - name: git_base_branch
-                value: $(body.pull_request.base.ref)
               - name: git_pr_url
                 value: $(body.pull_request.html_url)
               - name: git_username
@@ -55,9 +53,7 @@
           spec:
             params:
               - name: git_repo_url
-              - name: git_base_branch
               - name: git_pr_url
-              - name: git_pr_title
               - name: git_username
               - name: git_commit
               - name: git_commit_base
@@ -77,7 +73,6 @@
                     git_commit: $(tt.params.git_commit)
                   annotations:
                     git_pull_request_url: $(tt.params.git_pr_url)
-                    git_pull_request_title: $(tt.params.git_pr_title)
                 spec:
                   timeouts:
                     pipeline: "1h30m0s"
@@ -86,12 +81,8 @@
                   params:
                     - name: git_repo_url
                       value: $(tt.params.git_repo_url)
-                    - name: git_base_branch
-                      value: $(tt.params.git_base_branch)
                     - name: git_pr_url
                       value: $(tt.params.git_pr_url)
-                    - name: git_pr_title
-                      value: $(tt.params.git_pr_title)
                     - name: git_username
                       value: $(tt.params.git_username)
                     - name: git_commit

--- a/ansible/roles/operator-pipeline/tasks/operator-hosted-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-hosted-pipeline-trigger.yml
@@ -22,10 +22,6 @@
             params:
               - name: git_commit_base
                 value: $(body.pull_request.base.sha)
-              - name: git_pr_branch
-                value: $(body.pull_request.head.ref)
-              - name: git_pr_title
-                value: $(body.pull_request.title)
               - name: git_pr_url
                 value: $(body.pull_request.html_url)
               - name: git_fork_url
@@ -36,10 +32,6 @@
                 value: $(body.pull_request.user.login)
               - name: git_commit
                 value: $(body.pull_request.head.sha)
-              - name: git_base_branch
-                value: $(body.pull_request.base.ref)
-              - name: pr_head_label
-                value: $(body.pull_request.head.label)
               - name: env
                 value: "{{ env }}"
               - name: preflight_min_version
@@ -70,16 +62,12 @@
               env: "{{ env }}"
           spec:
             params:
-              - name: git_pr_branch
               - name: git_commit_base
-              - name: git_pr_title
               - name: git_pr_url
               - name: git_fork_url
               - name: git_repo_url
               - name: git_username
               - name: git_commit
-              - name: git_base_branch
-              - name: pr_head_label
               - name: env
               - name: preflight_min_version
               - name: preflight_trigger_environment
@@ -99,7 +87,6 @@
                     git_commit: $(tt.params.git_commit)
                   annotations:
                     git_pull_request_url: $(tt.params.git_pr_url)
-                    git_pull_request_title: $(tt.params.git_pr_title)
                 spec:
                   timeouts:
                     pipeline: "2h"
@@ -108,10 +95,6 @@
                   params:
                     - name: git_commit_base
                       value: $(tt.params.git_commit_base)
-                    - name: git_pr_branch
-                      value: $(tt.params.git_pr_branch)
-                    - name: git_pr_title
-                      value: $(tt.params.git_pr_title)
                     - name: git_pr_url
                       value: $(tt.params.git_pr_url)
                     - name: git_fork_url
@@ -120,10 +103,6 @@
                       value: $(tt.params.git_repo_url)
                     - name: git_username
                       value: $(tt.params.git_username)
-                    - name: git_base_branch
-                      value: $(tt.params.git_base_branch)
-                    - name: pr_head_label
-                      value: $(tt.params.pr_head_label)
                     - name: env
                       value: $(tt.params.env)
                     - name: preflight_min_version

--- a/ansible/roles/operator-pipeline/tasks/operator-release-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-release-pipeline-trigger.yml
@@ -26,17 +26,13 @@
                 value: $(body.pull_request.merge_commit_sha)
               - name: git_commit_base
                 value: $(body.pull_request.base.sha)
-              - name: git_pr_title
-                value: $(body.pull_request.title)
               - name: git_pr_url
                 value: $(body.pull_request.html_url)
-              - name: git_base_branch
-                value: $(body.pull_request.base.ref)
               - name: env
                 value: "{{ env }}"
               - name: pipeline_image
                 value: "{{ operator_pipeline_image_pull_spec }}"
-              - name: src_image_namespace
+              - name: image_namespace
                 value: "{{ operator_pipeline_pending_namespace }}"
               - name: dest_image_namespace
                 value: "{{ operator_pipeline_release_namespace }}"
@@ -58,12 +54,10 @@
               - name: git_repo_url
               - name: git_commit
               - name: git_commit_base
-              - name: git_pr_title
               - name: git_pr_url
-              - name: git_base_branch
               - name: env
               - name: pipeline_image
-              - name: src_image_namespace
+              - name: image_namespace
               - name: dest_image_namespace
             resourcetemplates:
               - apiVersion: tekton.dev/v1
@@ -77,7 +71,6 @@
                     git_commit: $(tt.params.git_commit)
                   annotations:
                     git_pull_request_url: $(tt.params.git_pr_url)
-                    git_pull_request_title: $(tt.params.git_pr_title)
                 spec:
                   timeouts:
                     pipeline: "4h15m0s"
@@ -90,18 +83,14 @@
                       value: $(tt.params.git_commit)
                     - name: git_commit_base
                       value: $(tt.params.git_commit_base)
-                    - name: git_pr_title
-                      value: $(tt.params.git_pr_title)
                     - name: git_pr_url
                       value: $(tt.params.git_pr_url)
-                    - name: git_base_branch
-                      value: $(tt.params.git_base_branch)
                     - name: env
                       value: $(tt.params.env)
                     - name: pipeline_image
                       value: $(tt.params.pipeline_image)
-                    - name: src_image_namespace
-                      value: $(tt.params.src_image_namespace)
+                    - name: image_namespace
+                      value: $(tt.params.image_namespace)
                     - name: dest_image_namespace
                       value: $(tt.params.dest_image_namespace)
                   workspaces:

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
@@ -6,10 +6,8 @@ metadata:
 spec:
   params:
     - name: git_repo_url
-    - name: git_pr_branch
     - name: git_fork_url
     - name: git_pr_url
-    - name: git_pr_title
     - name: git_username
     - name: git_commit
     - name: git_commit_base
@@ -73,16 +71,16 @@ spec:
       description: The key within the Kubernetes Secret that contains the gpg public key.
       default: public
 
-    - name: pyxis_ssl_secret_name
-      description: Kubernetes secret name that contains the Pyxis SSL files.
+    - name: pipeline_ssl_secret_name
+      description: Kubernetes secret name that contains the Pipeline SSL files.
       default: operator-pipeline-api-certs
 
-    - name: pyxis_ssl_cert_secret_key
-      description: The key within the Kubernetes secret that contains the Pyxis SSL cert.
+    - name: pipeline_ssl_cert_secret_key
+      description: The key within the Kubernetes secret that contains the Pipeline SSL cert.
       default: operator-pipeline.pem
 
-    - name: pyxis_ssl_key_secret_key
-      description: The key within the Kubernetes secret that contains the Pyxis SSL key.
+    - name: pipeline_ssl_key_secret_key
+      description: The key within the Kubernetes secret that contains the Pipeline SSL key.
       default: operator-pipeline.key
 
   workspaces:
@@ -289,11 +287,11 @@ spec:
         - name: pyxis_url
           value: "$(tasks.set-env-community.results.pyxis_url)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
       workspaces:
         - name: pr
           workspace: repository

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-release-pipeline.yml
@@ -6,13 +6,9 @@ metadata:
 spec:
   params:
     - name: git_repo_url
-    - name: git_base_branch
-    - name: git_pr_title
     - name: git_pr_url
-    - name: git_username
     - name: git_commit
     - name: git_commit_base
-    - name: git_head_sha
     - name: env
     - name: pipeline_image
       default: "quay.io/redhat-isv/operator-pipelines-images:released"
@@ -29,16 +25,16 @@ spec:
       description: The key within the Kubernetes Secret that contains the GitHub token.
       default: github_bot_token
 
-    - name: umb_ssl_secret_name
-      description: Kubernetes secret that contains SSL files
+    - name: pipeline_ssl_secret_name
+      description: Kubernetes secret name that contains the Pipeline SSL files.
       default: operator-pipeline-api-certs
 
-    - name: umb_ssl_cert_secret_key
-      description: Kubernetes secret that contains SSL cert
+    - name: pipeline_ssl_cert_secret_key
+      description: The key within the Kubernetes secret that contains the Pipeline SSL cert.
       default: operator-pipeline.pem
 
-    - name: umb_ssl_key_secret_key
-      description: Kubernetes secret that contains SSL key
+    - name: pipeline_ssl_key_secret_key
+      description: The key within the Kubernetes secret that contains the Pipeline SSL key.
       default: operator-pipeline.key
 
     - name: kerberos_keytab_secret_name
@@ -316,11 +312,11 @@ spec:
         - name: umb_url
           value: "$(tasks.set-env-community.results.umb_url)"
         - name: umb_ssl_secret_name
-          value: "$(params.umb_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: umb_ssl_cert_secret_key
-          value: "$(params.umb_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: umb_ssl_key_secret_key
-          value: "$(params.umb_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
       workspaces:
         - name: source
           workspace: repository
@@ -345,11 +341,11 @@ spec:
         - name: signature_data_file
           value: "$(tasks.request-signature.results.signature_data_file)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.umb_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.umb_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.umb_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
         - name: pyxis_url
           value: "$(tasks.set-env-community.results.pyxis_url)"
         - name: signing_pub_secret_name

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -226,19 +226,6 @@ spec:
           workspace: pipeline
           subPath: src
 
-    - name: get-organization
-      runAfter:
-        - commit-pinned-digest
-      taskRef:
-        name: get-organization
-      params:
-        - name: pipeline_image
-          value: "$(params.pipeline_image)"
-      workspaces:
-        - name: source
-          workspace: pipeline
-          subPath: src
-
     - name: content-hash
       runAfter:
         - commit-pinned-digest

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -7,10 +7,6 @@ spec:
   params:
     # When adding a new param, make sure to also add it to the webhook in
     # operator-hosted-pipeline-trigger.yml if possible
-    - name: git_pr_branch
-
-    - name: git_pr_title
-
     - name: git_pr_url
 
     - name: git_fork_url
@@ -22,11 +18,6 @@ spec:
     - name: git_commit
 
     - name: git_commit_base
-
-    - name: git_base_branch
-      description: Name of the base branch. e.g. "main"
-
-    - name: pr_head_label
 
     - name: env
       description: Which environment to run in. Can be one of [dev, qa, stage, prod]
@@ -89,16 +80,16 @@ spec:
       description: SSO URL.
       default: https://auth.redhat.com/auth/realms/EmployeeIDP/protocol/openid-connect/token
 
-    - name: pyxis_ssl_secret_name
-      description: Kubernetes secret name that contains the Pyxis SSL files.
+    - name: pipeline_ssl_secret_name
+      description: Kubernetes secret name that contains the Pipeline SSL files.
       default: operator-pipeline-api-certs
 
-    - name: pyxis_ssl_cert_secret_key
-      description: The key within the Kubernetes secret that contains the Pyxis SSL cert.
+    - name: pipeline_ssl_cert_secret_key
+      description: The key within the Kubernetes secret that contains the Pipeline SSL cert.
       default: operator-pipeline.pem
 
-    - name: pyxis_ssl_key_secret_key
-      description: The key within the Kubernetes secret that contains the Pyxis SSL key.
+    - name: pipeline_ssl_key_secret_key
+      description: The key within the Kubernetes secret that contains the Pipeline SSL key.
       default: operator-pipeline.key
 
     - name: kerberos_keytab_secret_name
@@ -223,7 +214,7 @@ spec:
         - name: url
           value: $(params.git_fork_url)
         - name: revision
-          value: $(params.git_pr_branch)
+          value: $(params.git_commit)
         - name: gitInitImage
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
       workspaces:
@@ -306,11 +297,11 @@ spec:
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
       workspaces:
         - name: pr
           workspace: repository
@@ -433,11 +424,11 @@ spec:
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
       workspaces:
         - name: source
           workspace: repository
@@ -477,11 +468,11 @@ spec:
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
         - name: current_certification_status
           value: "$(tasks.get-pyxis-certification-data.results.current_certification_status)"
 
@@ -501,11 +492,11 @@ spec:
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
         - name: source
           value: "$(tasks.get-organization.results.organization)"
 
@@ -777,11 +768,11 @@ spec:
         - name: operator_name
           value: "$(tasks.detect-changes.results.added_operator)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
       workspaces:
         - name: results
           workspace: results
@@ -858,11 +849,11 @@ spec:
         - name: connect_url
           value: "$(tasks.set-env.results.connect_url)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
       workspaces:
         - name: source
           workspace: repository
@@ -893,11 +884,11 @@ spec:
         - name: operator_name
           value: "$(tasks.detect-changes.results.added_operator)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
       workspaces:
         - name: results
           workspace: results
@@ -937,11 +928,11 @@ spec:
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
         - name: pull_request_url
           value: "$(params.git_pr_url)"
         - name: pull_request_status
@@ -1011,11 +1002,11 @@ spec:
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
         - name: pull_request_url
           value: "$(params.git_pr_url)"
         - name: pull_request_status
@@ -1049,11 +1040,11 @@ spec:
         - name: pipelinerun_name
           value: "$(context.pipelineRun.name)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
       workspaces:
         - name: source
           workspace: repository

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -7,23 +7,19 @@ spec:
   params:
     - name: git_repo_url
       description: ssh address of GitHub repository
-    - name: git_base_branch
-      description: Name of the base branch in the pull request. e.g. "main"
       default: "main"
     - name: git_commit
       description: Git repository HEAD commit
     - name: git_commit_base
-    - name: git_pr_title
-      description: title of the pull request with operator submission
     - name: git_pr_url
       description: URL to the pull request
-    - name: src_registry
+    - name: registry
       description: Source registry for the bundle image.
       default: quay.io
     - name: dest_registry
       description: Destination registry for the bundle image.
       default: quay.io
-    - name: src_image_namespace
+    - name: image_namespace
       description: The namespace/organization where the bundle image from the Hosted pipeline is stored.
       default: $(context.pipelineRun.namespace)
     - name: dest_image_namespace
@@ -41,25 +37,17 @@ spec:
     - name: github_token_secret_key
       description: The key within the Kubernetes Secret that contains the GitHub token.
       default: github_bot_token
-    - name: pyxis_ssl_secret_name
-      description: Kubernetes secret name that contains the Pyxis SSL files.
+    - name: pipeline_ssl_secret_name
+      description: Kubernetes secret name that contains the Pipeline SSL files.
       default: operator-pipeline-api-certs
-    - name: pyxis_ssl_cert_secret_key
-      description: The key within the Kubernetes secret that contains the Pyxis SSL cert.
+
+    - name: pipeline_ssl_cert_secret_key
+      description: The key within the Kubernetes secret that contains the Pipeline SSL cert.
       default: operator-pipeline.pem
-    - name: pyxis_ssl_key_secret_key
-      description: The key within the Kubernetes secret that contains the Pyxis SSL key.
+
+    - name: pipeline_ssl_key_secret_key
+      description: The key within the Kubernetes secret that contains the Pipeline SSL key.
       default: operator-pipeline.key
-    - name: ocp_registry_kubeconfig_secret_name
-      description: >-
-        The name of the Kubernetes Secret that contains the kubeconfig for service account
-        allowing connection with cluster that contains the ocp registries.
-      default: ocp-registry-kubeconfig
-    - name: ocp_registry_kubeconfig_secret_key
-      description: >-
-        The key within the Kubernetes Secret that contains the kubeconfig for service
-        account allowing connection with cluster that contains the ocp registries.
-      default: kubeconfig
     - name: kerberos_keytab_secret_name
       description: >-
         The name of the Kubernetes Secret that contains the kerberos keytab for submitting IIB builds.
@@ -154,7 +142,7 @@ spec:
         - name: url
           value: $(params.git_repo_url)
         - name: revision
-          value: $(params.git_base_branch)
+          value: $(params.git_commit)
         - name: gitInitImage
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
       workspaces:
@@ -284,23 +272,10 @@ spec:
         - name: pull_request_url
           value: "$(params.git_pr_url)"
 
-    - name: get-organization
-      runAfter:
-        - certification-project-check
-      taskRef:
-        name: get-organization
-      params:
-        - name: pipeline_image
-          value: "$(params.pipeline_image)"
-      workspaces:
-        - name: source
-          workspace: repository
-          subPath: src
-
     # Get additional data necessary for certification
     - name: get-pyxis-certification-data
       runAfter:
-        - get-organization
+        - certification-project-check
       taskRef:
         name: get-pyxis-certification-data
       params:
@@ -311,11 +286,11 @@ spec:
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
       workspaces:
         - name: source
           workspace: repository
@@ -332,7 +307,7 @@ spec:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
         - name: src_image
-          value: "$(params.src_registry)/$(params.src_image_namespace)/$(tasks.detect-changes.results.added_operator):$(tasks.detect-changes.results.added_bundle)"
+          value: "$(params.registry)/$(params.image_namespace)/$(tasks.detect-changes.results.added_operator):$(tasks.detect-changes.results.added_bundle)"
         - name: dest_image_registry_namespace_certproject
           value: "$(params.dest_registry)/$(params.dest_image_namespace)/$(tasks.certification-project-check.results.certification_project_id)"
         - name: dest_image_tag
@@ -355,7 +330,7 @@ spec:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
         - name: internal_registry
-          value: "$(params.src_registry)"
+          value: "$(params.registry)"
         - name: internal_repository
           value: "$(params.dest_image_namespace)/$(tasks.certification-project-check.results.certification_project_id)"
         - name: isv_pid
@@ -375,11 +350,11 @@ spec:
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
 
       workspaces:
         - name: image-data
@@ -490,11 +465,11 @@ spec:
         - name: sig_key_name
           value: "$(tasks.set-env.results.sig_key_name)"
         - name: umb_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: umb_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: umb_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
         - name: umb_client_name
           value: "$(tasks.set-env.results.umb_client_name)"
         - name: umb_url
@@ -523,11 +498,11 @@ spec:
         - name: signature_data_file
           value: "$(tasks.request-signature.results.signature_data_file)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
         - name: pyxis_url
           value: "$(tasks.set-env.results.pyxis_url)"
         - name: signing_pub_secret_name
@@ -596,11 +571,11 @@ spec:
         - name: pipelinerun_name
           value: "$(context.pipelineRun.name)"
         - name: pyxis_ssl_secret_name
-          value: "$(params.pyxis_ssl_secret_name)"
+          value: "$(params.pipeline_ssl_secret_name)"
         - name: pyxis_ssl_cert_secret_key
-          value: "$(params.pyxis_ssl_cert_secret_key)"
+          value: "$(params.pipeline_ssl_cert_secret_key)"
         - name: pyxis_ssl_key_secret_key
-          value: "$(params.pyxis_ssl_key_secret_key)"
+          value: "$(params.pipeline_ssl_key_secret_key)"
       workspaces:
         - name: source
           workspace: repository


### PR DESCRIPTION
Some pipeline params were no longer user and some had different names across multiple pipelines.

This commit removes unused params and rename existing to common names.