### PR TITLE
Fix: bump opm version to produce compatible catalogs

### DIFF
--- a/fbc/Makefile
+++ b/fbc/Makefile
@@ -25,7 +25,7 @@ OPERATOR_CATALOG_TEMPLATE_DIR = ${PDW}/catalog-templates
 
 # A list of OCP versions to generate catalogs for
 # This list can be customized to include the versions that are relevant to the operator
-# DO NOT change this line (except for the versions) if you want to take advantage 
+# DO NOT change this line (except for the versions) if you want to take advantage
 # of the automated catalog promotion
 OCP_VERSIONS=$(shell echo "v4.12 v4.13 v4.14 v4.15 v4.16" )
 
@@ -95,7 +95,7 @@ OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(shell uname -m | sed 's/x86_64/amd64/')
 
 # Automatically download the opm binary
-OPM_VERSION ?= v1.40.0
+OPM_VERSION ?= v1.46.0
 ${BINDIR}/opm:
 	if [ ! -d ${BINDIR} ]; then mkdir -p ${BINDIR}; fi
 	curl -sLO https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$(OS)-$(ARCH)-opm && chmod +x $(OS)-$(ARCH)-opm && mv $(OS)-$(ARCH)-opm ${BINDIR}/opm

--- a/operator-pipeline-images/Dockerfile
+++ b/operator-pipeline-images/Dockerfile
@@ -46,12 +46,12 @@ RUN dnf update -y && \
 COPY operator-pipeline-images/config/krb5.conf /etc/krb5.conf
 
 # Install oc, opm and operator-sdk CLI
-RUN curl -LO https://github.com/operator-framework/operator-registry/releases/download/v1.29.0/linux-${ARCH}-opm && \
+RUN curl -LO https://github.com/operator-framework/operator-registry/releases/download/v1.46.0/linux-${ARCH}-opm && \
     chmod +x linux-${ARCH}-opm && \
     mv linux-${ARCH}-opm /usr/local/bin/opm && \
-    curl -LO https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/stable-4.13/openshift-client-linux.tar.gz && \
+    curl -LO https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/stable-4.14/openshift-client-linux.tar.gz && \
     tar xzvf openshift-client-linux.tar.gz -C /usr/local/bin oc && \
-    curl -LO https://github.com/operator-framework/operator-sdk/releases/download/v1.32.0/operator-sdk_linux_${ARCH} && \
+    curl -LO https://github.com/operator-framework/operator-sdk/releases/download/v1.36.1/operator-sdk_linux_${ARCH} && \
     chmod +x operator-sdk_linux_${ARCH} && \
     mv operator-sdk_linux_${ARCH} /usr/local/bin/operator-sdk
 
@@ -67,7 +67,7 @@ WORKDIR /home/user
 COPY ./operator-pipeline-images ./operator-pipeline-images
 
 # install PDM
-RUN pip3 install --no-cache-dir --upgrade pip setuptools wheel && pip3 install --no-cache-dir pdm
+RUN pip3 install --no-cache-dir pdm
 # install dependencies in virtual environment
 COPY ./pdm.lock ./pyproject.toml ./README.md ./
 RUN pdm venv create 3.11 && pdm install --no-lock --no-editable \


### PR DESCRIPTION
An older version of opm produced a catalog that OCP server couldn't read and skipped operators. This change updates opm and few other dependencies to fix the issue.