### PR TITLE
Upload pipeline logs to GitHub Gist in isv pipelines

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -1200,6 +1200,8 @@ spec:
           value: "$(params.github_token_secret_key)"
         - name: pipelinerun
           value: "$(context.pipelineRun.name)"
+        - name: upload_pipeline_logs
+          value: "true"
         - name: comment_suffix
           value: |
 

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -714,6 +714,8 @@ spec:
           value: "$(params.github_token_secret_key)"
         - name: pipelinerun
           value: "$(context.pipelineRun.name)"
+        - name: upload_pipeline_logs
+          value: "true"
         - name: comment_suffix
           value: |
 


### PR DESCRIPTION
Both isv pipelines uploads logs to gist and adds a link to the pipeline summary comment.

JIRA: ISV-4638