### PR TITLE
Skip index image import in community tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -107,5 +107,5 @@ jobs:
             -e "operator_bundle_version=0.1.${{ github.run_number }}-${{ github.run_attempt }}"
             -e "operator_pipeline_image_tag=${{ github.sha }}"
             -e "suffix=${{ steps.prepare.outputs.suffix }}"
-            --skip-tags=signing-pipeline
+            --skip-tags=signing-pipeline,import-index-images
             -v


### PR DESCRIPTION
The index images are not needed in the community workflow and can be skipped.