### PR TITLE
updating preflight sha for version 1.9.9

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:665e8a6e0fc01e0db14a5a257fe9c2dc12e0a71ae9f1b1b87d61b4a266ab538d
+      default: quay.io/redhat-isv/preflight-test@sha256:a800ff4ff708194034fc5629503cd1d37577c507c9d20f7adb7c3896d21ed645
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
```
❯ crane digest quay.io/redhat-isv/preflight-test:1.9.8
sha256:665e8a6e0fc01e0db14a5a257fe9c2dc12e0a71ae9f1b1b87d61b4a266ab538d

~ 
❯ crane digest quay.io/redhat-isv/preflight-test:1.9.9
sha256:a800ff4ff708194034fc5629503cd1d37577c507c9d20f7adb7c3896d21ed645
```