### PR TITLE
updating preflight sha for version 1.9.5

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:138709be6c93714223077341f29c114e2c6d8769e895df1434a26de6c663c7e5
+      default: quay.io/redhat-isv/preflight-test@sha256:8cd846a504d869a79186b508c3b5e973eda6b1fa67c5095c4319cdc03d332f88
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
```
❯ crane digest quay.io/redhat-isv/preflight-test:1.9.4
sha256:138709be6c93714223077341f29c114e2c6d8769e895df1434a26de6c663c7e5

~ 
❯ crane digest quay.io/redhat-isv/preflight-test:1.9.5
sha256:8cd846a504d869a79186b508c3b5e973eda6b1fa67c5095c4319cdc03d332f88
```