### PR TITLE
Add FBC Makefile + doc

### DIFF
--- a/docs/users/fbc_workflow.md
+++ b/docs/users/fbc_workflow.md
@@ -1,0 +1,171 @@
+# FBC workflow
+
+The prerequisite for the File Based Catalog workflow is to convert the existing operator
+to FBC format. This can be done by following a [onboarding](./fbc_onboarding.md) documentation.
+
+After an existing operator is onboard or you introduce a brand new operator you can
+start the FBC workflow.
+
+### FBC operator config
+To indicate the operator is using fbc workflow an operator owner needs to indicate this
+fact in the `ci.yaml` file.
+
+Example of the `ci.yaml` with FBC config:
+```yaml
+---
+fbc:
+  enabled: true
+```
+
+## FBC templates
+File-based catalog templates serve as a simplified view of a catalog that can be updated
+by the user. The OPM currently supports 3 types of templates and it is up to the user which
+template the operator will be using.
+
+* Basic template
+* SemVer template
+* Composite template
+
+More information about each template can be found at [opm doc](https://olm.operatorframework.io/docs/reference/catalog-templates/).
+
+The recommended template from the maintainability point of view is `SemVer` or `Composite` with
+`SemVer`integration.
+
+## Generate catalogs using templates
+To generate a final catalog for an operator a user needs to execute different `opm`
+commands based on the template type. We as operator pipeline maintainers want
+to simplify this process and we prepared a `Makefile` with all pre-configured targets.
+
+To get the `Makefile` follow these steps
+
+```bash
+cd <operator-repo>/operator/<operator-name>
+wget https://raw.githubusercontent.com/redhat-openshift-ecosystem/operator-pipelines/main/fbc/Makefile
+```
+
+The right place for the Makefile is in the operator's root directory
+```
+.
+├── 0.0.1
+│   ├── manifests
+│   └── metadata
+├── catalogs.yaml
+├── catalog-templates
+├── ci.yaml
+├── composite-config.yaml
+└── Makefile
+
+```
+
+You can modify the Makefile based on your needs and use it to generate catalogs by running `make catalog`.
+The command uses the `opm` and converts templates into catalogs. The generated catalogs
+can be submitted as a PR in Github and once the PR is processed changes will be released to the
+OCP index.
+
+```bash
+$ tree catalogs
+catalogs
+├── v4.12
+│   └── aqua
+│       └── catalog.yaml
+├── v4.13
+│   └── aqua
+│       └── catalog.yaml
+├── v4.14
+│   └── aqua
+│       └── catalog.yaml
+├── v4.15
+│   └── aqua
+│       └── catalog.yaml
+└── v4.16
+    └── aqua
+        └── catalog.yaml
+
+```
+
+### Adding new bundle to Catalog
+To add a bundle to the catalog you need to first submit the new version of the operator
+using traditional [PR workflow](./contributing-via-pr.md). The operator pipeline builds,
+tests, and releases the bundle into the registry. At this point, the operator is not available
+in the catalog yet. To add the bundle to the catalog you need to update catalog templates
+and add a bundle pullspec given by pull request comment and open a new pull request with catalog
+changes.
+
+#### SemVer
+For example if I want to add `v1.1.0` bundle into `Fast` channel of a specific catalog I'll
+add it as mentioned in the example below:
+
+```yaml
+---
+Schema: olm.semver
+GenerateMajorChannels: true
+GenerateMinorChannels: true
+Candidate:
+  Bundles:
+  - Image: quay.io/foo/olm:testoperator.v0.1.0
+  - Image: quay.io/foo/olm:testoperator.v0.1.1
+  - Image: quay.io/foo/olm:testoperator.v0.1.2
+  - Image: quay.io/foo/olm:testoperator.v0.1.3
+  - Image: quay.io/foo/olm:testoperator.v0.2.0
+  - Image: quay.io/foo/olm:testoperator.v0.2.1
+  - Image: quay.io/foo/olm:testoperator.v0.2.2
+  - Image: quay.io/foo/olm:testoperator.v0.3.0
+  - Image: quay.io/foo/olm:testoperator.v1.0.0
+  - Image: quay.io/foo/olm:testoperator.v1.0.1
+  - Image: quay.io/foo/olm:testoperator.v1.1.0
+Fast:
+  Bundles:
+  - Image: quay.io/foo/olm:testoperator.v0.2.1
+  - Image: quay.io/foo/olm:testoperator.v0.2.2
+  - Image: quay.io/foo/olm:testoperator.v0.3.0
+  - Image: quay.io/foo/olm:testoperator.v1.0.0
+  - Image: quay.io/foo/olm:testoperator.v1.1.0 # <-- Add new bundle into fast channel
+Stable:
+  Bundles:
+  - Image: quay.io/foo/olm:testoperator.v1.0.0
+```
+Also see [opm doc](https://olm.operatorframework.io/docs/advanced-tasks/catalog-update-formulary/#fbc)
+for automate-able step.
+
+#### Basic
+For example, if I want to add `v0.2.0` bundle into `stable` channel of specific catalog I'll
+add it as mentioned in the example below.
+
+1. Add a new `olm.bundle` entry with bundle pullspec
+2. Add bundle into the `stable` channel
+
+```yaml
+---
+schema: olm.package
+name: example-operator
+defaultChannel: stable
+
+---
+schema: olm.channel
+package: example-operator
+name: stable
+entries:
+- name: example-operator.v0.1.0
+- name: example-operator.v0.2.0 # <-- Add bundle into channel
+  replaces: example-operator.v0.1.0
+
+---
+schema: olm.bundle
+image: docker.io/example/example-operator-bundle:0.1.0
+
+---
+schema: olm.bundle # <-- Add new bundle entry
+image: docker.io/example-operator-bundle:0.2.0
+```
+
+Also see [opm doc](https://olm.operatorframework.io/docs/advanced-tasks/catalog-update-formulary/#semver)
+for automate-able step.
+
+### Updating existing catalogs
+A great benefit of FBC is that users can update operator update graphs independently
+of operator releases. This allows any post-release modification of the catalogs.
+If you want to change the order of updates, remove an invalid bundle, or do any other modification
+you are free to do that.
+
+After updating catalog templates don't forget to run `make catalog` to generate a catalog
+from templates and submit the resulting catalog using PR workflow.

--- a/fbc/Makefile
+++ b/fbc/Makefile
@@ -1,0 +1,107 @@
+# This Makefile provides a set of targets to generate and validate operator catalogs
+# using the Operator Package Manager (opm) tool.
+
+# The makefile should be placed in the root of the operator repository.
+# for example at: <operator-repo>/operators/<operator-name>/Makefile
+
+# A user can customize "catalog" target to generate the operator catalog in a way
+# that suits the operator.
+# OPM allows for the generation of catalogs using different templates.
+# - basic: generates a basic catalog
+# - semver: generates a catalog with semver versioning
+# - composite: generates a catalog using a composite template
+
+PDW=$(shell pwd)
+OPERATOR_NAME=$(shell basename $(PDW))
+TOPDIR=$(abspath $(dir $(PWD))/../)
+BINDIR=${TOPDIR}/bin
+
+# A place to store the generated catalogs
+CATALOG_DIR=${TOPDIR}/catalogs
+
+# A place to store the operator catalog templates
+OPERATOR_CATALOG_TEMPLATE_DIR = ${PDW}/catalog-templates
+
+# A list of OCP versions to generate catalogs for
+# This list can be customized to include the versions that are relevant to the operator
+OCP_VERSIONS=$(shell echo "v4.12 v4.13 v4.14 v4.15 v4.16" )
+
+
+#
+.PHONY: fbc-onboarding
+fbc-onboarding: fbc-onboarding-deps clean
+	fbc-onboarding \
+		--repo-root $(TOPDIR) \
+		--operator-name $(OPERATOR_NAME) \
+		--cache-dir $(TOPDIR)/.catalog_cache \
+		--verbose
+
+.PHONY: catalog
+# replace this stub with one customized to serve your needs ... some examples below
+
+# here are a few examples of different approaches to fulfilling this target
+# comment out / customize the one that makes the most sense, or use them as examples in defining your own
+#
+# --- BASIC TEMPLATE ---
+#catalog: basic
+#
+# --- SEMVER TEMPLATE ---
+#catalog: semver
+#
+# --- COMPOSITE TEMPLATE ---
+catalog: composite
+
+# basic target provides an example FBC generation from a `basic` template type.
+# this example takes a single file as input and generates a well-formed FBC operator contribution as an output
+.PHONY: basic
+basic: ${BINDIR}/opm clean
+	for version in $(OCP_VERSIONS); do \
+		mkdir -p ${CATALOG_DIR}/$${version}/${OPERATOR_NAME}/ && \
+		${BINDIR}/opm alpha render-template basic -o yaml ${OPERATOR_CATALOG_TEMPLATE_DIR}/$${version}.yaml > ${CATALOG_DIR}/$${version}/${OPERATOR_NAME}/catalog.yaml; \
+	done
+
+
+# semver target provides an example FBC generation from a `semver` template type.
+# this example takes a single file as input and generates a well-formed FBC operator contribution as an output
+.PHONY: semver
+semver: ${BINDIR}/opm clean
+	for version in $(OCP_VERSIONS); do \
+		mkdir -p ${CATALOG_DIR}/$${version}/${OPERATOR_NAME}/ && \
+		${BINDIR}/opm alpha render-template semver -o yaml  ${OPERATOR_CATALOG_TEMPLATE_DIR}/$${version}.yaml > ${CATALOG_DIR}/$${version}/${OPERATOR_NAME}/catalog.yaml; \
+	done
+
+# composite target processes a composite template to generate the FBC contributions
+# `render-template composite` has `--validate` option enabled by default,
+# so no subsequent validation is required
+.PHONY: composite
+composite: ${BINDIR}/opm clean
+	${BINDIR}/opm alpha render-template composite -f ${PDW}/catalogs.yaml -c ${PDW}/composite-config.yaml
+
+#
+# validate target illustrates FBC validation
+# all FBC must pass opm validation in order to be able to be used in a catalog
+.PHONY: validate
+validate: ${BINDIR}/opm
+	${BINDIR}/opm validate $(CATALOG_DIR) && echo "catalog validation passed" || echo "catalog validation failed"
+
+.PHONY: create-catalog-dir
+create-catalog-dir:
+	mkdir -p $(CATALOG_DIR)
+
+.PHONY: clean
+clean: create-catalog-dir
+	find $(CATALOG_DIR) -type d -name ${OPERATOR_NAME} -exec rm -rf {} +
+
+# fbc-onboarding-deps installs the fbc-onboarding tool using pip
+.PHONY: fbc-onboarding-deps
+fbc-onboarding-deps:
+	pip install git+https://github.com/redhat-openshift-ecosystem/operator-pipelines.git
+
+OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(shell uname -m | sed 's/x86_64/amd64/')
+
+# Automatically download the opm binary
+OPM_VERSION ?= v1.40.0
+${BINDIR}/opm:
+	if [ ! -d ${BINDIR} ]; then mkdir -p ${BINDIR}; fi
+	curl -sLO https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$(OS)-$(ARCH)-opm && chmod +x $(OS)-$(ARCH)-opm && mv $(OS)-$(ARCH)-opm ${BINDIR}/opm

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,8 @@ nav:
       - "Before submitting your Operator": "users/contributing-prerequisites.md"
       - "Where to place operator": "users/contributing-where-to.md"
       - "Best practices": "users/best-practices.md"
-      - "File base catalog": "users/fbc_onboarding.md"
+      - "File base catalog onboarding": "users/fbc_onboarding.md"
+      - "File base catalog workflow": "users/fbc_workflow.md"
       - "OKD/OpenShift Catalogs criteria and options": "users/packaging-required-criteria-ocp.md"
   - "Admin":
       - "Admin guide": "pipeline-admin-guide.md"


### PR DESCRIPTION
The Makefile will be used by operator owners to generate catalogs from templates. This file simplifies the workflow and hides any opm related commands from a user.

The commit also introduces a user documentation for a FBC workflow.

JIRA: ISV-4512