### PR TITLE
[ISV-4299] Add explicit token permissions to release step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,6 +133,7 @@ jobs:
   release:
     name: Github release
     runs-on: ubuntu-latest
+    permissions: write-all
     needs:
       - deploy-prod
     steps:


### PR DESCRIPTION
The cause of the "_Resource not accessible by integration_" error seems to be something related to the github token permissions:
* https://github.com/mathieudutour/github-tag-action/issues/138
* https://stackoverflow.com/questions/75995802/resource-not-accessible-by-integration-github-action-fails-for-pushed-commit

I'd be worth to try add this explicit declaration of token permissions to the _release_ job and observe if the problem does not appear anymore.