### PR TITLE
updating preflight sha to latest release of 1.9.0

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:6cab9ab1e3196bd5931e6ad2ed03aca94e494db470be06b258779131ec57e7aa
+      default: quay.io/redhat-isv/preflight-test@sha256:3cc1bd092a912cd7f2ada7c9ad7d3bbb3b465c1c0720d5086ad997252021a43d
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
```
╰─○ crane digest quay.io/opdev/preflight:1.8.1
sha256:6cab9ab1e3196bd5931e6ad2ed03aca94e494db470be06b258779131ec57e7aa
╰─○ crane digest quay.io/opdev/preflight:1.9.0
sha256:3cc1bd092a912cd7f2ada7c9ad7d3bbb3b465c1c0720d5086ad997252021a43d
```