### PR TITLE
Fix: Remove deprecated inventory for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,8 +43,7 @@ jobs:
           requirements: playbooks/requirements.yml
           vault_password: ${{secrets.VAULT_PASSWORD}}
           options: |
-            --inventory inventory/operator-pipeline-dev
-            --extra-vars "operator_pipeline_image_tag=${{ github.sha }} suffix=${{needs.prepare-env.outputs.short_sha}}"
+            --extra-vars "operator_pipeline_image_tag=${{ github.sha }} suffix=${{needs.prepare-env.outputs.short_sha}} env=dev"
             --skip-tags ci,import-index-images
             --verbose
 
@@ -70,8 +69,7 @@ jobs:
           requirements: playbooks/requirements.yml
           vault_password: ${{secrets.VAULT_PASSWORD}}
           options: |
-            --inventory inventory/operator-pipeline-qa
-            --extra-vars "operator_pipeline_image_tag=${{ github.sha }} suffix=${{needs.prepare-env.outputs.short_sha}}"
+            --extra-vars "operator_pipeline_image_tag=${{ github.sha }} suffix=${{needs.prepare-env.outputs.short_sha}} env=qa"
             --skip-tags ci,import-index-images
             --verbose
 
@@ -98,8 +96,7 @@ jobs:
           requirements: playbooks/requirements.yml
           vault_password: ${{secrets.VAULT_PASSWORD}}
           options: |
-            --inventory inventory/operator-pipeline-stage
-            --extra-vars "operator_pipeline_image_tag=${{ github.sha }} suffix=${{needs.prepare-env.outputs.short_sha}}"
+            --extra-vars "operator_pipeline_image_tag=${{ github.sha }} suffix=${{needs.prepare-env.outputs.short_sha}} env=stage"
             --skip-tags ci,import-index-images
             --verbose
 
@@ -125,8 +122,7 @@ jobs:
           requirements: playbooks/requirements.yml
           vault_password: ${{secrets.VAULT_PASSWORD_PROD}}
           options: |
-            --inventory inventory/operator-pipeline-prod
-            --extra-vars "operator_pipeline_image_tag=${{ github.sha }} suffix=${{needs.prepare-env.outputs.short_sha}}"
+            --extra-vars "operator_pipeline_image_tag=${{ github.sha }} suffix=${{needs.prepare-env.outputs.short_sha}} env=prod"
             --skip-tags ci,import-index-images
             --verbose
 

--- a/ansible/inventory/group_vars/operator-pipeline-integration-tests.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-integration-tests.yml
@@ -24,7 +24,7 @@ integration_tests_src_operator_git_branch: e2e-test-operator
 integration_tests_src_operator_package_name: test-e2e-operator
 integration_tests_src_operator_bundle_version: 0.0.8
 
-integration_tests_ocp_versions_range: "=v4.15"
+integration_tests_ocp_versions_range: "=v4.14"
 
 integration_tests_fbc_catalog: false
 integration_tests_verify_bundle_in_catalog: true

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -1,6 +1,6 @@
 ---
 - name: Deploy all the operator pipelines
-  hosts: all
+  hosts: "operator-pipeline-{{ env }}"
   vars_files:
     - ../vaults/{{ env }}/secret-vars.yml
     - ../vaults/{{ env }}/ocp-token.yml


### PR DESCRIPTION
A inventory used in deployment workflow was removed in previous commit and was replaced by the new one controlled by the env variable.

This commit also fixed a target version of ocp index image for integration tests. The previous version wasn't aligned with tested cluster.