### PR TITLE
updating preflight sha for version 1.10.0

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:a800ff4ff708194034fc5629503cd1d37577c507c9d20f7adb7c3896d21ed645
+      default: quay.io/redhat-isv/preflight-test@sha256:e4707e5f3a61c737c9b5f04d2ebe45675fde2d1c72b65df9152e8a053acd6c61
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
```
❯ crane digest quay.io/redhat-isv/preflight-test:1.9.9
sha256:a800ff4ff708194034fc5629503cd1d37577c507c9d20f7adb7c3896d21ed645

~ 
❯ crane digest quay.io/redhat-isv/preflight-test:1.10.0
sha256:e4707e5f3a61c737c9b5f04d2ebe45675fde2d1c72b65df9152e8a053acd6c61
```