### PR TITLE
[ISV-4595] event listener allows modification of catalogs dir

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/community-pipeline-event-listener.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-pipeline-event-listener.yml
@@ -46,7 +46,7 @@
                             header.match("X-GitHub-Event", "pull_request")
                             && body.action in ["opened", "reopened", "synchronize"]
                             && body.pull_request.base.ref == "{{ branch }}"
-                            && extensions.changed_files.matches("operators/")
+                            && (extensions.changed_files.matches("operators/") || extensions.changed_files.matches("catalogs/"))
                           )
                 bindings:
                   - ref: community-operator-hosted-pipeline-trigger-binding
@@ -80,7 +80,7 @@
                             && body.action == "closed"
                             && body.pull_request.base.ref == "{{ branch }}"
                             && body.pull_request.merged == true
-                            && extensions.changed_files.matches("operators/")
+                            && (extensions.changed_files.matches("operators/") || extensions.changed_files.matches("catalogs/"))
                           )
                 bindings:
                   - ref: community-operator-release-pipeline-trigger-binding

--- a/ansible/roles/operator-pipeline/tasks/operator-pipeline-event-listener.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-pipeline-event-listener.yml
@@ -22,19 +22,29 @@
               # run Hosted pipeline on PR opened, reopened, synchronized
               - name: github-pull-request-listener-hosted
                 interceptors:
-                  - github:
-                      secretRef:
-                        secretName: github-webhook-secret
-                        secretKey: webhook-secret
-                      eventTypes:
-                        - pull_request
-                  - cel:
-                      filter: >-
-                        (
-                          header.match("X-GitHub-Event", "pull_request")
-                          && body.action in ["opened", "reopened", "synchronize"]
-                          && body.pull_request.base.ref == "{{ branch }}"
-                        )
+                  - ref:
+                      name: "github"
+                    params:
+                      - name: "secretRef"
+                        value:
+                          secretName: github-webhook-secret
+                          secretKey: webhook-secret
+                      - name: "eventTypes"
+                        value: ["pull_request"]
+                      - name: "addChangedFiles"
+                        value:
+                          enabled: true
+                  - ref:
+                      name: cel
+                    params:
+                      - name: filter
+                        value: >-
+                          (
+                            header.match("X-GitHub-Event", "pull_request")
+                            && body.action in ["opened", "reopened", "synchronize"]
+                            && body.pull_request.base.ref == "{{ branch }}"
+                            && (extensions.changed_files.matches("operators/") || extensions.changed_files.matches("catalogs/"))
+                          )
                 bindings:
                   - ref: operator-hosted-pipeline-trigger-binding
                 template:
@@ -62,21 +72,31 @@
               # run Release pipeline on merged PR
               - name: github-pull-request-listener-release
                 interceptors:
-                  - github:
-                      secretRef:
-                        secretName: github-webhook-secret
-                        secretKey: webhook-secret
-                      eventTypes:
-                        - pull_request
-                  - cel:
-                      filter: >-
-                        (
-                          header.match("X-GitHub-Event", "pull_request")
-                          && body.action == "closed"
-                          && body.pull_request.base.ref == "{{ branch }}"
-                          && body.pull_request.merged == true
-                          && body.sender.login == "rh-operator-bundle-bot"
-                        )
+                  - ref:
+                      name: "github"
+                    params:
+                      - name: "secretRef"
+                        value:
+                          secretName: github-webhook-secret
+                          secretKey: webhook-secret
+                      - name: "eventTypes"
+                        value: ["pull_request"]
+                      - name: "addChangedFiles"
+                        value:
+                          enabled: true
+                  - ref:
+                      name: cel
+                    params:
+                      - name: filter
+                        value: >-
+                          (
+                            header.match("X-GitHub-Event", "pull_request")
+                            && body.action == "closed"
+                            && body.pull_request.base.ref == "{{ branch }}"
+                            && body.pull_request.merged == true
+                            && (extensions.changed_files.matches("operators/") || extensions.changed_files.matches("catalogs/"))
+                            && body.sender.login == "rh-operator-bundle-bot"
+                          )
                 bindings:
                   - ref: operator-release-pipeline-trigger-binding
                 template:


### PR DESCRIPTION
Based on the new repository structure outlined in [FBC<-> ISV integration doc](https://docs.google.com/document/d/1GRPfLm6r-aclZaSsX-OP5vrlAOKnmPUq9k9pP3RGijU/edit#heading=h.n4zfkq3fn1ym) extension for directory changes was updated with `catalogs/` dir for the community pipeline; for isv hosted/release pipeline both `catalogs/` and `operators/` dir were included to monitor changes in both directories
It was tested on both [community](https://github.com/redhat-openshift-ecosystem/community-operators-pipeline-preprod/pull/236) and [certified operators](https://github.com/redhat-openshift-ecosystem/certified-operators-preprod/pull/4249) repo with dir filtering extension turned on/off

---
Closes [ISV-4595](https://issues.redhat.com/browse/ISV-4595)