### PR TITLE
Fix: Render only catalogs supported by an operator

### DIFF
--- a/docs/users/fbc_onboarding.md
+++ b/docs/users/fbc_onboarding.md
@@ -30,6 +30,10 @@ wget https://raw.githubusercontent.com/redhat-openshift-ecosystem/operator-pipel
 Now we can convert existing operator into FBC. The initial run takes a while because
 a local cache is generated during a run.
 
+> [!NOTE]
+> A user executing the conversion script needs to be authenticated to registries used by OLM catalog.
+> Use `podman login` to log in into all registries.
+
 To convert existing operator to `FBC` format you need to execute following command:
 
 ```bash
@@ -41,7 +45,11 @@ $ make fbc-onboarding
 ...
 ```
 
-The Makefile will execute the following steps:
+> [!IMPORTANT]
+> In case an operator isn't shipped to all OCP catalog versions manually update `OCP_VERSIONS`
+> variable in the `Makefile` and include only versions supported by an operator.
+
+The Makefile will execute following steps:
  - Download dependencies needed for the migration (opm, fbc-onboarding CLI)
  - Fetch a list of currently supported OCP catalogs
  - Transform existing catalogs into a basic template

--- a/docs/users/fbc_workflow.md
+++ b/docs/users/fbc_workflow.md
@@ -56,6 +56,11 @@ The right place for the Makefile is in the operator's root directory
 ```
 
 You can modify the Makefile based on your needs and use it to generate catalogs by running `make catalog`.
+
+> [!IMPORTANT]
+> In case an operator isn't shipped to all OCP catalog versions manually update `OCP_VERSIONS`
+> variable in the `Makefile` and include only versions supported by an operator.
+
 The command uses the `opm` and converts templates into catalogs. The generated catalogs
 can be submitted as a PR in Github and once the PR is processed changes will be released to the
 OCP index.

--- a/operator-pipeline-images/tests/entrypoints/test_fbc_onboarding.py
+++ b/operator-pipeline-images/tests/entrypoints/test_fbc_onboarding.py
@@ -134,12 +134,30 @@ def test_generate_and_save_base_templates(
     mock_yaml_load: MagicMock, mock_yaml_dump: MagicMock, mock_template: MagicMock
 ) -> None:
     mock_yaml_load.return_value = []
+    mock_template.return_value = [{}]
+
+    with mock.patch("builtins.open", mock.mock_open()) as mock_open:
+        resp = fbc_onboarding.generate_and_save_base_templates(
+            "v1", "img", "/tmp", "/tmp"
+        )
+
+        mock_yaml_dump.assert_called_once()
+        assert resp == mock_template.return_value
+
+
+@patch("operatorcert.entrypoints.fbc_onboarding.get_base_template_from_catalog")
+@patch("operatorcert.entrypoints.fbc_onboarding.yaml.safe_dump_all")
+@patch("operatorcert.entrypoints.fbc_onboarding.yaml.safe_load_all")
+def test_generate_and_save_base_templates_no_content(
+    mock_yaml_load: MagicMock, mock_yaml_dump: MagicMock, mock_template: MagicMock
+) -> None:
+    mock_yaml_load.return_value = []
     mock_template.return_value = []
 
     with mock.patch("builtins.open", mock.mock_open()) as mock_open:
         fbc_onboarding.generate_and_save_base_templates("v1", "img", "/tmp", "/tmp")
 
-        mock_yaml_dump.assert_called_once()
+        mock_yaml_dump.assert_not_called()
 
 
 @patch("operatorcert.entrypoints.fbc_onboarding.yaml.safe_dump")


### PR DESCRIPTION
The fbc onboarding script is updated to only generate a template and catalog for ocp versions where the catalog exists. The script skips version where operator has never been shipped.

JIRA: ISV-5131