### PR TITLE
composite template deprecation

### DIFF
--- a/docs/users/fbc_workflow.md
+++ b/docs/users/fbc_workflow.md
@@ -24,12 +24,10 @@ template the operator will be using.
 
 * Basic template
 * SemVer template
-* Composite template
 
 More information about each template can be found at [opm doc](https://olm.operatorframework.io/docs/reference/catalog-templates/).
 
-The recommended template from the maintainability point of view is `SemVer` or `Composite` with
-`SemVer`integration.
+The recommended template from the maintainability point of view is `SemVer`.
 
 ## Generate catalogs using templates
 To generate a final catalog for an operator a user needs to execute different `opm`
@@ -49,10 +47,8 @@ The right place for the Makefile is in the operator's root directory
 ├── 0.0.1
 │   ├── manifests
 │   └── metadata
-├── catalogs.yaml
 ├── catalog-templates
 ├── ci.yaml
-├── composite-config.yaml
 └── Makefile
 
 ```
@@ -63,7 +59,7 @@ can be submitted as a PR in Github and once the PR is processed changes will be 
 OCP index.
 
 ```bash
-$ tree catalogs
+$ tree (repository-root)/catalogs
 catalogs
 ├── v4.12
 │   └── aqua

--- a/fbc/Makefile
+++ b/fbc/Makefile
@@ -9,7 +9,6 @@
 # OPM allows for the generation of catalogs using different templates.
 # - basic: generates a basic catalog
 # - semver: generates a catalog with semver versioning
-# - composite: generates a catalog using a composite template
 
 PDW=$(shell pwd)
 OPERATOR_NAME=$(shell basename $(PDW))
@@ -47,9 +46,7 @@ fbc-onboarding: fbc-onboarding-deps clean
 #
 # --- SEMVER TEMPLATE ---
 #catalog: semver
-#
-# --- COMPOSITE TEMPLATE ---
-catalog: composite
+
 
 # basic target provides an example FBC generation from a `basic` template type.
 # this example takes a single file as input and generates a well-formed FBC operator contribution as an output
@@ -69,13 +66,6 @@ semver: ${BINDIR}/opm clean
 		mkdir -p ${CATALOG_DIR}/$${version}/${OPERATOR_NAME}/ && \
 		${BINDIR}/opm alpha render-template semver -o yaml  ${OPERATOR_CATALOG_TEMPLATE_DIR}/$${version}.yaml > ${CATALOG_DIR}/$${version}/${OPERATOR_NAME}/catalog.yaml; \
 	done
-
-# composite target processes a composite template to generate the FBC contributions
-# `render-template composite` has `--validate` option enabled by default,
-# so no subsequent validation is required
-.PHONY: composite
-composite: ${BINDIR}/opm clean
-	${BINDIR}/opm alpha render-template composite -f ${PDW}/catalogs.yaml -c ${PDW}/composite-config.yaml
 
 #
 # validate target illustrates FBC validation


### PR DESCRIPTION
Here's a quickie PR to demonstrate how redirecting the onboarding flows away from composite templates might look.  If https://github.com/operator-framework/operator-registry/pull/1335 merges, then existing FBC --> basic-template would be even simpler, as you could do `opm alpha convert-template basic $INFILE`. 

I tried to cover all the bases, although I'm sure there's some context I'm missing and would be happy to learn about. 

