### PR TITLE
adding apt-get update before calling install in gha

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install non-python dependencies
         run: |
-          sudo apt-get install -y libkrb5-dev
+          sudo apt-get update && sudo apt-get install -y libkrb5-dev
 
       - name: Install Hadolint via Brew
         run: |


### PR DESCRIPTION
- adding apt-get update to try and resolve ci failures
- https://github.com/redhat-openshift-ecosystem/operator-pipelines/actions/runs/10321380409/job/28575546743?pr=705