### PR TITLE
Set channel of test operator based on version

### DIFF
--- a/ansible/roles/integration_tests/tasks/test_data.yml
+++ b/ansible/roles/integration_tests/tasks/test_data.yml
@@ -28,6 +28,7 @@
     # Modify the test operator version
     cp -avr $SRC_VERSION $DEST_VERSION
     find $DEST_VERSION/ -type f -exec sed -i "s/${SRC_VERSION//\./\\.}/$DEST_VERSION/g" {} \;
+    find $DEST_VERSION/metadata/annotations.yaml -type f -exec sed -i "s/stable/$DEST_VERSION/g" {} \;
     diff -bur $SRC_VERSION/ $DEST_VERSION/ || true
     rm -rv ./$SRC_VERSION
 


### PR DESCRIPTION
In many cases when running integration tests we faced a conflict of version when adding bundle to index. This changes creates new channel for each bundle.