### PR TITLE
[ISV-4915] Fix corner cases in check_operator_name

### DIFF
--- a/operator-pipeline-images/operatorcert/static_tests/common/bundle.py
+++ b/operator-pipeline-images/operatorcert/static_tests/common/bundle.py
@@ -42,11 +42,6 @@ def check_operator_name(bundle: Bundle) -> Iterator[CheckResult]:
     other_bundles = all_bundles - {bundle}
     other_metadata_operator_names = {x.metadata_operator_name for x in other_bundles}
     other_csv_operator_names = {x.csv_operator_name for x in other_bundles}
-    # Count how many unique names are in use in the CSV and annotations.yaml across
-    # all other bundles. Naming is consistent if the count is zero (when the bundle
-    # under test is the only bundle for its operator) or one
-    consistent_metadata_names = len(other_metadata_operator_names) < 2
-    consistent_csv_names = len(other_csv_operator_names) < 2
     if other_bundles:
         yield from _check_consistency(
             bundle.metadata_operator_name,
@@ -65,16 +60,10 @@ def check_operator_name(bundle: Bundle) -> Iterator[CheckResult]:
             f"Operator name from annotations.yaml ({bundle.metadata_operator_name})"
             f" does not match the name defined in the CSV ({bundle.csv_operator_name})"
         )
-        if consistent_metadata_names and consistent_csv_names:
-            yield Fail(msg)
-        else:
-            yield Warn(msg)
+        yield Warn(msg) if other_bundles else Fail(msg)
     if bundle.metadata_operator_name != bundle.operator_name:
         msg = (
             f"Operator name from annotations.yaml ({bundle.metadata_operator_name})"
             f" does not match the operator's directory name ({bundle.operator_name})"
         )
-        if consistent_metadata_names:
-            yield Fail(msg)
-        else:
-            yield Warn(msg)
+        yield Warn(msg) if other_bundles else Fail(msg)

--- a/operator-pipeline-images/tests/static_tests/common/test_bundle.py
+++ b/operator-pipeline-images/tests/static_tests/common/test_bundle.py
@@ -141,12 +141,12 @@ from typing import Any
             ("hello", "0.0.3"),
             {
                 (
-                    Fail,
+                    Warn,
                     "Operator name from annotations.yaml (foo) does not match"
                     " the operator's directory name (hello)",
                 ),
                 (
-                    Fail,
+                    Warn,
                     "Operator name from annotations.yaml (foo) does not match"
                     " the name defined in the CSV (hello)",
                 ),
@@ -171,7 +171,7 @@ from typing import Any
             ("hello", "0.0.3"),
             {
                 (
-                    Fail,
+                    Warn,
                     "Operator name from annotations.yaml (hello) does not match"
                     " the name defined in the CSV (foo)",
                 ),
@@ -182,6 +182,34 @@ from typing import Any
                 ),
             },
             id="Wrong CSV name, consistent bundles",
+        ),
+        pytest.param(
+            [
+                bundle_files(
+                    "hello",
+                    "0.0.1",
+                    csv={"metadata": {"name": "foo.v0.0.1"}},
+                ),
+                bundle_files(
+                    "hello",
+                    "0.0.2",
+                    csv={"metadata": {"name": "foo.v0.0.2"}},
+                ),
+                bundle_files(
+                    "hello",
+                    "0.0.3",
+                    csv={"metadata": {"name": "foo.v0.0.3"}},
+                ),
+            ],
+            ("hello", "0.0.3"),
+            {
+                (
+                    Warn,
+                    "Operator name from annotations.yaml (hello) does not match"
+                    " the name defined in the CSV (foo)",
+                ),
+            },
+            id="Wrong CSV name in all bundles",
         ),
     ],
     indirect=False,


### PR DESCRIPTION
Inconsistencies between operator names defined within a bundle are now fatal only if the bundle being added is the first bundle of a new operator.
Inconsistencies across bundles still cause failures only if the inconsistency is caused by the bundle being added and just result in a warning if the inconsistency was pre-existing.