### PR TITLE
[ISV-4830] Release pipeline shares a summary in PR comment

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -1397,6 +1397,10 @@ spec:
           value: "true"
         - name: pipeline_name
           value: "$(context.pipeline.name)"
+        - name: pipeline_status
+          value: "$(tasks.status)"
+        - name: fbc-enabled
+          value: "$(tasks.read-config.results.fbc-enabled)"
       workspaces:
         - name: base
           workspace: repository

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -331,6 +331,9 @@ spec:
           workspace: registry-pull-credentials
         - name: dest-registry-credentials
           workspace: registry-push-credentials
+        - name: output
+          workspace: results
+          subPath: summary
 
     # Publish bundle metadata to Pyxis
     - name: publish-pyxis-data
@@ -642,6 +645,10 @@ spec:
           value: "$(tasks.get-organization.results.organization)"
         - name: quay_push_final_index_secret
           value: "$(params.quay_push_final_index_secret)"
+      workspaces:
+        - name: output
+          workspace: results
+          subPath: summary
 
 
   finally:
@@ -840,6 +847,10 @@ spec:
           value: "true"
         - name: pipeline_name
           value: "$(context.pipeline.name)"
+        - name: pipeline_status
+          value: "$(tasks.status)"
+        - name: fbc-enabled
+          value: "$(tasks.read-config.results.fbc-enabled)"
       workspaces:
         - name: base
           workspace: repository

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -345,6 +345,9 @@ spec:
         - input: "$(tasks.certification-project-check.results.certification_project_id)"
           operator: "notin"
           values: [""]
+        - input: "$(tasks.detect-changes.results.added_bundle)"
+          operator: "notin"
+          values: [""]
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/copy-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/copy-image.yml
@@ -36,7 +36,7 @@ spec:
 
         # Save data about released bundle to volume
         RELEASE_INFO_DIR_PATH="$(workspaces.output.path)/release_info"
-        mkdir "$RELEASE_INFO_DIR_PATH"
+        mkdir -p "$RELEASE_INFO_DIR_PATH"
         echo "- $(params.src_image)" | tee "$RELEASE_INFO_DIR_PATH/released_bundle.txt"
 
         if [[ "$(params.vendor_label)" == "" ]]; then

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/copy-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/copy-image.yml
@@ -34,6 +34,13 @@ spec:
       script: |
         set -xe
 
+        if [[ "$(params.dest_image_tag)" == "" ]]; then
+          echo "A pipeline is not releasing a bundle. Skipping a copy step.."
+          echo -n > "$(results.container_digest.path)"
+          echo -n "$(params.src_image)" > "$(results.image_pullspec.path)"
+          exit 0
+        fi
+
         # Save data about released bundle to volume
         RELEASE_INFO_DIR_PATH="$(workspaces.output.path)/release_info"
         mkdir -p "$RELEASE_INFO_DIR_PATH"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/copy-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/copy-image.yml
@@ -23,6 +23,8 @@ spec:
       description: Docker config for the source registry
     - name: dest-registry-credentials
       description: Docker config for the destination registry
+    - name: output
+      description: Scratch space and storage for the comment and related data
   results:
     - name: container_digest
     - name: image_pullspec
@@ -31,6 +33,11 @@ spec:
       image: "$(params.pipeline_image)"
       script: |
         set -xe
+
+        # Save data about released bundle to volume
+        RELEASE_INFO_DIR_PATH="$(workspaces.output.path)/release_info"
+        mkdir "$RELEASE_INFO_DIR_PATH"
+        echo "- $(params.src_image)" | tee "$RELEASE_INFO_DIR_PATH/released_bundle.txt"
 
         if [[ "$(params.vendor_label)" == "" ]]; then
           echo "Image pullspec for community bundle is the source image itself."

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
@@ -157,7 +157,7 @@ spec:
           fi
 
           # Add info how to update catalog for FBC bundles
-          if [[ "$(params.fbc-enabled)" == "true" ]]; then
+          if [[ "$(params.fbc-enabled)" == "true" && -f "$RELEASE_INFO_DIR_PATH/released_bundle.txt" ]]; then
             echo -e "\n## Catalog update\n" >> "$PR_NAME/comment.md"
             echo -e "Operator bundle using FBC mode has been released.\nTo add bundle to FBC templates, follow [this guide](https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_workflow/#adding-new-bundle-to-catalog) to create a new PR with catalog changes." >> "$PR_NAME/comment.md"
           fi

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
@@ -41,6 +41,9 @@ spec:
     - name: pipeline_name
       description: The name of the Pipeline.
 
+    - name: pipeline_status
+      description: The result status of the Pipeline.
+
     - name: pipeline_image
       description: The common pipeline image.
 
@@ -49,6 +52,12 @@ spec:
       description: |
         A flag that determines whether pipeline logs should be uploaded to Github gists
       type: string
+
+    - name: fbc-enabled
+      default: "false"
+      description: |
+        A flag that determines whether bundle uses fbc mode.
+
 
   steps:
     - name: gather-info
@@ -128,6 +137,30 @@ spec:
           DOC_LINK="https://redhat-openshift-ecosystem.github.io/community-operators-prod/"
         else
           DOC_LINK="https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md"
+        fi
+
+        if [[ "$(params.pipeline_name)" == "operator-release-pipeline" && ("$(params.pipeline_status)" == "Succeeded" || "$(params.pipeline_status)" == "Completed") ]]; then
+          # Add details about released bundle and indices
+          echo -e "\n## Release info\n" >> "$PR_NAME/comment.md"
+          RELEASE_INFO_DIR_PATH="$(workspaces.output.path)/release_info"
+          if [[ -d "$RELEASE_INFO_DIR_PATH" ]]; then
+            if [[ -f "$RELEASE_INFO_DIR_PATH/released_bundle.txt" ]]; then
+              echo -e "\n*Released bundle:* \n" >> "$PR_NAME/comment.md"
+              cat "$RELEASE_INFO_DIR_PATH/released_bundle.txt" >> "$PR_NAME/comment.md"
+            fi
+            if [[ -f "$RELEASE_INFO_DIR_PATH/updated_indices.txt" ]]; then
+              echo -e "\n*Updated indices:* \n" >> "$PR_NAME/comment.md"
+              cat "$RELEASE_INFO_DIR_PATH/updated_indices.txt" >> "$PR_NAME/comment.md"
+            fi
+          else
+            echo -e "\nNothing was released.\n" >> "$PR_NAME/comment.md"
+          fi
+
+          # Add info how to update catalog for FBC bundles
+          if [[ "$(params.fbc-enabled)" == "true" ]]; then
+            echo -e "\n## Catalog update\n" >> "$PR_NAME/comment.md"
+            echo -e "Operator bundle using FBC mode has been released.\nTo add bundle to FBC templates, follow [this guide](https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_workflow/#adding-new-bundle-to-catalog) to create a new PR with catalog changes." >> "$PR_NAME/comment.md"
+          fi
         fi
 
         echo -e "\n## Troubleshooting\n\nPlease refer to the [troubleshooting guide]($DOC_LINK)." >> $PR_NAME/comment.md

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-index.yml
@@ -97,6 +97,10 @@ spec:
         else
           FROM_INDEX_PROXY="registry.stage.redhat.io/redhat/${INDEX_NAME}"
         fi
+        # Create folder for release info if it's non-existent
+        RELEASE_INFO_DIR_PATH="$(workspaces.output.path)/release_info"
+        mkdir -p "$RELEASE_INFO_DIR_PATH"
+
         echo "Copying index images to published repos..."
 
         TEMP_IMAGES=$(echo $(params.index_image_paths) | tr "," " ")
@@ -133,7 +137,6 @@ spec:
             docker://$SRC_IMAGE \
             docker://$DEST_IMAGE_PERMANENT_TAG
 
-          # Save data about indexes to volume
-          RELEASE_INFO_DIR_PATH="$(workspaces.output.path)/release_info"
+          # Save data about updated indices to volume
           echo "- ${FROM_INDEX_PROXY}:${VERSION}" | tee -a "$RELEASE_INFO_DIR_PATH/updated_indices.txt"
         done

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-index.yml
@@ -22,6 +22,9 @@ spec:
         - iib-quay-credentials (default) - for connect and marketplace repositories
         - community-push-final-index-quay-credentials - for community repositories
       default: iib-quay-credentials
+  workspaces:
+    - name: output
+      description: Scratch space and storage for the comment and related data
   steps:
     - name: skopeo-copy
       # Pipeline image is needed for Red Hat internal SSL cert
@@ -87,6 +90,13 @@ spec:
         esac
 
         echo "FROM_INDEX: $FROM_INDEX"
+        # Replace internal registry with external address
+        INDEX_NAME="${FROM_INDEX#*----}"
+        if [[ "$(params.environment)" == "prod" ]]; then
+          FROM_INDEX_PROXY="registry.redhat.io/redhat/${INDEX_NAME}"
+        else
+          FROM_INDEX_PROXY="registry.stage.redhat.io/redhat/${INDEX_NAME}"
+        fi
         echo "Copying index images to published repos..."
 
         TEMP_IMAGES=$(echo $(params.index_image_paths) | tr "," " ")
@@ -122,4 +132,8 @@ spec:
             --dest-creds $QUAY_USER:$QUAY_TOKEN \
             docker://$SRC_IMAGE \
             docker://$DEST_IMAGE_PERMANENT_TAG
+
+          # Save data about indexes to volume
+          RELEASE_INFO_DIR_PATH="$(workspaces.output.path)/release_info"
+          echo "- ${FROM_INDEX_PROXY}:${VERSION}" | tee -a "$RELEASE_INFO_DIR_PATH/updated_indices.txt"
         done

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/read-config.yaml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/read-config.yaml
@@ -35,7 +35,7 @@ spec:
 
         CONFIG_PATH="$(params.operator_path)/ci.yaml"
 
-        if [[ ! -f "$CONFIG_PATH" || -z "$(params.bundle_path)" ]]; then
+        if [[ ! -f "$CONFIG_PATH" ]]; then
             echo "Config file $CONFIG_PATH does not exist or no bundle affected."
             echo "replaces" | tee $(results.upgrade-graph-mode.path)
             echo -n "false" | tee $(results.fbc-enabled.path)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/read-config.yaml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/read-config.yaml
@@ -38,7 +38,7 @@ spec:
         if [[ ! -f "$CONFIG_PATH" || -z "$(params.bundle_path)" ]]; then
             echo "Config file $CONFIG_PATH does not exist or no bundle affected."
             echo "replaces" | tee $(results.upgrade-graph-mode.path)
-            echo "false" | tee $(results.fbc-enabled.path)
+            echo -n "false" | tee $(results.fbc-enabled.path)
             exit 0
         fi
 
@@ -62,5 +62,5 @@ spec:
             UPGRADE_GRAPH_MODE=`echo $UPGRADE_GRAPH_MODE | sed 's/-mode$//'`
         fi
 
-        echo $FBC_ENABLEMENT | tee $(results.fbc-enabled.path)
+        echo -n $FBC_ENABLEMENT | tee $(results.fbc-enabled.path)
         echo -n $UPGRADE_GRAPH_MODE | tee $(results.upgrade-graph-mode.path)


### PR DESCRIPTION
Release pipeline adds info about released bundle and updated indices to Github PR comment.

If bundle uses FBC, link to documentation with instruction how to create PR with catalog changes is added.

Example of ISV PR:
- https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/1469
Example of community PR:
- https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/1470
Example with FBC comment:
- https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/1465
