### PR TITLE
Fix: read-config support FBC catalog submission

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -378,8 +378,8 @@ spec:
           value: "$(params.pipeline_image)"
         - name: operator_path
           value: "$(tasks.detect-changes.results.operator_path)"
-        - name: bundle_path
-          value: "$(tasks.detect-changes.results.bundle_path)"
+        - name: catalog_operator_path
+          value: "$(tasks.detect-changes.results.affected_catalog_operators)"
       workspaces:
         - name: source
           workspace: repository

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -226,8 +226,8 @@ spec:
           value: "$(params.pipeline_image)"
         - name: operator_path
           value: "$(tasks.detect-changes.results.operator_path)"
-        - name: bundle_path
-          value: "$(tasks.detect-changes.results.bundle_path)"
+        - name: catalog_operator_path
+          value: "$(tasks.detect-changes.results.affected_catalog_operators)"
       workspaces:
         - name: source
           workspace: repository

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/read-config.yaml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/read-config.yaml
@@ -14,8 +14,9 @@ spec:
       description: |
         Path to an operator within the git repository where the config is expected.
 
-    - name: bundle_path
-      description: Path indicating bundle affected with the change
+    - name: catalog_operator_path
+      description: path indicating the location of the catalog operator within the repository
+      default: ""
 
   results:
     - name: upgrade-graph-mode
@@ -35,7 +36,17 @@ spec:
         #! /usr/bin/env bash
         set -ex
 
-        CONFIG_PATH="$(params.operator_path)/ci.yaml"
+        if [ "$(params.operator_path)" != "" ]; then
+          PKG_PATH="$(params.operator_path)"
+        elif [ "$(params.catalog_operator_path)" != "" ]; then
+          OPERATOR_NAME=$(echo $(params.catalog_operator_path) | cut -d ',' -f 1 | cut -d '/' -f 2)
+          PKG_PATH=operators/$OPERATOR_NAME
+        else
+          echo "Bundle path is missing."
+          exit 1
+        fi
+
+        CONFIG_PATH="$PKG_PATH/ci.yaml"
 
         if [[ ! -f "$CONFIG_PATH" ]]; then
             echo "Config file $CONFIG_PATH does not exist or no bundle affected."


### PR DESCRIPTION
The read-config didn't support a case where a FBC catalog only was submitted. This commit make a task compatible with FBC by finding a ci.yaml file in the operator directory based on which catalog operator was submitted.

JIRA: ISV-5115