### PR TITLE
Fix a graph loop test

### DIFF
--- a/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
+++ b/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
@@ -303,7 +303,8 @@ def follow_graph(graph: Any, bundle: Bundle, visited: List[Bundle]) -> List[Bund
     visited.append(bundle)
     next_bundles = graph[bundle]
     for next_bundle in next_bundles:
-        follow_graph(graph, next_bundle, visited)
+        visited_copy = visited.copy()
+        follow_graph(graph, next_bundle, visited_copy)
     return visited
 
 


### PR DESCRIPTION
The loop test needs to reset the visited list in case there are more than one path from the current node. Before this commit the update graph path could overlap which causes false negatives.

This fixes a false negatives in case there are multiple paths in upgrade graph.