### PR TITLE
[ISV-4253] Script to automate catalog promotion

### DIFF
--- a/fbc/Makefile
+++ b/fbc/Makefile
@@ -25,6 +25,8 @@ OPERATOR_CATALOG_TEMPLATE_DIR = ${PDW}/catalog-templates
 
 # A list of OCP versions to generate catalogs for
 # This list can be customized to include the versions that are relevant to the operator
+# DO NOT change this line (except for the versions) if you want to take advantage 
+# of the automated catalog promotion
 OCP_VERSIONS=$(shell echo "v4.12 v4.13 v4.14 v4.15 v4.16" )
 
 

--- a/operator-pipeline-images/operatorcert/entrypoints/github_pr.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/github_pr.py
@@ -84,7 +84,7 @@ def open_pr(  # pylint: disable=too-many-arguments
         github_api_url (str): Github API URL
         repo_name (str): Repository name where the PR will be open
         head (str): Current git head that's used as a source for the PR
-        base (str): A targer branch
+        base (str): A target branch
         title (str): Pull request title
         body (str): Pull request body
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -4,8 +4,8 @@
 [metadata]
 groups = ["default", "operatorcert-dev", "tox"]
 strategy = ["cross_platform"]
-lock_version = "4.4.1"
-content_hash = "sha256:9c5f7ad776d9dd03d91ef8aa0c95f3edbb764040a2d8f5e3cf909e747d3c985f"
+lock_version = "4.4.2"
+content_hash = "sha256:326d5038d9b194383571099fff92d9311e189dae414da0c10eab2638a8c8f8de"
 
 [[package]]
 name = "argcomplete"
@@ -901,8 +901,8 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.31.0"
-requires_python = ">=3.7"
+version = "2.32.3"
+requires_python = ">=3.8"
 summary = "Python HTTP for Humans."
 dependencies = [
     "certifi>=2017.4.17",
@@ -911,8 +911,8 @@ dependencies = [
     "urllib3<3,>=1.21.1",
 ]
 files = [
-    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
-    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
+    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
 ]
 
 [[package]]

--- a/scripts/promote-catalog.py
+++ b/scripts/promote-catalog.py
@@ -1,0 +1,486 @@
+""" A script to promote catalog to latest/desired version """
+
+import argparse
+import logging
+import os
+import shutil
+
+from datetime import datetime
+from git import Repo as GitRepo
+from typing import Any
+
+from operatorcert import github, ocp_version_info
+from operator_repo import Repo as OperatorRepo
+
+LOG = logging.getLogger(__name__)
+
+ORGANIZATIONS = {
+    "certified-operators": {
+        "gh_repository": "redhat-openshift-ecosystem/certified-operators",
+        "organization": "certified-operators",
+    },
+    "redhat-marketplace-operators": {
+        "gh_repository": "redhat-openshift-ecosystem/redhat-marketplace-operators",
+        "organization": "redhat-marketplace",
+    },
+    "community-operators-prod": {
+        "gh_repository": "redhat-openshift-ecosystem/community-operators-prod",
+        "organization": "community-operators",
+    },
+    "community-operators-pipeline-preprod": {
+        "gh_repository": "redhat-openshift-ecosystem/community-operators-pipeline-preprod",
+        "organization": "community-operators",
+    },
+}
+
+
+def setup_argparser() -> Any:
+    """
+    Setup a argument parser for the script
+
+    Returns:
+        Any: Argument parser
+    """
+    parser = argparse.ArgumentParser(
+        description="Promote catalog to the target version, defaults to latest supported. "
+        "You need to have GITHUB_TOKEN exported in the environment to create PRs. "
+        "Author of the PRs will be the owner of the token."
+    )
+    parser.add_argument(
+        "--local-repo", help="Local repository to be processed (abs path)"
+    )
+    parser.add_argument("--target-version", help="Version to promote to (eg. 4.16)")
+    parser.add_argument(
+        "--pyxis-url",
+        default="https://catalog.redhat.com/api/containers/",
+        help="Base URL for Pyxis container metadata API",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Verbose output")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Dry run mode - branches will be pushed without creating PRs. "
+        "Can be used to avoid multiple pipelines starting at once",
+        default=False,
+    )
+
+    return parser
+
+
+def copy_files_if_not_exist(
+    operator_name: str,
+    repo_dir: str,
+    source_version: str,
+    target_version: str,
+) -> list[str]:
+    """
+    Copy catalog and template files if they don't exist
+
+    Args:
+        operator_name (str): Operator name
+        repo_dir (str): Path to the processed local repository
+        source (str): Source catalog directory
+        target (str): Target catalog directory
+
+    Returns:
+        list[str]: List of relative paths to copied files
+        for Git commit
+    """
+    to_commit = []
+
+    # copy catalog files if they don't exist
+    relative_catalog_dir = os.path.join("catalogs", f"v{target_version}", operator_name)
+    catalog_target_dir = os.path.join(repo_dir, relative_catalog_dir)
+    if not os.path.exists(catalog_target_dir):
+        os.makedirs(catalog_target_dir)
+    catalog_source_dir = os.path.join(
+        repo_dir, "catalogs", f"v{source_version}", operator_name
+    )
+    for file in os.listdir(catalog_source_dir):
+        source_file = os.path.join(catalog_source_dir, file)
+        target_file = os.path.join(catalog_target_dir, file)
+        if not os.path.exists(target_file):
+            LOG.info("Copying catalog %s to %s", source_file, target_file)
+            shutil.copyfile(source_file, target_file)
+            to_commit.append(os.path.join(relative_catalog_dir, file))
+
+    # copy template file if they don't exist
+    relative_template_file = os.path.join(
+        "operators", operator_name, "catalog-templates", f"v{target_version}.yaml"
+    )
+    source_template = os.path.join(
+        repo_dir, f"operators/{operator_name}/catalog-templates/v{source_version}.yaml"
+    )
+    target_template = os.path.join(repo_dir, relative_template_file)
+    if not os.path.exists(target_template):
+        LOG.info("Copying template %s to %s", source_template, target_template)
+        shutil.copyfile(source_template, target_template)
+        to_commit.append(relative_template_file)
+
+    return to_commit
+
+
+def update_makefile(
+    operator_name: str,
+    repo_dir: str,
+    target_version: str,
+) -> str:
+    """
+    Add target version to the `OCP_VERSIONS` in the Makefile if missing
+
+    Args:
+        operator_name (str): Operator name
+        repo_dir (str): Path to the processed local repository
+        target_version (str): Target version to add
+    """
+    to_commit = ""
+
+    relative_makefile_path = os.path.join("operators", operator_name, "Makefile")
+    makefile_path = os.path.join(repo_dir, relative_makefile_path)
+    with open(makefile_path, "r") as makefile:
+        makefile_content = makefile.readlines()
+
+    makefile_out = []
+    for line in makefile_content:
+        if line.startswith("OCP_VERSIONS"):
+            if target_version not in line:
+                # assuming line looks like:
+                # `OCP_VERSIONS=$(shell echo "v4.12 v4.13 v4.14 v4.15" )`
+                split_point = line.rindex('"')
+                updated = f"{line[:split_point]} v{target_version}{line[split_point:]}"
+                makefile_out.append(updated)
+                to_commit = relative_makefile_path
+            else:
+                makefile_out.append(line)
+        else:
+            makefile_out.append(line)
+
+    with open(makefile_path, "w") as makefile:
+        makefile.writelines(makefile_out)
+
+    return to_commit
+
+
+def triage_operators(
+    operators: list[str], repository: OperatorRepo
+) -> tuple[list[str], list[str], list[str]]:
+    """
+    Triage operators based on promotion strategy
+
+    Args:
+        operators (list[str]): List of operators
+    Returns:
+        tuple ([list[str], ...): Operators triaged
+        into 'never', 'always' and 'review'
+    """
+    never, always, review = [], [], []
+    for operator in operators:
+        config = repository.operator(operator).config
+        strategy = config.get("fbc", {}).get("version_promotion_strategy")
+        if strategy == "never":
+            never.append(operator)
+        elif strategy == "always":
+            always.append(operator)
+        elif strategy == "review-needed":
+            review.append(operator)
+        else:
+            LOG.warning("Unknown promotion strategy for operator %s", operator)
+            never.append(operator)
+
+    return never, always, review
+
+
+def commit_and_push(
+    git_repo: GitRepo,
+    head_branch: str,
+    files_to_commit: list[str],
+    message: str,
+) -> None:
+    """
+    Commit and push changes to GH
+
+    Args:
+        git_repo (GitRepo): Git repository object
+        head_branch (str): Source branch for the PR
+        files_to_commit (list[str]): List of files to commit
+        message (str): Commit message
+    """
+    git_repo.index.add(files_to_commit)
+    LOG.info("Committing and pushing changes to %s", head_branch)
+    git_repo.index.commit(message)
+    git_repo.remotes.origin.push(head_branch)
+
+
+def create_pr(
+    base: str,
+    head: str,
+    title: str,
+    local_repo: str,
+) -> dict[str, Any]:
+    """
+    Create PR using GitHub API
+
+    Args:
+        base (str): Target branch
+        head (str): Source branch of the PR
+        title (str): PR title
+        local_repo (str): Work directory
+    """
+    gh_repo = ORGANIZATIONS[local_repo]["gh_repository"]
+    LOG.info("Creating PR in %s for branch %s", gh_repo, head)
+    gh_api_url = f"https://api.github.com/repos/{gh_repo}/pulls"
+    data = {"head": head, "base": base, "title": title}
+    return github.post(gh_api_url, data)
+
+
+def promote_catalog(
+    repo_dir: str,
+    git_repo: GitRepo,
+    valid_versions: list[str],
+    target_version: str,
+) -> tuple[list[dict[str, Any]], str]:
+    """
+    Promote catalog to the target version.
+    Separate processing based on the promotion strategy
+
+    Args:
+        repo_dir (str): Path to the processed local repository
+        git_repo (GitRepo): Git repository object
+        valid_versions (list[str]): List of valid OCP versions in descending order
+        target_version (str): Target version to promote to
+
+    Returns:
+        tuple ([list[dict[str, Any]], str]): List of dictionaries with promo branch, PR title
+        and reviewers list and string with branch suffix for better branch identification
+    """
+    # decide source version for promotion
+    try:
+        source_version = valid_versions[valid_versions.index(target_version) + 1]
+    except IndexError:
+        LOG.error("No version to promote from")
+        return
+    LOG.info("Source version for promotion: %s", source_version)
+
+    # get list of operators from the source catalog
+    source_catalog = os.path.join(repo_dir, "catalogs", f"v{source_version}")
+    if not os.path.exists(source_catalog):
+        LOG.error("Source catalog %s not found", source_catalog)
+        return
+    source_operators = os.listdir(source_catalog)
+    operator_repo = OperatorRepo(repo_dir)
+    never, always, review = triage_operators(source_operators, operator_repo)
+
+    # prepare common variables
+    base_branch = str(git_repo.active_branch)
+    branch_suffix = str(int(datetime.now().timestamp()))
+
+    LOG.info("Processing promotion from source branch: %s", base_branch)
+
+    # store branch info for PR creation
+    pr_info = []
+
+    # process operators with `fbc.version_promotion_strategy == always`
+    # meaning single PR for all operators
+    head_branch = f"always-promote-v{target_version}-{branch_suffix}"
+    create_or_clear_branch_and_checkout(
+        git_repo,
+        base_branch=base_branch,
+        head_branch=head_branch,
+    )
+    always_strategy_to_commit = []
+    for operator in always:
+        to_commit = copy_files_if_not_exist(
+            operator, repo_dir, source_version, target_version
+        )
+        if to_commit:
+            always_strategy_to_commit.extend(to_commit)
+        to_commit_makefile = update_makefile(operator, repo_dir, target_version)
+        if to_commit_makefile:
+            always_strategy_to_commit.append(to_commit_makefile)
+    if always_strategy_to_commit:
+        commit_and_push(
+            git_repo,
+            head_branch,
+            always_strategy_to_commit,
+            f"Promote operators with `fbc.version_promotion_strategy == always`"
+            f" to catalog version {target_version}",
+        )
+        pr_info.append(
+            {
+                "head": head_branch,
+                "title": f"Promote all operators with `version_promotion_strategy` 'always' "
+                f" to catalog version {target_version}",
+            }
+        )
+    LOG.info(
+        "Processed operators with `fbc.version_promotion_strategy == always`: %s",
+        always,
+    )
+
+    # process operators with `fbc.version_promotion_strategy == review-needed`
+    # single PR for each operator for review reasons
+    for operator in review:
+        head_branch = f"review-promote-v{target_version}-{operator}-{branch_suffix}"
+        create_or_clear_branch_and_checkout(
+            git_repo,
+            base_branch=base_branch,
+            head_branch=head_branch,
+        )
+        to_commit = copy_files_if_not_exist(
+            operator, repo_dir, source_version, target_version
+        )
+        to_commit_makefile = update_makefile(operator, repo_dir, target_version)
+        if to_commit_makefile:
+            to_commit.append(to_commit_makefile)
+        # commit only if there is content
+        if to_commit:
+            commit_and_push(
+                git_repo,
+                head_branch,
+                to_commit,
+                f"Promote operator {operator} to catalog version {target_version}.",
+            )
+            pr_info.append(
+                {
+                    "head": head_branch,
+                    "title": f"Promote operator {operator} to catalog version {target_version}.",
+                }
+            )
+    LOG.info(
+        "Processed operators with `fbc.version_promotion_strategy == review-needed`: %s",
+        review,
+    )
+
+    LOG.info("Operators excluded from promotion: %s", never)
+    return pr_info, branch_suffix
+
+
+def create_or_clear_branch_and_checkout(
+    git_repo: GitRepo,
+    base_branch: str = None,
+    head_branch: str = None,
+) -> None:
+    """
+    Clear source/active branch and create target branch
+    from source branch if provided
+
+    Args:
+        git_repo (GitRepo): Git repository object
+        base_branch (str): Source branch for the changes
+        head_branch (str): Target branch for the changes
+    """
+    # all new branches will be based on the base branch
+    # if not provided, the active branch will be used
+    if base_branch:
+        git_repo.git.checkout(base_branch)
+    # clear the active branch
+    git_repo.git.clean("--force", "-d")  # remove untracked files
+    git_repo.git.reset("--hard")  # remove uncommited changes
+    # create and checkout to the new branch
+    if head_branch:
+        git_repo.git.checkout("HEAD", b=head_branch)
+
+
+def repo_status_clean(git_repo: GitRepo) -> bool:
+    """
+    Check the working branch, uncommited changes and untracked files
+
+    Args:
+        git_repo (GitRepo): Git repository object
+    """
+    branch = str(git_repo.active_branch)
+    uncommited_changes = git_repo.is_dirty()
+    untracked_files = bool(git_repo.untracked_files)
+    if branch not in ["main", "master"] or uncommited_changes or untracked_files:
+        return False
+    return True
+
+
+def main() -> None:
+    """
+    Main function
+    """
+    parser = setup_argparser()
+    args = parser.parse_args()
+    LOG.setLevel(logging.INFO)
+    if args.verbose:
+        LOG.setLevel(logging.DEBUG)
+    LOG.addHandler(logging.StreamHandler())
+
+    LOG.info("Starting promotion process")
+
+    local_repo_name = os.path.basename(args.local_repo.strip("/"))
+    try:
+        organization = ORGANIZATIONS.get(local_repo_name, {})["organization"]
+    except KeyError:
+        LOG.error("Repository %s not supported", local_repo_name)
+        return
+
+    # check repo status
+    # all new branches will be based on actual branch
+    # all previous changes will be lost
+    git_repo = GitRepo(args.local_repo)
+    base_branch = str(git_repo.active_branch)
+    if not repo_status_clean(git_repo):
+        LOG.warning(
+            "The repo is either dirty or not on main branch, "
+            "please check its status. "
+            "If you decide to continue, the uncommited changes "
+            "and untracked files will be lost."
+        )
+        its_ok = input("Do you want to continue? [y/N]: ") or "n"
+        if its_ok.lower() != "y":
+            LOG.info("Exiting")
+            return
+
+    create_or_clear_branch_and_checkout(git_repo)
+
+    # configure repo with the token
+    access_token = os.environ.get("GITHUB_TOKEN")
+    gh_repository = ORGANIZATIONS[local_repo_name]["gh_repository"]
+    remote_url_with_token = f"https://{access_token}@github.com/{gh_repository}.git"
+    git_repo.remotes.origin.set_url(remote_url_with_token)
+
+    # gather ocp_version related info
+    target_version = args.target_version
+    pyxis_url = args.pyxis_url
+    ocp_versions = ocp_version_info(None, pyxis_url, organization)
+    # `indices` are sorted by version in descending order
+    valid_versions = [v.get("ocp_version") for v in ocp_versions["indices"]]
+    # check if target version index exists
+    if target_version and target_version not in valid_versions:
+        LOG.error(
+            "Target version %s not in valid versions %s", target_version, valid_versions
+        )
+        return
+
+    # default to max version index
+    if not target_version:
+        target_version = ocp_versions["max_version_index"].get("ocp_version")
+
+    # process promotion
+    LOG.info("Promotion to version: %s", target_version)
+    pr_info, branch_suffix = promote_catalog(
+        args.local_repo, git_repo, valid_versions, target_version
+    )
+    LOG.info("Suffix for all branches created and pushed: %s", branch_suffix)
+
+    # dry run only pushes branches without creating PRs
+    # this can be used to prepare PR branches and then create PRs manually
+    # to avoid multiple pipelines starting at once
+    if pr_info and not args.dry_run:
+        for push_data in pr_info:
+            create_pr(
+                base_branch,
+                push_data["head"],
+                push_data["title"],
+                local_repo_name,
+            )
+
+    LOG.info("Promotion process finished")
+    # checkout back to the base branch
+    git_repo.git.checkout(base_branch)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/promote-catalog.py
+++ b/scripts/promote-catalog.py
@@ -140,7 +140,6 @@ def update_makefile(
         # search for variable assignment
         if bool(re.match(r"^OCP_VERSIONS\s*=", line)):
             # find the group of versions on the line
-            # OR any single quoted variants
             versions = re.search(r"(v\d+\.\d+(?:\s+v\d+\.\d+)*)", line)
             if not versions:
                 LOG.warning(
@@ -151,7 +150,7 @@ def update_makefile(
             # check target version in versions list to avoid false positives
             # from searching just the string
             if target_version not in ocp_string.split():
-                split_point = line.rindex(ocp_string) + len(ocp_string)
+                split_point = line.index(ocp_string) + len(ocp_string)
                 # update the line with target version
                 updated = f"{line[:split_point]} v{target_version}{line[split_point:]}"
                 makefile_out.append(updated)

--- a/scripts/promote-catalog.py
+++ b/scripts/promote-catalog.py
@@ -97,7 +97,7 @@ def copy_files_if_not_exist(
     # copy catalog files if they don't exist
     catalog_dir = repo_dir / "catalogs"
     catalog_target_dir = catalog_dir / f"v{target_version}" / operator_name
-    catalog_target_dir.mkdir(mode=755, parents=True, exist_ok=True)
+    catalog_target_dir.mkdir(mode=0o755, parents=True, exist_ok=True)
     catalog_source_dir = catalog_dir / f"v{source_version}" / operator_name
     for file in os.listdir(catalog_source_dir):
         source_file = catalog_source_dir / file


### PR DESCRIPTION
When not provided the script will target the highest index version.
Author of the commits is based on the GITHUB_TOKEN provided, same for the PRs creation.
Dry run implemented in a way that the branches are created and pushed but not PRs submitted - to avoid pipeline overload.
Base branch for the script is always the active branch to allow testing or targeting different branch.

Test run of the script produced this [PRs in test repository](https://github.com/mantomas/community-test-repo/pulls).

JIRA: ISV-4523