### PR TITLE
Use container in fbc-onboarding target

### DIFF
--- a/docs/users/fbc_onboarding.md
+++ b/docs/users/fbc_onboarding.md
@@ -21,6 +21,10 @@ We want to help with this process and we prepared a tooling that helps with this
 As a prerequisite to this process, you need to download a `Makefile` that
 automates the migration process.
 
+An initial system requirement is to have following dependencies installed:
+ - [podman](https://podman.io/docs/installation)
+ - [make](https://www.gnu.org/software/make/)
+
 ```bash
 # Go to the operator repo directory (certified-operators, marketplace-operators, community-operators-prod)
 cd <operator-repo>/operators/<operator-name>
@@ -33,6 +37,8 @@ a local cache is generated during a run.
 > **Note**
 > A user executing the conversion script needs to be authenticated to registries used by OLM catalog.
 > Use `podman login` to log in into all registries.
+> A conversion script assumes you have `$(XDG_RUNTIME_DIR)/containers/auth.json` or `~/.docker/config.json` present
+> with valid registry tokens.
 
 To convert existing operator to `FBC` format you need to execute following command:
 
@@ -109,7 +115,7 @@ $ git commit --signoff -m "Add FBC resources for aqua operator"
 Catalog templates are used to simplify a view of a catalog and allow easier manipulation of catalogs. The automated conversion pre-generates a basic template that can be turned into full FBC using the following command:
 
 ```bash
-make catalog
+make catalogs
 ```
 
 Of course, you can choose any type of template that you prefer by modifying the Makefile target.

--- a/docs/users/fbc_workflow.md
+++ b/docs/users/fbc_workflow.md
@@ -51,7 +51,7 @@ The right place for the Makefile is in the operator's root directory
 
 ```
 
-You can modify the Makefile based on your needs and use it to generate catalogs by running `make catalog`.
+You can modify the Makefile based on your needs and use it to generate catalogs by running `make catalogs`.
 
 > [!IMPORTANT]
 > In case an operator isn't shipped to all OCP catalog versions manually update `OCP_VERSIONS`
@@ -167,5 +167,5 @@ of operator releases. This allows any post-release modification of the catalogs.
 If you want to change the order of updates, remove an invalid bundle, or do any other modification
 you are free to do that.
 
-After updating catalog templates don't forget to run `make catalog` to generate a catalog
+After updating catalog templates don't forget to run `make catalogs` to generate a catalog
 from templates and submit the resulting catalog using PR workflow.

--- a/fbc/Makefile
+++ b/fbc/Makefile
@@ -23,33 +23,54 @@ CATALOG_DIR=${TOPDIR}/catalogs
 # A place to store the operator catalog templates
 OPERATOR_CATALOG_TEMPLATE_DIR = ${PDW}/catalog-templates
 
+# The operator pipeline image to use for the fbc-onboarding target
+OPERATOR_PIPELINE_IMAGE ?= quay.io/redhat-isv/operator-pipelines-images:released
+
+# Define the paths for both auth files
+DOCKER_CONFIG := $(HOME)/.docker/config.json
+CONTAINERS_AUTH := $(XDG_RUNTIME_DIR)/containers/auth.json
+
 # A list of OCP versions to generate catalogs for
 # This list can be customized to include the versions that are relevant to the operator
 # DO NOT change this line (except for the versions) if you want to take advantage
 # of the automated catalog promotion
-OCP_VERSIONS=$(shell echo "v4.12 v4.13 v4.14 v4.15 v4.16" )
+OCP_VERSIONS=$(shell echo "v4.12 v4.13 v4.14 v4.15 v4.16 v4.17" )
 
 
-#
 .PHONY: fbc-onboarding
-fbc-onboarding: fbc-onboarding-deps ${BINDIR}/opm clean
-	fbc-onboarding \
-		--repo-root $(TOPDIR) \
-		--operator-name $(OPERATOR_NAME) \
-		--cache-dir $(TOPDIR)/.catalog_cache \
-		--verbose
+fbc-onboarding: clean
+	@if [ -f $(DOCKER_CONFIG) ]; then \
+		echo "Using Docker config file: $(DOCKER_CONFIG)"; \
+		CONFIG_VOLUME="-v $(DOCKER_CONFIG):/root/.docker/config.json"; \
+	elif [ -f $(CONTAINERS_AUTH) ]; then \
+		echo "Using containers auth file: $(CONTAINERS_AUTH)"; \
+		CONFIG_VOLUME="-v $(CONTAINERS_AUTH):/root/.docker/config.json"; \
+	else \
+		echo "No authentication file found."; \
+	fi; \
+	podman run \
+		--rm \
+		--user $(id -u):$(id -g) \
+		--security-opt label=disable \
+		--pull always \
+		-v $(TOPDIR):/workspace \
+		$$CONFIG_VOLUME \
+		$(OPERATOR_PIPELINE_IMAGE) fbc-onboarding \
+			--repo-root /workspace \
+			--operator-name $(OPERATOR_NAME) \
+			--cache-dir /workspace/.catalog_cache
 
-.PHONY: catalog
+.PHONY: catalogs
 # replace this stub with one customized to serve your needs ... some examples below
 
 # here are a few examples of different approaches to fulfilling this target
 # comment out / customize the one that makes the most sense, or use them as examples in defining your own
 #
 # --- BASIC TEMPLATE ---
-catalog: basic
+catalogs: basic
 #
 # --- SEMVER TEMPLATE ---
-#catalog: semver
+#catalogs: semver
 
 
 # basic target provides an example FBC generation from a `basic` template type.
@@ -71,11 +92,11 @@ semver: ${BINDIR}/opm clean
 		${BINDIR}/opm alpha render-template semver -o yaml  ${OPERATOR_CATALOG_TEMPLATE_DIR}/$${version}.yaml > ${CATALOG_DIR}/$${version}/${OPERATOR_NAME}/catalog.yaml; \
 	done
 
-#
-# validate target illustrates FBC validation
+
+# validate-catalogs target illustrates FBC validation
 # all FBC must pass opm validation in order to be able to be used in a catalog
-.PHONY: validate
-validate: ${BINDIR}/opm
+.PHONY: validate-catalogs
+validate-catalogs: ${BINDIR}/opm
 	${BINDIR}/opm validate $(CATALOG_DIR) && echo "catalog validation passed" || echo "catalog validation failed"
 
 .PHONY: create-catalog-dir
@@ -86,10 +107,6 @@ create-catalog-dir:
 clean: create-catalog-dir
 	find $(CATALOG_DIR) -type d -name ${OPERATOR_NAME} -exec rm -rf {} +
 
-# fbc-onboarding-deps installs the fbc-onboarding tool using pip
-.PHONY: fbc-onboarding-deps
-fbc-onboarding-deps:
-	pip install git+https://github.com/redhat-openshift-ecosystem/operator-pipelines.git
 
 OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(shell uname -m | sed 's/x86_64/amd64/')

--- a/operator-pipeline-images/operatorcert/entrypoints/fbc_onboarding.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/fbc_onboarding.py
@@ -3,7 +3,6 @@
 import argparse
 import logging
 import os
-import sys
 from typing import Any, Dict, Optional
 
 import requests
@@ -168,11 +167,7 @@ def create_catalog_template_dir_if_not_exists(operator: Any) -> str:
         str: Path to the template directory
     """
     template_dir = os.path.join(operator.root, CATALOG_TEMPLATES_DIR)
-    if os.path.exists(template_dir):
-        LOGGER.info("FBC template directory already exists at %s", template_dir)
-        user_input = input("FBC template directory already exists. Overwrite? [y/n]: ")
-        if user_input.lower() != "y":
-            sys.exit(0)
+
     if not os.path.exists(template_dir):
         LOGGER.info("Creating template directory at %s", template_dir)
         os.makedirs(template_dir)

--- a/operator-pipeline-images/tests/entrypoints/test_fbc_onboarding.py
+++ b/operator-pipeline-images/tests/entrypoints/test_fbc_onboarding.py
@@ -126,12 +126,6 @@ def test_create_catalog_template_dir_if_not_exists(
     fbc_onboarding.create_catalog_template_dir_if_not_exists(operator)
     mock_makedir.assert_called_once_with("/tmp/catalog-templates")
 
-    mock_makedir.reset_mock()
-    mock_exists.return_value = True
-    mock_input.return_value = "n"
-    with pytest.raises(SystemExit):
-        fbc_onboarding.create_catalog_template_dir_if_not_exists(operator)
-
 
 @patch("operatorcert.entrypoints.fbc_onboarding.get_base_template_from_catalog")
 @patch("operatorcert.entrypoints.fbc_onboarding.yaml.safe_dump")


### PR DESCRIPTION
To minimize a need of installing dependencies the fbc-onboarding target in the Makefile uses podman to run a container instead of running Python scripts on the system.

JIRA: ISV-5229