### PR TITLE
Fix: Import only version tag index images

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/operator-pipeline-import-index-images.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-pipeline-import-index-images.yml
@@ -26,15 +26,43 @@
           env: "{{ env }}"
       spec:
         import: true
-        repository:
-          from:
-            kind: DockerImage
-            name: "{{ certified_operator_index }}"
-          importPolicy:
-            insecure: "{{ insecure_index_import | default(false) }}"
-            scheduled: true
-          referencePolicy:
-            type: Local
+        images:
+          - from:
+              kind: DockerImage
+              name: "{{ certified_operator_index }}:v4.12"
+            importPolicy:
+              insecure: "{{ insecure_index_import | default(false) }}"
+              scheduled: true
+          - from:
+              kind: DockerImage
+              name: "{{ certified_operator_index }}:v4.13"
+            importPolicy:
+              insecure: "{{ insecure_index_import | default(false) }}"
+              scheduled: true
+          - from:
+              kind: DockerImage
+              name: "{{ certified_operator_index }}:v4.14"
+            importPolicy:
+              insecure: "{{ insecure_index_import | default(false) }}"
+              scheduled: true
+          - from:
+              kind: DockerImage
+              name: "{{ certified_operator_index }}:v4.15"
+            importPolicy:
+              insecure: "{{ insecure_index_import | default(false) }}"
+              scheduled: true
+          - from:
+              kind: DockerImage
+              name: "{{ certified_operator_index }}:v4.16"
+            importPolicy:
+              insecure: "{{ insecure_index_import | default(false) }}"
+              scheduled: true
+          - from:
+              kind: DockerImage
+              name: "{{ certified_operator_index }}:v4.17"
+            importPolicy:
+              insecure: "{{ insecure_index_import | default(false) }}"
+              scheduled: true
 
 - name: Import redhat-marketplace-index imagestream
   tags:
@@ -61,12 +89,40 @@
           env: "{{ env }}"
       spec:
         import: true
-        repository:
-          from:
-            kind: DockerImage
-            name: "{{ redhat_marketplace_index }}"
-          importPolicy:
-            insecure: "{{ insecure_index_import | default(false) }}"
-            scheduled: true
-          referencePolicy:
-            type: Local
+        images:
+          - from:
+              kind: DockerImage
+              name: "{{ redhat_marketplace_index }}:v4.12"
+            importPolicy:
+              insecure: "{{ insecure_index_import | default(false) }}"
+              scheduled: true
+          - from:
+              kind: DockerImage
+              name: "{{ redhat_marketplace_index }}:v4.13"
+            importPolicy:
+              insecure: "{{ insecure_index_import | default(false) }}"
+              scheduled: true
+          - from:
+              kind: DockerImage
+              name: "{{ redhat_marketplace_index }}:v4.14"
+            importPolicy:
+              insecure: "{{ insecure_index_import | default(false) }}"
+              scheduled: true
+          - from:
+              kind: DockerImage
+              name: "{{ redhat_marketplace_index }}:v4.15"
+            importPolicy:
+              insecure: "{{ insecure_index_import | default(false) }}"
+              scheduled: true
+          - from:
+              kind: DockerImage
+              name: "{{ redhat_marketplace_index }}:v4.16"
+            importPolicy:
+              insecure: "{{ insecure_index_import | default(false) }}"
+              scheduled: true
+          - from:
+              kind: DockerImage
+              name: "{{ redhat_marketplace_index }}:v4.17"
+            importPolicy:
+              insecure: "{{ insecure_index_import | default(false) }}"
+              scheduled: true


### PR DESCRIPTION
The repository contains many index images for each catalog build. For purposes of the import task we only need a main version that are currently supported by OpenShift version support. This commit imports only 6 tags per image stream that could be used by ci-pipeline.

JIRA: ISV-4298