### PR TITLE
Tests: reduce index count in tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,16 +20,9 @@ jobs:
           - isv
           - community
           - isv-fbc-bundle
-        experimental: [false]
-        include:
-          # Test ISV FBC Catalog only in experimental mode
-          # because there is a bug that needs to be fixed
-          # TODO: remove this block when the bug is fixed
-          - test_type: isv-fbc-catalog
-            experimental: true
+          - isv-fbc-catalog
 
       fail-fast: false
-    continue-on-error: ${{ matrix.experimental }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/ansible/inventory/group_vars/operator-pipeline-integration-tests-isv-fbc-catalog.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-integration-tests-isv-fbc-catalog.yml
@@ -10,4 +10,4 @@ integration_tests_fbc_catalog: true
 integration_tests_pr_title: "Catalog update {{ integration_tests_operator_package_name }} ({{ integration_tests_operator_bundle_version }})"
 
 # To avoid conflicts with the non-fbc tests, we use a different range
-integration_tests_ocp_versions_range: "v4.16-v4.17"
+integration_tests_ocp_versions_range: "=v4.16"

--- a/ansible/inventory/group_vars/operator-pipeline-integration-tests.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-integration-tests.yml
@@ -24,7 +24,7 @@ integration_tests_src_operator_git_branch: e2e-test-operator
 integration_tests_src_operator_package_name: test-e2e-operator
 integration_tests_src_operator_bundle_version: 0.0.8
 
-integration_tests_ocp_versions_range: "v4.14-v4.15"
+integration_tests_ocp_versions_range: "=v4.15"
 
 integration_tests_fbc_catalog: false
 integration_tests_verify_bundle_in_catalog: true

--- a/ansible/roles/integration_tests/tasks/test_data.yml
+++ b/ansible/roles/integration_tests/tasks/test_data.yml
@@ -145,9 +145,6 @@
 
     popd
 
-    # Copy a same catalog to one more version
-    cp -r catalogs/v4.16 catalogs/v4.17
-
     git add catalogs
     git commit -m "[Integration Test] Add catalog for $OPERATOR_PACKAGE_NAME"
     git push origin "$PR_BRANCH"


### PR DESCRIPTION
The bottleneck for integration tests is IIB which builds index images in series. The previous configuration always released 2 catalogs per tests. This caused a significant delays and sometime IIB builds failed with timeout due to a long queue.

This commit reduce amount of affected index images to only one and at the same time makes isv-fbc-catalog test mandatory. All bugs that cause a test to fails have been already fixed and there is no need for making this test optional anymore.