### PR TITLE
[ISV-4972] Fix community integration test failure

### DIFF
--- a/operator-pipeline-images/operatorcert/utils.py
+++ b/operator-pipeline-images/operatorcert/utils.py
@@ -217,7 +217,7 @@ def copy_images_to_destination(
             "skopeo",
             "copy",
             f"docker://{response.get('index_image_resolved')}",
-            f"docker://{destination}:{version}-{tag_suffix}",
+            f"docker://{destination}:{version}{tag_suffix}",
         ]
         if auth_file:
             cmd.extend(["--authfile", auth_file])

--- a/operator-pipeline-images/tests/test_utils.py
+++ b/operator-pipeline-images/tests/test_utils.py
@@ -147,7 +147,9 @@ def test_copy_images_to_destination(mock_subprocess: MagicMock) -> None:
             "index_image_resolved": "quay.io/qwe/asd@sha256:1234",
         }
     ]
-    utils.copy_images_to_destination(iib_response, "quay.io/foo/bar", "foo", "test.txt")
+    utils.copy_images_to_destination(
+        iib_response, "quay.io/foo/bar", "-foo", "test.txt"
+    )
 
     mock_subprocess.run.assert_called_once_with(
         [


### PR DESCRIPTION
This avoids introducing a double dash in the tag of the index reference copied from IIB which would cause a mismatch with the reference passed to preflight.