### PR TITLE
Add github secrets to isv event listener

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/operator-pipeline-event-listener.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-pipeline-event-listener.yml
@@ -34,6 +34,9 @@
                       - name: "addChangedFiles"
                         value:
                           enabled: true
+                          personalAccessToken:
+                            secretName: github-bot-token
+                            secretKey: github_bot_token
                   - ref:
                       name: cel
                     params:
@@ -84,6 +87,9 @@
                       - name: "addChangedFiles"
                         value:
                           enabled: true
+                          personalAccessToken:
+                            secretName: github-bot-token
+                            secretKey: github_bot_token
                   - ref:
                       name: cel
                     params:


### PR DESCRIPTION
Github secrets were missing for the isv event listener. This caused an error limiting from the Github API.