### PR TITLE
adding exit 1 if gh cli tool fails to merge a pull request

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
@@ -93,4 +93,5 @@ spec:
         else
             echo "Cannot merge PR"
             echo -n "false" > "$(results.pr_merged.path)"
+            exit 1
         fi


### PR DESCRIPTION
- Adding `exit 1` when the `gh` cli fails, so that the GH comments show a `red x` instead of a `check mark`, indicating that support should manually re-run the `gh` cmd in the `merge task` of the given pipeline.