### PR TITLE
Check permission script supports user's repositories

### DIFF
--- a/operator-pipeline-images/operatorcert/entrypoints/check_permissions.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/check_permissions.py
@@ -7,7 +7,7 @@ import os
 import urllib
 from typing import Any
 
-from github import Auth, Github
+from github import Auth, Github, UnknownObjectException
 from operator_repo import Operator
 from operator_repo import Repo as OperatorRepo
 from operatorcert import pyxis
@@ -194,7 +194,11 @@ class OperatorReview:
         )
         github_auth = Auth.Token(os.environ.get("GITHUB_TOKEN") or "")
         github = Github(auth=github_auth)
-        members = github.get_organization(self.github_repo_org).get_members()
+        try:
+            members = github.get_organization(self.github_repo_org).get_members()
+        except UnknownObjectException:
+            LOGGER.info("Organization %s does not exist", self.github_repo_org)
+            return False
 
         for member in members:
             if self.pr_owner in member.login:

--- a/operator-pipeline-images/tests/entrypoints/test_check_permissions.py
+++ b/operator-pipeline-images/tests/entrypoints/test_check_permissions.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, call, patch
 
 import operatorcert.entrypoints.check_permissions as check_permissions
 import pytest
+from github import UnknownObjectException
 from operator_repo import Repo as OperatorRepo
 from tests.utils import bundle_files, create_files
 
@@ -178,6 +179,13 @@ def test_OperatorReview_is_org_member(
     # User is not a member of the organization
     members = [MagicMock(login="user123")]
     mock_organization.get_members.return_value = members
+    assert review_community.is_org_member() == False
+
+    # Organization does not exist
+    members = [MagicMock(login="user123")]
+    mock_github.return_value.get_organization.side_effect = UnknownObjectException(
+        404, "", {}
+    )
     assert review_community.is_org_member() == False
 
 


### PR DESCRIPTION
When user forks a repository under its own namespace the Github API raises exception since the organization doesn't exists and instead user namespace is used. This commits add a support of such a repository to allow running pipelines from forks.