### PR TITLE
Make cert project optional for the hosted pipeline

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -135,6 +135,12 @@ spec:
       description: A comma separate list of paths to a test suite that is executed
       default: operatorcert.static_tests.isv,operatorcert.static_tests.common
 
+    - name: cert_project_required
+      description: >-
+        A flag determines whether a cert project identifier is required
+        for the pipeline. The flag distinguish between ISV and community operators.
+      default: "true"
+
   workspaces:
     - name: repository
     - name: results
@@ -377,6 +383,8 @@ spec:
           value: "$(params.pipeline_image)"
         - name: bundle_path
           value: "$(tasks.detect-changes.results.bundle_path)"
+        - name: cert_project_required
+          value: "$(params.cert_project_required)"
       workspaces:
         - name: source
           workspace: repository
@@ -426,6 +434,10 @@ spec:
         - get-pyxis-certification-data
       taskRef:
         name: verify-project
+      when: &certProjectExists
+        - input: "$(tasks.certification-project-check.results.certification_project_id)"
+          operator: "notin"
+          values: [""]
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
@@ -443,6 +455,7 @@ spec:
         - verify-project
       taskRef:
         name: update-cert-project-status
+      when: *certProjectExists
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
@@ -467,6 +480,7 @@ spec:
         - update-cert-project-status
       taskRef:
         name: reserve-operator-name
+      when: *certProjectExists
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
@@ -563,6 +577,9 @@ spec:
           value: "$(params.pipeline_image)"
         - name: bundle_path
           value: "$(tasks.detect-changes.results.bundle_path)"
+        # Pin digest only for ISV projects
+        - name: enabled
+          value: "$(params.cert_project_required)"
       workspaces:
         - name: source
           workspace: repository
@@ -594,6 +611,7 @@ spec:
         - reserve-operator-name
       taskRef:
         name: merge-registry-credentials
+      when: *certProjectExists
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
@@ -808,6 +826,7 @@ spec:
         - preflight-trigger
       taskRef:
         name: upload-artifacts
+      when: *certProjectExists
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
@@ -878,6 +897,7 @@ spec:
         - evaluate-preflight-result
       taskRef:
         name: get-ci-results
+      when: *certProjectExists
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
@@ -914,6 +934,7 @@ spec:
         - get-ci-results
       taskRef:
         name: link-pull-request
+      when: *certProjectExists
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
@@ -938,6 +959,7 @@ spec:
         - link-pull-request-with-open-status
       taskRef:
         name: query-publishing-checklist
+      when: *certProjectExists
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
@@ -1014,6 +1036,7 @@ spec:
     - name: upload-pipeline-logs
       taskRef:
         name: upload-pipeline-logs
+      when: *certProjectExists
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
@@ -1047,6 +1070,9 @@ spec:
     # with the support link pointing to the affected PR
     - name: post-support-link-for-pr
       when:
+        - input: "$(tasks.certification-project-check.results.certification_project_id)"
+          operator: "notin"
+          values: [""]
         - input: $(tasks.status)
           operator: notin
           values: ["Succeeded", "Completed"]
@@ -1074,6 +1100,7 @@ spec:
     - name: github-add-connect-url-comment
       taskRef:
         name: github-add-comment
+      when: *certProjectExists
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/cert-project-check.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/cert-project-check.yml
@@ -8,6 +8,9 @@ spec:
     - name: pipeline_image
     - name: bundle_path
       description: path indicating the location of the certified bundle within the repository
+    - name: cert_project_required
+      description: A flag determines whether a cert project ID needs to be present
+      default: "true"
   results:
     - name: certification_project_id
       description: Identifier of certification project from Red Hat Connect
@@ -19,6 +22,7 @@ spec:
       workingDir: $(workspaces.source.path)
       script: |
         #! /usr/bin/env bash
+        set -xe
         echo "Checking availability of cert project identifier"
 
         PKG_PATH=$(dirname $(realpath $(params.bundle_path)))
@@ -28,8 +32,14 @@ spec:
         CERT_PROJECT_ID=$(cat $CI_FILE_PATH | yq -r '.cert_project_id | select (.!=null)')
 
         if [ -z $CERT_PROJECT_ID ]; then
-          echo "Certification project ID is missing in ci.yaml file (cert_project_id)"
-          exit 1
+          if [ "$(params.cert_project_required)" == "true" ]; then
+            echo "Certification project ID is missing in ci.yaml file (cert_project_id)"
+            exit 1
+          else
+            echo "Cert project ID is not required."
+            echo -n "" | tee $(results.certification_project_id.path)
+            exit 0
+          fi
         fi
 
         echo -n $CERT_PROJECT_ID | tee $(results.certification_project_id.path)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/check_permissions.yaml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/check_permissions.yaml
@@ -55,7 +55,7 @@ spec:
     - name: approved
       description: "An indication whether a changes introduced in the PR are authorized"
   steps:
-    - name: build-fragment-images
+    - name: check-permissions
       image: "$(params.pipeline_image)"
       workingDir: $(workspaces.output.path)
       env:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
@@ -27,6 +27,11 @@ spec:
         #! /usr/bin/env bash
         set -xe
 
+        if [ "$(params.enabled)" != "true" ]; then
+          echo "Digest pinning is not enabled"
+          exit 0
+        fi
+
         if [[ "$(workspaces.registry-credentials.bound)" == "true" ]]; then
           # Setup registry credentials for pinning tools. Combine the default credentials
           # with those found in the workspace to maintain access to the internal

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/get-pyxis-certification-data.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/get-pyxis-certification-data.yml
@@ -61,6 +61,21 @@ spec:
       script: |
         #! /usr/bin/env bash
         set -xe -o pipefail
+        if [ "$(params.cert_project_id)" == "" ]; then
+
+          # The project is not present - return a default empty values
+          echo -n | tee \
+              "$(results.new_certification_status.path)" \
+              "$(results.isv_pid.path)" \
+              "$(results.repo_name.path)" \
+              "$(results.operator_distribution.path)" \
+              "$(results.org_id.path)" \
+              "$(results.contacts.path)" \
+              "$(results.current_certification_status.path)" \
+              "$(results.github_usernames.path)" \
+              "$(results.project_status.path)"
+          exit 0
+        fi
 
         get-cert-project-related-data \
           --pyxis-url $(params.pyxis_url) \
@@ -119,6 +134,10 @@ spec:
       script: |
         #! /usr/bin/env bash
         set -xe -o pipefail
+        if [ "$(params.cert_project_id)" == "" ]; then
+          echo -n "" | tee "$(results.vendor_label.path)"
+          exit 0
+        fi
 
         ORG_ID=$(cat org_id.txt)
 


### PR DESCRIPTION
The isv hosted pipeline now supports an optional cert projects. In case the project is set as an optional a various tasks that directly or indirectly depends on the project are skipped.

JIRA: ISV-4631