### PR TITLE
adding a timeout to preflight trigger task to insure logs from prow

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
@@ -171,6 +171,7 @@ spec:
               --output-path prowjob-base-url
           fi
       workingDir: $(workspaces.output.path)
+      timeout: "1h15m0s"
     - env:
         - name: PIPELINE_GPG_DECRYPTION_PRIVATE_KEY
           value: /etc/gpg-key/$(params.gpg_decryption_private_key_secret_key)


### PR DESCRIPTION
## Motivation
After looking into recent prow failures, and the pipeline not having logs, it seems that prow takes a few minutes longer to report back the failures, even though it also has a 60min timeout. So having the default 60mins in the pipeline, doesn't really make sense. Below are some sample prow job run times.

[https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-red[…]tem-certified-operators-prod-ocp-4.13-preflight-prod-claim](https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-redhat-openshift-ecosystem-certified-operators-prod-ocp-4.13-preflight-prod-claim)
[https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-red[…]tem-certified-operators-prod-ocp-4.14-preflight-prod-claim](https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-redhat-openshift-ecosystem-certified-operators-prod-ocp-4.14-preflight-prod-claim)

## Changes
I just added a timeout to the specific step that triggers prow, I feel like this is correct, but if we want it on the overall job/task, happy to adjust as well.