### PR TITLE
[ISV-5191] Release pipeline can be triggered by label only when PR is merged

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/community-pipeline-event-listener.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-pipeline-event-listener.yml
@@ -121,6 +121,7 @@
                             body.action == "labeled"
                             && body.label.name == "pipeline/trigger-release"
                             && body.pull_request.base.ref == "{{ branch }}"
+                            && body.pull_request.merged == true
                           )
                 bindings:
                   - ref: community-operator-release-pipeline-trigger-binding

--- a/ansible/roles/operator-pipeline/tasks/operator-pipeline-event-listener.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-pipeline-event-listener.yml
@@ -108,6 +108,7 @@
                           body.action == "labeled"
                           && body.label.name == "pipeline/trigger-release"
                           && body.pull_request.base.ref == "{{ branch }}"
+                          && body.pull_request.merged == true
                         )
                 bindings:
                   - ref: operator-release-pipeline-trigger-binding


### PR DESCRIPTION
Tested in personal OC playground on top of [this PR](https://github.com/redhat-openshift-ecosystem/community-operators-pipeline-preprod/pull/244) - intercepted event evaluated as False and release pipeline was not triggered.

Event listener test log:
```
{
  "severity": "info",
  "timestamp": "2024-09-06T08:22:31.987Z",
  "logger": "eventlistener",
  "caller": "sink/sink.go:420",
  "message": "interceptor stopped trigger processing: rpc error: code = FailedPrecondition desc = expression (\n  body.action == \"labeled\"\n  && body.label.name == \"pipeline/trigger-release\"\n  && body.pull_request.base.ref == \"tman-test\"\n  && body.pull_request.merged == true\n) did not return true",
  "commit": "80de3d1",
  "eventlistener": "community-operator-pipeline-github-listener",
  "namespace": "tman-playground",
  "/triggers-eventid": "4e7da982-ebdb-40d4-962e-756e37033d83",
  "eventlistenerUID": "fb05bb4f-0ad7-4c95-9231-2972cea3a237",
  "/trigger": "github-community-label-listener-release"
}
```

Closes ISV-5191