### PR TITLE
[ISV-4962] remove support link from community release pipeline

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -696,6 +696,9 @@ spec:
     # with the support link pointing to the affected PR
     - name: post-support-link-for-pr
       when:
+        - input: "$(tasks.certification-project-check.results.certification_project_id)"
+          operator: "notin"
+          values: [""]
         - input: $(tasks.status)
           operator: notin
           values: ["Succeeded", "Completed"]


### PR DESCRIPTION
Condition added from hosted to release pipeline to skip adding support link when no certProject id exist (community). Tested in release pipeline, task skipped and [link not visible in PR](https://github.com/redhat-openshift-ecosystem/community-operators-pipeline-preprod/pull/251).

JIRA: ISV-4962