### PR TITLE
Fix: FBC support in cert-project-check task

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -489,6 +489,8 @@ spec:
           value: "$(params.pipeline_image)"
         - name: bundle_path
           value: "$(tasks.detect-changes.results.bundle_path)"
+        - name: catalog_operator_path
+          value: "$(tasks.detect-changes.results.affected_catalog_operators)"
         - name: cert_project_required
           value: "$(params.cert_project_required)"
       workspaces:

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -263,6 +263,8 @@ spec:
           value: "$(params.pipeline_image)"
         - name: bundle_path
           value: "$(tasks.detect-changes.results.bundle_path)"
+        - name: catalog_operator_path
+          value: "$(tasks.detect-changes.results.affected_catalog_operators)"
         - name: cert_project_required
           value: "$(params.cert_project_required)"
       workspaces:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/cert-project-check.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/cert-project-check.yml
@@ -8,6 +8,9 @@ spec:
     - name: pipeline_image
     - name: bundle_path
       description: path indicating the location of the certified bundle within the repository
+    - name: catalog_operator_path
+      description: path indicating the location of the catalog operator within the repository
+      default: ""
     - name: cert_project_required
       description: A flag determines whether a cert project ID needs to be present
       default: "true"
@@ -30,8 +33,15 @@ spec:
           echo -n "" | tee $(results.certification_project_id.path)
           exit 0
         fi
-
-        PKG_PATH=$(dirname $(realpath $(params.bundle_path)))
+        if [ "$(params.bundle_path)" != "" ]; then
+          PKG_PATH=$(dirname $(realpath $(params.bundle_path)))
+        elif [ "$(params.catalog_operator_path)" != "" ]; then
+          OPERATOR_NAME=$(echo $(params.catalog_operator_path) | cut -d ',' -f 1 | cut -d '/' -f 2)
+          PKG_PATH=operators/$OPERATOR_NAME
+        else
+          echo "Bundle path is missing."
+          exit 1
+        fi
 
         CI_FILE_PATH="$PKG_PATH/ci.yaml"
 


### PR DESCRIPTION
The task that checks a cert project didn't support the FBC catalog workflow. This commit adds the support and the task parses the cert project from ci.yaml even though only the catalog change is submitted.

JIRA: ISV-5114