### PR TITLE
Build temporary catalog for FBC operators

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -844,7 +844,14 @@ spec:
     - name: add-bundle-to-index
       runAfter:
         - add-fbc-fragments-to-index
-      when: *operatorOrBundleChange
+      when:
+        # Run only when a bundle is added and it doesn't use FBC
+        - input: "$(tasks.detect-changes.results.affected_catalogs)"
+          operator: in
+          values: [""]
+        - input: "$(tasks.read-config.results.fbc-enabled)"
+          operator: notin
+          values: ["true"]
       taskRef:
         name: add-bundle-to-index
       params:
@@ -875,9 +882,50 @@ spec:
           workspace: results
           subPath: paths
 
+    - name: build-fbc-scratch-catalog
+      runAfter:
+        - add-fbc-fragments-to-index
+      when:
+        # Run only when a bundle is added and it uses FBC
+        - input: "$(tasks.detect-changes.results.affected_catalogs)"
+          operator: in
+          values: [""]
+        - input: "$(tasks.read-config.results.fbc-enabled)"
+          operator: in
+          values: ["true"]
+      taskRef:
+        name: build-fbc-scratch-catalog
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: fbc_enabled
+          value: "$(tasks.read-config.results.fbc-enabled)"
+        - name: ocp_version
+          value: "$(tasks.get-supported-versions.results.max_supported_ocp_version)"
+        - name: bundle_pullspec
+          value: *bundleImage
+        - name: operator_name
+          value: "$(tasks.detect-changes.results.added_operator)"
+        - name: bundle_version
+          value: "$(tasks.detect-changes.results.added_bundle)"
+        - name: index_image_destination
+          value: *tempIndexRepo
+        - name: index_image_destination_tag_suffix
+          value: "-$(params.git_commit)"
+      workspaces:
+        - name: source
+          workspace: repository
+          subPath: src
+        - name: credentials
+          workspace: registry-credentials
+        - name: output
+          workspace: results
+          subPath: paths
+
     - name: make-index-repo-public
       runAfter:
         - add-bundle-to-index
+        - build-fbc-scratch-catalog
       when: *operatorOrBundleChange
       taskRef:
         name: set-quay-repo-visibility

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/build-fbc-scratch-catalog.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/build-fbc-scratch-catalog.yml
@@ -1,0 +1,77 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: build-fbc-scratch-catalog
+spec:
+  description: |
+    The purpose of this task is to build a new index/catalog image with a single
+    operator bundle. The catalog is used only for testing purposes to test if
+    a bundle can be installed. After the tests are executed the catalog is
+    no longer used.
+
+    The catalog is build using FBC mechanism:
+      - create an empty catalog
+      - create a basic FBC template and insert the bundle
+      - render a template to FBC
+      - build and push a catalog to registry given by arguments
+  params:
+    - name: pipeline_image
+
+    - name: catalog_repository
+      default: "."
+      description: A git repository where catalog is pushed
+
+    - name: ocp_version
+      description: A version of OCP that is going to be used as a target for a catalog
+
+    - name: bundle_pullspec
+      description: Bundle pullspec
+
+    - name: operator_name
+      description: A name of an operator given by the directory name in git repository.
+
+    - name: bundle_version
+      description: A version of a bundle that will be added to the catalog
+
+    - name: index_image_destination
+      default: ""
+      description: "The destination registry and repository where index images will be pushed"
+
+    - name: index_image_destination_tag_suffix
+      default: ""
+      description: "A tag suffix that is added to an image tag in destination registry"
+
+  workspaces:
+    - name: source
+    - name: output
+    - name: credentials
+      optional: true
+      description: A workspace with credentials for registry push
+  steps:
+    - name: build-fbc-catalog
+      image: "$(params.pipeline_image)"
+      workingDir: $(workspaces.source.path)
+      securityContext:
+        privileged: true
+      script: |
+        #! /usr/bin/env bash
+        set -xe
+
+        EXTRA_ARGS=""
+        if [[ "$(workspaces.credentials.bound)" == "true" ]]; then
+          EXTRA_ARGS+=" --authfile $(workspaces.credentials.path)/.dockerconfigjson"
+        fi
+
+        # The registry pull-spec is in following format:
+        # quay.io/{namespace}/{repository}:{ocp-version}{suffix}
+        # Example: quay.io/namespace/repo-name:v4.15-suffix
+        CATALOG_REPO="$(params.index_image_destination):v$(params.ocp_version)$(params.index_image_destination_tag_suffix)"
+
+        build-scratch-catalog \
+          --repo-path "$(params.catalog_repository)" \
+          --operator-name "$(params.operator_name)" \
+          --bundle-version "$(params.bundle_version)" \
+          --bundle-pullspec "$(params.bundle_pullspec)" \
+          --repository-destination $CATALOG_REPO \
+          --verbose $EXTRA_ARGS

--- a/operator-pipeline-images/operatorcert/buildah.py
+++ b/operator-pipeline-images/operatorcert/buildah.py
@@ -1,0 +1,61 @@
+"""Module for building and pushing images using buildah."""
+
+import logging
+import os
+from typing import Any
+
+from operatorcert.utils import run_command
+
+LOGGER = logging.getLogger("operator-cert")
+
+
+def build_image(dockerfile_path: str, context: str, output_image: str) -> Any:
+    """
+    Build an image using buildah using given dockerfile and context.
+
+    Args:
+        dockerfile_path (str): Path to a dockerfile
+        context (str): Build context directory
+        output_image (str): A name of the output image
+
+    Returns:
+        Any: Command output
+    """
+    cmd = [
+        "buildah",
+        "bud",
+        "--format",
+        "docker",
+        "-f",
+        dockerfile_path,
+        "-t",
+        output_image,
+        context,
+    ]
+    LOGGER.info("Building image: %s", output_image)
+    return run_command(cmd)
+
+
+def push_image(image: str, authfile: str) -> Any:
+    """
+    Push an image to a registry using buildah.
+
+    Args:
+        image (str): A name of the image to push
+        authfile (str): A path to the authentication file
+
+    Returns:
+        Any: Command output
+    """
+    authfile = os.path.expanduser(authfile)
+    cmd = [
+        "buildah",
+        "push",
+        "--authfile",
+        authfile,
+        image,
+        f"docker://{image}",
+    ]
+
+    LOGGER.info("Pushing image: %s", image)
+    return run_command(cmd)

--- a/operator-pipeline-images/operatorcert/entrypoints/build_scratch_catalog.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/build_scratch_catalog.py
@@ -1,0 +1,176 @@
+"""Create a catalog image dockerfile and build catalog image."""
+
+import argparse
+import logging
+import os
+import tempfile
+from typing import Any
+
+import yaml
+from operator_repo import Repo, Bundle
+from operatorcert import buildah, opm
+from operatorcert.logger import setup_logger
+
+LOGGER = logging.getLogger("operator-cert")
+
+
+def setup_argparser() -> argparse.ArgumentParser:
+    """
+    Setup argument parser
+
+    Returns:
+        argparse.ArgumentParser: Argument parser
+    """
+    parser = argparse.ArgumentParser(
+        description="Build a temporary scratch catalog and add a single bundle to it."
+    )
+    parser.add_argument(
+        "--repo-path",
+        default=".",
+        help="Path to the repository with operators and catalogs",
+    )
+    parser.add_argument("--operator-name", required=True, help="Operator name")
+    parser.add_argument(
+        "--bundle-version", required=True, help="Operator bundle version"
+    )
+    parser.add_argument(
+        "--bundle-pullspec", required=True, help="Operator bundle pullspec"
+    )
+    parser.add_argument(
+        "--repository-destination",
+        required=True,
+        help="Registry and repository where the image will be pushed including"
+        "the tag",
+    )
+    parser.add_argument(
+        "--authfile",
+        default="~/.docker/config.json",
+        help="A path to the authentication file",
+    )
+
+    parser.add_argument("--verbose", action="store_true", help="Verbose output")
+
+    return parser
+
+
+def generate_and_save_basic_template(  # pylint: disable=too-many-arguments
+    template_path: str,
+    package: str,
+    default_channel: str,
+    channel_name: str,
+    csv_name: str,
+    bundle_pullspec: str,
+) -> Any:
+    """
+    Generate and save basic template into a file given the parameters.
+
+    Args:
+        template_path (str): A path to the file where the template will be saved
+        package (str): A name of the package
+        default_channel (str): A name of the default channel for the package
+        channel_name (str): A name of the channel for the package
+        csv_name (str): A name of the CSV resource
+        bundle_pullspec (str): A pullspec of the bundle image
+
+    Returns:
+        Any: A path to the saved template
+    """
+
+    package_obj = {
+        "schema": "olm.package",
+        "name": package,
+        "defaultChannel": default_channel,
+    }
+    channel = {
+        "schema": "olm.channel",
+        "package": package,
+        "name": channel_name,
+        "entries": [{"name": csv_name}],
+    }
+
+    bundles = {"schema": "olm.bundle", "image": bundle_pullspec}
+
+    with open(template_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump_all(
+            [package_obj, channel, bundles],
+            f,
+            explicit_start=True,
+            indent=2,
+        )
+
+    return template_path
+
+
+def build_and_push_catalog_image(
+    bundle: Bundle, bundle_pullspec: str, repository_destination: str, authfile: Any
+) -> None:
+    """
+    Build and push a catalog image with a single bundle.
+
+    The function creates a temporary directory, generates a basic template and
+    renders it to a catalog. Then it creates a Dockerfile for the catalog image,
+    builds the image and pushes it to the repository.
+
+    Args:
+        bundle (Bundle): An instance of the Bundle class representing the bundle
+            being added to the catalog
+        bundle_pullspec (str): A pullspec of the bundle image
+        repository_destination (str): A full path to the repository where the
+            catalog image will be pushed
+        authfile (Any): A path to the authentication file for the repository
+            where the catalog image will be pushed
+    """
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        bundle_dir = f"{tmpdir}/{bundle.metadata_operator_name}"
+        os.mkdir(bundle_dir)
+
+        template_path = os.path.join(tmpdir, "template.yaml")
+        channel_name = list(bundle.channels)[0] if bundle.channels else "stable"
+
+        generate_and_save_basic_template(
+            template_path=template_path,
+            package=bundle.metadata_operator_name,
+            default_channel=bundle.default_channel,
+            channel_name=channel_name,
+            csv_name=bundle.csv["metadata"]["name"],
+            bundle_pullspec=bundle_pullspec,
+        )
+
+        catalog_path = os.path.join(bundle_dir, "catalog.yaml")
+        opm.render_template_to_catalog(template_path, catalog_path)
+
+        dockerfile_path = opm.create_catalog_dockerfile(
+            tmpdir, bundle.metadata_operator_name
+        )
+        buildah.build_image(dockerfile_path, tmpdir, repository_destination)
+        buildah.push_image(repository_destination, authfile)
+
+
+def main() -> None:
+    """
+    Main function of the script
+    """
+    # Args
+    parser = setup_argparser()
+    args = parser.parse_args()
+
+    # Logging
+    log_level = "INFO"
+    if args.verbose:
+        log_level = "DEBUG"
+    setup_logger(level=log_level)
+
+    repo = Repo(args.repo_path)
+    bundle = repo.operator(args.operator_name).bundle(args.bundle_version)
+
+    build_and_push_catalog_image(
+        bundle,
+        args.bundle_pullspec,
+        args.repository_destination,
+        args.authfile,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/operator-pipeline-images/operatorcert/opm.py
+++ b/operator-pipeline-images/operatorcert/opm.py
@@ -1,0 +1,50 @@
+"""A collection of functions for working with Operator Package Manager (OPM)"""
+
+import logging
+import os
+
+from operatorcert.utils import run_command
+
+LOGGER = logging.getLogger("operator-cert")
+
+
+def create_catalog_dockerfile(catalog_path: str, catalog_name: str) -> str:
+    """
+    Generate a Dockerfile using opm for a given catalog.
+
+    Args:
+        catalog_path (str): Path to a catalogs direcotory
+        catalog_name (str): Name of the catalog in the catalogs directory
+
+    Returns:
+        str: A Dockerfile path for the given catalog
+    """
+    dockerfile_path = f"{catalog_path}/{catalog_name}.Dockerfile"
+    if os.path.exists(dockerfile_path):
+        LOGGER.warning("Dockerfile already exists: %s. Removing...", dockerfile_path)
+        os.remove(dockerfile_path)
+    cmd = [
+        "opm",
+        "generate",
+        "dockerfile",
+        f"{catalog_path}/{catalog_name}",
+    ]
+    LOGGER.debug("Creating dockerfile: %s", catalog_name)
+    run_command(cmd)
+    return f"{catalog_path}/{catalog_name}.Dockerfile"
+
+
+def render_template_to_catalog(template_path: str, catalog_path: str) -> None:
+    """
+    Render a basic template to a catalog in yaml format.
+
+    Args:
+        template_path (str): A path to a template file
+        catalog_path (str): A path to a catalog file to save the rendered template
+
+    """
+    command = ["opm", "alpha", "render-template", "basic", "-o", "yaml", template_path]
+    response = run_command(command)
+
+    with open(catalog_path, "w", encoding="utf-8") as f:
+        f.write(response.stdout.decode("utf-8"))

--- a/operator-pipeline-images/tests/entrypoints/test_build_fragment_images.py
+++ b/operator-pipeline-images/tests/entrypoints/test_build_fragment_images.py
@@ -1,66 +1,19 @@
 from pathlib import Path
 from typing import Any
 from unittest import mock
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, call, patch
 
 import operatorcert.entrypoints.build_fragment_images as build_fragment_images
 from tests.utils import create_files
 
 
-@patch("operatorcert.entrypoints.build_fragment_images.os.remove")
-@patch("operatorcert.entrypoints.build_fragment_images.os.path.exists")
-@patch("operatorcert.entrypoints.build_fragment_images.run_command")
-def test_create_dockerfilee(
-    mock_run_command: MagicMock, mock_exists: MagicMock, mock_remove: MagicMock
-) -> None:
-    mock_exists.return_value = True
-
-    result = build_fragment_images.create_dockerfile("catalogs", "catalog1")
-    assert result == "catalogs/catalog1.Dockerfile"
-
-    mock_remove.assert_called_once_with("catalogs/catalog1.Dockerfile")
-    mock_run_command.assert_called_once_with(
-        ["opm", "generate", "dockerfile", "catalogs/catalog1"]
-    )
-
-
-@patch("operatorcert.entrypoints.build_fragment_images.run_command")
-def test_build_fragment_image(mock_run_command: MagicMock) -> None:
-    result = build_fragment_images.build_fragment_image(
-        "dockerfile", "context", "image"
-    )
-    assert result == mock_run_command.return_value
-
-    mock_run_command.assert_called_once_with(
-        [
-            "buildah",
-            "bud",
-            "--format",
-            "docker",
-            "-f",
-            "dockerfile",
-            "-t",
-            "image",
-            "context",
-        ]
-    )
-
-
-@patch("operatorcert.entrypoints.build_fragment_images.run_command")
-def test_push_fragment_image(mock_run_command: MagicMock) -> None:
-    result = build_fragment_images.push_fragment_image("image", "authfile")
-    assert result == mock_run_command.return_value
-
-    mock_run_command.assert_called_once_with(
-        ["buildah", "push", "--authfile", "authfile", "image", "docker://image"]
-    )
-
-
-@patch("operatorcert.entrypoints.build_fragment_images.push_fragment_image")
-@patch("operatorcert.entrypoints.build_fragment_images.build_fragment_image")
-@patch("operatorcert.entrypoints.build_fragment_images.create_dockerfile")
+@patch("operatorcert.entrypoints.build_fragment_images.buildah.push_image")
+@patch("operatorcert.entrypoints.build_fragment_images.buildah.build_image")
+@patch("operatorcert.entrypoints.build_fragment_images.opm.create_catalog_dockerfile")
 def test_create_fragment_image(
-    mock_create_dockerfile: MagicMock, mock_build: MagicMock, mock_push: MagicMock
+    mock_create_catalog_dockerfile: MagicMock,
+    mock_build: MagicMock,
+    mock_push: MagicMock,
 ) -> None:
     args = MagicMock()
     args.tag_suffix = "foo"
@@ -68,9 +21,9 @@ def test_create_fragment_image(
     result = build_fragment_images.create_fragment_image("catalogs", "catalog1", args)
 
     assert result == "bar:catalog1-foo"
-    mock_create_dockerfile.assert_called_once_with("catalogs", "catalog1")
+    mock_create_catalog_dockerfile.assert_called_once_with("catalogs", "catalog1")
     mock_build.assert_called_once_with(
-        mock_create_dockerfile.return_value, "catalogs", "bar:catalog1-foo"
+        mock_create_catalog_dockerfile.return_value, "catalogs", "bar:catalog1-foo"
     )
     mock_push.assert_called_once_with("bar:catalog1-foo", args.authfile)
 

--- a/operator-pipeline-images/tests/entrypoints/test_build_scratch_catalog.py
+++ b/operator-pipeline-images/tests/entrypoints/test_build_scratch_catalog.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+from typing import Any
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import operatorcert.entrypoints.build_scratch_catalog as build_scratch_catalog
+
+
+def test_setup_argparser() -> None:
+    assert build_scratch_catalog.setup_argparser() is not None
+
+
+@patch("operatorcert.entrypoints.build_scratch_catalog.yaml.safe_dump_all")
+def test_generate_and_save_basic_template(mock_yaml_dump_all: MagicMock) -> None:
+    with patch(
+        "operatorcert.entrypoints.build_scratch_catalog.open", mock.mock_open()
+    ) as mock_open:
+        build_scratch_catalog.generate_and_save_basic_template(
+            "template.yaml",
+            "package",
+            "default_channel",
+            "channel_name",
+            "csv_name",
+            "bundle_pullspec",
+        )
+
+    package_obj = {
+        "schema": "olm.package",
+        "name": "package",
+        "defaultChannel": "default_channel",
+    }
+    channel = {
+        "schema": "olm.channel",
+        "package": "package",
+        "name": "channel_name",
+        "entries": [{"name": "csv_name"}],
+    }
+
+    bundles = {"schema": "olm.bundle", "image": "bundle_pullspec"}
+
+    mock_open.assert_called_once_with("template.yaml", "w", encoding="utf-8")
+    mock_yaml_dump_all.assert_called_once_with(
+        [package_obj, channel, bundles],
+        mock_open.return_value,
+        explicit_start=True,
+        indent=2,
+    )
+
+
+@patch("operatorcert.entrypoints.build_scratch_catalog.buildah.push_image")
+@patch("operatorcert.entrypoints.build_scratch_catalog.buildah.build_image")
+@patch("operatorcert.entrypoints.build_scratch_catalog.opm.create_catalog_dockerfile")
+@patch("operatorcert.entrypoints.build_scratch_catalog.opm.render_template_to_catalog")
+@patch(
+    "operatorcert.entrypoints.build_scratch_catalog.generate_and_save_basic_template"
+)
+@patch("operatorcert.entrypoints.build_scratch_catalog.tempfile.TemporaryDirectory")
+def test_build_and_push_catalog_image(
+    mock_tmp: MagicMock,
+    mock_template: MagicMock,
+    mock_render: MagicMock,
+    mock_dockerfile: MagicMock,
+    mock_build: MagicMock,
+    mock_push: MagicMock,
+) -> None:
+
+    mock_tmp.return_value.__enter__.return_value = "/tmp"
+    bundle = MagicMock()
+    bundle.channels = set(["channel"])
+    build_scratch_catalog.build_and_push_catalog_image(
+        bundle, "bundle_pullspec", "repository_destination", "authfile"
+    )
+    mock_template.assert_called_once_with(
+        template_path="/tmp/template.yaml",
+        package=bundle.metadata_operator_name,
+        default_channel=bundle.default_channel,
+        channel_name=list(bundle.channels)[0],
+        csv_name=bundle.csv["metadata"]["name"],
+        bundle_pullspec="bundle_pullspec",
+    )
+    mock_render.assert_called_once_with(
+        "/tmp/template.yaml", f"/tmp/{bundle.metadata_operator_name}/catalog.yaml"
+    )
+    mock_dockerfile.assert_called_once_with("/tmp", bundle.metadata_operator_name)
+    mock_build.assert_called_once_with(
+        mock_dockerfile.return_value, "/tmp", "repository_destination"
+    )
+    mock_push.assert_called_once_with("repository_destination", "authfile")
+
+
+@patch("operatorcert.entrypoints.build_scratch_catalog.build_and_push_catalog_image")
+@patch("operatorcert.entrypoints.build_scratch_catalog.Repo")
+@patch("operatorcert.entrypoints.build_scratch_catalog.setup_logger")
+@patch("operatorcert.entrypoints.build_scratch_catalog.setup_argparser")
+def test_main(
+    mock_setup_argparser: MagicMock,
+    mock_setup_logger: MagicMock,
+    mock_repo: MagicMock,
+    mock_build_and_push_catalog_image: MagicMock,
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    args = MagicMock()
+
+    mock_setup_argparser.return_value.parse_args.return_value = args
+
+    build_scratch_catalog.main()
+
+    mock_repo.assert_called_once_with(args.repo_path)
+
+    mock_build_and_push_catalog_image.assert_called_once_with(
+        mock_repo.return_value.operator.return_value.bundle.return_value,
+        args.bundle_pullspec,
+        args.repository_destination,
+        args.authfile,
+    )

--- a/operator-pipeline-images/tests/test_buildah.py
+++ b/operator-pipeline-images/tests/test_buildah.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock, patch
+
+from operatorcert import buildah
+
+
+@patch("operatorcert.buildah.run_command")
+def test_build_image(mock_run_command: MagicMock) -> None:
+    result = buildah.build_image("dockerfile", "context", "image")
+    assert result == mock_run_command.return_value
+
+    mock_run_command.assert_called_once_with(
+        [
+            "buildah",
+            "bud",
+            "--format",
+            "docker",
+            "-f",
+            "dockerfile",
+            "-t",
+            "image",
+            "context",
+        ]
+    )
+
+
+@patch("operatorcert.buildah.run_command")
+def test_push_image(mock_run_command: MagicMock) -> None:
+    result = buildah.push_image("image", "authfile")
+    assert result == mock_run_command.return_value
+
+    mock_run_command.assert_called_once_with(
+        ["buildah", "push", "--authfile", "authfile", "image", "docker://image"]
+    )

--- a/operator-pipeline-images/tests/test_opm.py
+++ b/operator-pipeline-images/tests/test_opm.py
@@ -1,0 +1,33 @@
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+from operatorcert import opm
+
+
+@patch("operatorcert.opm.os.remove")
+@patch("operatorcert.opm.os.path.exists")
+@patch("operatorcert.opm.run_command")
+def test_create_dockerfile(
+    mock_run_command: MagicMock, mock_exists: MagicMock, mock_remove: MagicMock
+) -> None:
+    mock_exists.return_value = True
+
+    result = opm.create_catalog_dockerfile("catalogs", "catalog1")
+    assert result == "catalogs/catalog1.Dockerfile"
+
+    mock_remove.assert_called_once_with("catalogs/catalog1.Dockerfile")
+    mock_run_command.assert_called_once_with(
+        ["opm", "generate", "dockerfile", "catalogs/catalog1"]
+    )
+
+
+@patch("operatorcert.opm.run_command")
+def test_render_template_to_catalog(mock_run_command: MagicMock) -> None:
+    mock_open = mock.mock_open()
+    with mock.patch("builtins.open", mock_open):
+        opm.render_template_to_catalog("template.yaml", "catalog.yaml")
+        mock_open.assert_called_once_with("catalog.yaml", "w", encoding="utf-8")
+
+    mock_run_command.assert_called_once_with(
+        ["opm", "alpha", "render-template", "basic", "-o", "yaml", "template.yaml"]
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
 add-fbc-fragments-to-index = "operatorcert.entrypoints.add_fbc_fragments_to_index:main"
 apply-test-waivers = "operatorcert.entrypoints.apply_test_waivers:main"
 build-fragment-images = "operatorcert.entrypoints.build_fragment_images:main"
+build-scratch-catalog = "operatorcert.entrypoints.build_scratch_catalog:main"
 bundle-dockerfile = "operatorcert.entrypoints.bundle_dockerfile:main"
 check-permissions = "operatorcert.entrypoints.check_permissions:main"
 create-container-image = "operatorcert.entrypoints.create_container_image:main"


### PR DESCRIPTION
The temporary catalog is build in hosted pipeline and is used for preflight testing. The catalog contains just one operator and it is generated using basic template.

JIRA: ISV-4990