### PR TITLE
Fix integration tests

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/community-hosted-pipeline.yml
@@ -646,7 +646,8 @@ spec:
       when:
         - input: "$(tasks.check-permissions.results.approved)"
           operator: in
-          values: ["true"]
+          values:
+            - "true"
         - input: "$(tasks.status)"
           operator: in
           values:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/check_permissions.yaml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/check_permissions.yaml
@@ -87,4 +87,4 @@ spec:
           --verbose
 
         cat "$(params.output_file)" | jq
-        cat "$(params.output_file)" | jq -r ".approved" | tee "$(results.approved.path)"
+        cat "$(params.output_file)" | jq -r ".approved" | tr -d '\r\n' | tee "$(results.approved.path)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/get-manifest-digests.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/get-manifest-digests.yml
@@ -46,7 +46,7 @@ spec:
 
             DIGEST=$(echo $i | awk -F '+' '{print $2}')
 
-            MANIFEST_LIST=$(podman manifest inspect $DIGEST)
+            MANIFEST_LIST=$(skopeo inspect --raw docker://$DIGEST)
             MANIFEST_LIST=$(echo $MANIFEST_LIST | jq -r '.manifests[].digest')
 
             # create comma separated index images that match each digest

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "operatorcert-dev", "tox"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:b106adcf0b4bfd7f466e2ce907c607b16a215a804ec7078fe61f2b61cdd5697a"
+content_hash = "sha256:0b5c869f80a07709ed8dbf171d539528022ef3d4d4cb3be684189cef814b7276"
 
 [[package]]
 name = "argcomplete"
@@ -584,11 +584,11 @@ files = [
 
 [[package]]
 name = "operator-repo"
-version = "0.4.1"
+version = "0.4.2"
 requires_python = ">=3.9"
 git = "https://github.com/mporrato/operator-repo.git"
-ref = "v0.4.1"
-revision = "f0dc42829cee804f9e1e98a3d0c8949b28865d5d"
+ref = "v0.4.2"
+revision = "cffa3b58107d92b73d7fda0853dfcf727144d999"
 summary = "Library and utilities to handle repositories of kubernetes operators"
 dependencies = [
     "pyyaml>=6.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "PyGithub<2.0,>=1.59.0",
     "GitPython>=3.1.37",
     "semver>=3.0.1",
-    "operator-repo @ git+https://github.com/mporrato/operator-repo.git@v0.4.1",
+    "operator-repo @ git+https://github.com/mporrato/operator-repo.git@v0.4.2",
     "urllib3>=2.0.7",
 ]
 


### PR DESCRIPTION
 - Permission check ignored the ci.yaml file. This has been addressed in the oprator repo library
 - The podman is still broken and is now replaced by skopeo