### PR TITLE
updating multi-arch job to run on ubuntu-latest

### DIFF
--- a/.github/workflows/build-multi-arch-image.yml
+++ b/.github/workflows/build-multi-arch-image.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         architecture: [amd64, ppc64le, s390x, arm64]
         platform: [linux]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: add checkout action...
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
   build-multiarch:
     needs: build-multiarch-images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Create and add to manifest
         run: |


### PR DESCRIPTION
- Updating job to run on `ubuntu-latest`
- See Job [here](https://github.com/acornett21/operator-pipelines/actions/runs/8143818463/job/22256500453) which passes.