### PR TITLE
[ISV-4889] Pipeline timeouts do not trigger cleanup tasks

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/community-hosted-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-hosted-pipeline-trigger.yml
@@ -94,6 +94,7 @@
                 spec:
                   timeouts:
                     pipeline: "2h"
+                    tasks: "1h50m"
                   pipelineRef:
                     name: operator-hosted-pipeline
                   params:

--- a/ansible/roles/operator-pipeline/tasks/community-release-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-release-pipeline-trigger.yml
@@ -87,7 +87,8 @@
                     git_pull_request_url: $(tt.params.git_pr_url)
                 spec:
                   timeouts:
-                    pipeline: "1h30m0s"
+                    pipeline: "4h15m0s"
+                    tasks: "4h5m"
                   pipelineRef:
                     name: operator-release-pipeline
                   params:

--- a/ansible/roles/operator-pipeline/tasks/operator-hosted-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-hosted-pipeline-trigger.yml
@@ -91,6 +91,7 @@
                 spec:
                   timeouts:
                     pipeline: "2h"
+                    tasks: "1h50m"
                   pipelineRef:
                     name: operator-hosted-pipeline
                   params:

--- a/ansible/roles/operator-pipeline/tasks/operator-release-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-release-pipeline-trigger.yml
@@ -80,6 +80,7 @@
                 spec:
                   timeouts:
                     pipeline: "4h15m0s"
+                    tasks: "4h5m"
                   pipelineRef:
                     name: operator-release-pipeline
                   params:


### PR DESCRIPTION
- Update pipeline timeouts to leave some margin for cleanup tasks
- Bump the timeout for for the community release pipeline from 1h30m to 4h15m to align to the isv release pipeline as we are sometimes hitting the timeout when a bunch of PRs are submitted at the same time (typically with ack-* operators)