### PR TITLE
Skip preflight test only when previous attempt was sucesfull

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -819,6 +819,11 @@ spec:
           value: "$(params.prow_kubeconfig_secret_key)"
         - name: test_result_path
           value: "$(tasks.get-ci-results-attempt.results.preflight_results)"
+        # Skip preflight trigger in case there was a previous SUCCESSFUL test
+        # The test could be executed in CI or hosted pipeline but it needs
+        # to be successful. Previous failed test don't skip this task.
+        - name: skip
+          value: "$(tasks.get-ci-results-attempt.results.preflight_results_exists)"
         - name: github_token_secret_name
           value: "$(params.github_token_secret_name)"
         - name: github_token_secret_key

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight-trigger.yml
@@ -55,6 +55,11 @@ spec:
     - name: test_result_path
       description: "A path to existing test results. This indicates if we can skip a preflight test."
       default: "none"
+
+    - name: skip
+      description: "Set to 'true' to skip"
+      default: 'false'
+      type: string
   results:
     - description: ''
       name: log_output_file
@@ -90,7 +95,7 @@ spec:
       script: |
           #!/usr/bin/env bash
 
-          if [ "$(params.test_result_path)" != "none" ]; then
+          if [ "$(params.skip)" == "true" ]; then
               echo "Preflight testing has been skipped"
               exit 0
           fi
@@ -129,7 +134,7 @@ spec:
       script: |
           #!/usr/bin/env bash
 
-          if [ "$(params.test_result_path)" != "none" ]; then
+          if [ "$(params.skip)" == "true" ]; then
               echo "Preflight testing has been skipped"
               exit 0
           fi
@@ -191,7 +196,7 @@ spec:
       script: |
           #!/usr/bin/env bash
 
-          if [ "$(params.test_result_path)" != "none" ]; then
+          if [ "$(params.skip)" == "true" ]; then
               echo "Preflight testing has been skipped"
               echo -n "none" > "$(results.log_output_file.path)"
               echo -n "$(params.test_result_path)" > "$(results.result_output_file.path)"


### PR DESCRIPTION
There was a bug introduced in recent commit that cause a preflight to be skipped even for previous attempts that weren't successful.

This commit fixes the workflow to skip a preflight only when test was successful and always execute preflight when previous attempt wasn't found or attempt failed.

JIRA: ISV-4741