### PR TITLE
Fix icon validation when base64data contains whitespace

### DIFF
--- a/operator-pipeline-images/operatorcert/static_tests/community/validations.py
+++ b/operator-pipeline-images/operatorcert/static_tests/community/validations.py
@@ -5,6 +5,7 @@
 import binascii
 import datetime
 from base64 import b64decode
+import string
 from typing import Any
 
 from dateutil.parser import isoparse
@@ -109,11 +110,13 @@ def validate_icon(value: Any) -> bool:
     if len(value) < 1:
         return False
     for icon in value:
-        # base64data must contain valid base64 data
-        if len(icon["base64data"]) < 4:
+        # remove all whitespace from the base64 payload
+        data = icon["base64data"].translate({ord(c): None for c in string.whitespace})
+        # check that the content is valid base64 encoded data
+        if len(data) < 4:
             return False
         try:
-            _ = b64decode(icon["base64data"], validate=True)
+            _ = b64decode(data, validate=True)
         except binascii.Error:
             return False
         # mediatype must be a supported image format

--- a/operator-pipeline-images/tests/static_tests/community/test_validations.py
+++ b/operator-pipeline-images/tests/static_tests/community/test_validations.py
@@ -127,6 +127,8 @@ def test_validate_list_of_dicts(
         ([{"base64data": "", "mediatype": "image/png"}], False),
         ([{"base64data": "foobar", "mediatype": "image/png"}], False),
         ([{"base64data": "Zm9v", "mediatype": "text/plain"}], False),
+        ([{"base64data": "Zm^v", "mediatype": "image/png"}], False),
+        ([{"base64data": " Zm\n9v\n", "mediatype": "image/png"}], True),
     ],
     indirect=False,
     ids=[
@@ -135,6 +137,8 @@ def test_validate_list_of_dicts(
         "Empty base64data",
         "Invalid base64data",
         "Invalid mediatype",
+        "Invalid characters in base64data",
+        "Whitespace in base64data",
     ],
 )
 def test_validate_icon(value: Any, expected: bool) -> None:


### PR DESCRIPTION
Fixes https://github.com/redhat-openshift-ecosystem/community-operators-prod/issues/4328