### PR TITLE
[ISV-5194] Operator pipeline merge-pr parse the gh tool response

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -1245,6 +1245,9 @@ spec:
         - name: source
           workspace: repository
           subPath: src
+        - name: output
+          workspace: results
+          subPath: summary
 
     # link pull request details to test results
     - name: link-pull-request-with-merged-status

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
@@ -164,6 +164,13 @@ spec:
           fi
         fi
 
+
+        if [[ -f "$(workspaces.output.path)/merge_error.txt" ]]; then
+          MERGE_ERROR=$(cat "$(workspaces.output.path)/merge_error.txt")
+          echo -e "\n## ❌ Not merged\n" >> $PR_NAME/comment.md
+          echo -e "PR cannot be merged for the following reasons: \`$MERGE_ERROR\`" >> $PR_NAME/comment.md
+        fi
+
         echo -e "\n## Troubleshooting\n\nPlease refer to the [troubleshooting guide]($DOC_LINK)." >> $PR_NAME/comment.md
         echo -e "\nRun \`/pipeline restart $(params.pipeline_name)\` in case of pipeline failure to restart a pipeline." >> $PR_NAME/comment.md
 

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
@@ -21,6 +21,8 @@ spec:
       default: token
   workspaces:
     - name: source
+    - name: output
+      description: Scratch space and storage for the comment and related data
   results:
     - name: bool_merge
     - name: pr_merged
@@ -62,12 +64,6 @@ spec:
         # in a single call upfront and process the result later
         gh pr view "$(params.git_pr_url)" --json isDraft,reviews >/tmp/pr.json
 
-        if [[ "$(jq -r ".isDraft" /tmp/pr.json)" == "true" ]] ; then
-            echo "Skipping merge: PR is set as draft"
-            echo -n "false" > "$(results.pr_merged.path)"
-            exit 0
-        fi
-
         # Extract all reviews and return one line per reviewer containing three space separated fields:
         #   $state $authorAssociation $author
         # where
@@ -84,21 +80,31 @@ spec:
 
         # Do not merge if we do not have approval from the bot or any other repo member
         if ! grep "^APPROVED MEMBER " /tmp/reviews.txt ; then
-            echo "Skipping merge: PR is not approved."
+            echo -n "Skipping merge: PR is not approved." | tee "$(workspaces.output.path)/merge_error.txt"
             echo -n "false" > "$(results.pr_merged.path)"
             exit 0
         fi
 
         # Squash and merge only if the head commit sha has not changed since
         # the start of the pipeline run
-        gh pr merge "$(params.git_pr_url)" --squash --auto \
-            --match-head-commit "$(params.git_head_commit)"
+        MERGE_STDERR=$(gh pr merge "$(params.git_pr_url)" --squash --auto --match-head-commit "$(params.git_head_commit)" 2>&1 >/dev/null)
+        MERGE_RESULT=$?
+        MERGE_ERROR=$(echo "$MERGE_STDERR" | grep -oP '(?<=GraphQL: ).*')
 
-        if [[ $? -eq 0 ]] ; then
+        if [[ $MERGE_RESULT -eq 0 ]] ; then
             echo "PR has been merged!"
             echo -n "true" > "$(results.pr_merged.path)"
         else
             echo "Cannot merge PR"
             echo -n "false" > "$(results.pr_merged.path)"
-            exit 1
+            # Pass details about merge error to summary comment task
+            echo -n $MERGE_ERROR | tee "$(workspaces.output.path)/merge_error.txt"
+            # Custom error message when other pipeline is running.
+            if [[ "$MERGE_ERROR" == "Head branch was modified. Review and try the merge again. (mergePullRequest)" ]] ; then
+              echo -n "Another pipeline is already in progress: please wait for the result of the new tests." | tee "$(workspaces.output.path)/merge_error.txt"
+            fi
+            # Fail pipeline if the error is not explicitly allowed.
+            if [[ "$MERGE_ERROR" != "Pull Request is still a draft (mergePullRequest)" && "$MERGE_ERROR" != "Head branch was modified. Review and try the merge again. (mergePullRequest)" ]] ; then
+              exit 1
+            fi
         fi

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/read-config.yaml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/read-config.yaml
@@ -27,7 +27,7 @@ spec:
   workspaces:
     - name: source
     - name: output
-      description: Scratch space and storage for the comment and related date
+      description: Scratch space and storage for the comment and related data
   steps:
     - name: read-config
       image: "$(params.pipeline_image)"


### PR DESCRIPTION
If `merge-pr` step of hosted pipeline fails, error message is included in the PR comment.

If merge fails because PR is marked as a draft or because there are new commits, pipeline passes without merge. Otherwise, pipeline fails.

Passing pipeline:
https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/1757

Merge failed because of draft:
https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/1760

Merge failed because of new commit:
https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/1759

Merge failed with different non-allowed error:
https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/1761