### PR TITLE
[ISV-4971] Skip subset of static checks for FBC operators

### DIFF
--- a/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
+++ b/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
@@ -17,6 +17,7 @@ from operator_repo import Bundle
 from operator_repo.checks import CheckResult, Fail, Warn
 from operator_repo.utils import lookup_dict
 from operatorcert import utils
+from operatorcert.static_tests.helpers import skip_fbc
 from semver import Version
 
 from .validations import (
@@ -179,6 +180,7 @@ def check_required_fields(bundle: Bundle) -> Iterator[CheckResult]:
         yield Fail(message) if fatal else Warn(message)
 
 
+@skip_fbc
 def check_dangling_bundles(bundle: Bundle) -> Iterator[CheckResult]:
     """
     Check dangling bundles in the operator update graph
@@ -216,6 +218,7 @@ def check_dangling_bundles(bundle: Bundle) -> Iterator[CheckResult]:
             yield Fail(f"Channel {channel} has dangling bundles: {dangling_bundles}")
 
 
+@skip_fbc
 def check_api_version_constraints(bundle: Bundle) -> Iterator[CheckResult]:
     """Check that the ocp and k8s api version constraints are consistent"""
     ocp_versions_str = bundle.annotations.get("com.redhat.openshift.versions")
@@ -297,6 +300,7 @@ def check_api_version_constraints(bundle: Bundle) -> Iterator[CheckResult]:
         )
 
 
+@skip_fbc
 def check_upgrade_graph_loop(bundle: Bundle) -> Iterator[CheckResult]:
     """
     Detect loops in the upgrade graph
@@ -358,6 +362,7 @@ def follow_graph(graph: Any, bundle: Bundle, visited: List[Bundle]) -> List[Bund
     return visited
 
 
+@skip_fbc
 def check_replaces_availability(bundle: Bundle) -> Iterator[CheckResult]:
     """
     Check if the current bundle and the replaced bundle support the same OCP versions

--- a/operator-pipeline-images/operatorcert/static_tests/community/operator.py
+++ b/operator-pipeline-images/operatorcert/static_tests/community/operator.py
@@ -10,8 +10,10 @@ from collections.abc import Iterator
 
 from operator_repo import Operator
 from operator_repo.checks import CheckResult, Fail, Warn
+from operatorcert.static_tests.helpers import skip_fbc
 
 
+@skip_fbc
 def check_operator_name_unique(operator: Operator) -> Iterator[CheckResult]:
     """Ensure all operator's bundles use the same operator name in their CSV"""
     names = {bundle.csv_operator_name for bundle in operator}

--- a/operator-pipeline-images/operatorcert/static_tests/helpers.py
+++ b/operator-pipeline-images/operatorcert/static_tests/helpers.py
@@ -1,0 +1,40 @@
+""" Static tests helper utilities. """
+
+import logging
+
+from functools import wraps
+from typing import Any, Callable, Iterator
+from operator_repo import Operator, Bundle
+
+
+LOGGER = logging.getLogger("operator-cert")
+
+
+def skip_fbc(func: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    Decorator to skip a static check for FBC enabled operators.
+
+    First argument of the decorated function should be either an Operator or a Bundle,
+    otherwise the 'check' will be executed as usual.
+    """
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Iterator[Any]:
+        first_arg = args[0]
+        if isinstance(first_arg, Bundle):
+            operator = first_arg.operator
+        elif isinstance(first_arg, Operator):
+            operator = first_arg
+
+        config = operator.config if operator else {}
+        if not config.get("fbc", {}).get("enabled", False):
+            yield from func(*args, **kwargs)
+
+        LOGGER.info(
+            "Skipping %s for FBC enabled operator %s",
+            func.__name__,
+            operator.operator_name,
+        )
+        yield from []
+
+    return wrapper

--- a/operator-pipeline-images/operatorcert/static_tests/isv/bundle.py
+++ b/operator-pipeline-images/operatorcert/static_tests/isv/bundle.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator
 
 from operator_repo import Bundle
 from operator_repo.checks import CheckResult, Fail, Warn
+from operatorcert.static_tests.helpers import skip_fbc
 
 PRUNED_GRAPH_ERROR = (
     "olm.skipRange annotation is set but replaces field is not set in the CSV. "
@@ -15,6 +16,7 @@ PRUNED_GRAPH_ERROR = (
 )
 
 
+@skip_fbc
 def check_pruned_graph(bundle: Bundle) -> Iterator[CheckResult]:
     """
     Check if the update graph is pruned when the bundle is added to the index

--- a/operator-pipeline-images/tests/static_tests/test_helpers.py
+++ b/operator-pipeline-images/tests/static_tests/test_helpers.py
@@ -1,0 +1,51 @@
+from typing import Any, Iterator
+
+from operatorcert.static_tests.helpers import skip_fbc
+from operator_repo import Operator, Bundle
+from unittest.mock import call, MagicMock, patch
+
+
+@patch("operatorcert.static_tests.helpers.LOGGER")
+@patch.object(Operator, "probe", return_value=True)
+@patch.object(Bundle, "probe", return_value=True)
+def test_skip__fbc(
+    mock_bundle: MagicMock, mock_operator: MagicMock, mock_logger: MagicMock
+) -> None:
+
+    @skip_fbc
+    def check_bundle(bundle: Bundle) -> Iterator[str]:
+        yield "processed"
+
+    @skip_fbc
+    def check_operator(operator: Operator) -> Iterator[str]:
+        yield "processed"
+
+    operator = Operator("test-operator")
+    operator.config = {"fbc": {"enabled": True}}
+    bundle = Bundle("test-bundle", operator)
+
+    assert list(check_bundle(bundle)) == []
+    assert list(check_operator(operator)) == []
+
+    mock_logger.assert_has_calls(
+        [
+            call.info(
+                "Skipping %s for FBC enabled operator %s",
+                "check_bundle",
+                "test-operator",
+            ),
+            call.info(
+                "Skipping %s for FBC enabled operator %s",
+                "check_operator",
+                "test-operator",
+            ),
+        ]
+    )
+
+    operator.config = {"fbc": {"enabled": False}}
+    assert list(check_bundle(bundle)) == ["processed"]
+    assert list(check_operator(operator)) == ["processed"]
+
+    operator.config = {}
+    assert list(check_bundle(bundle)) == ["processed"]
+    assert list(check_operator(operator)) == ["processed"]


### PR DESCRIPTION
Added decorator for skipping a subset of the tests. Test run of the pipeline for FBC enabled operator [can be found here](https://gist.github.com/rh-operator-bundle-bot/3de4daaf95cfbda488bfda3ae37f6628#file-operator-hosted-pipeline-runz4l29-log-L280).

JIRA: ISV-4971