### PR TITLE
Fix integration tests failing on fbc catalog changes

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -401,8 +401,6 @@ spec:
           value: "$(params.pipeline_image)"
         - name: operator_path
           value: "$(tasks.detect-changes.results.operator_path)"
-        - name: catalog_operator_path
-          value: "$(tasks.detect-changes.results.affected_catalog_operators)"
       workspaces:
         - name: source
           workspace: repository
@@ -529,8 +527,6 @@ spec:
           value: "$(params.pipeline_image)"
         - name: operator_path
           value: "$(tasks.detect-changes.results.operator_path)"
-        - name: catalog_operator_path
-          value: "$(tasks.detect-changes.results.affected_catalog_operators)"
         - name: cert_project_required
           value: "$(params.cert_project_required)"
       workspaces:

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -226,8 +226,6 @@ spec:
           value: "$(params.pipeline_image)"
         - name: operator_path
           value: "$(tasks.detect-changes.results.operator_path)"
-        - name: catalog_operator_path
-          value: "$(tasks.detect-changes.results.affected_catalog_operators)"
       workspaces:
         - name: source
           workspace: repository
@@ -281,8 +279,6 @@ spec:
           value: "$(params.pipeline_image)"
         - name: operator_path
           value: "$(tasks.detect-changes.results.operator_path)"
-        - name: catalog_operator_path
-          value: "$(tasks.detect-changes.results.affected_catalog_operators)"
         - name: cert_project_required
           value: "$(params.cert_project_required)"
       workspaces:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/cert-project-check.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/cert-project-check.yml
@@ -8,8 +8,6 @@ spec:
     - name: pipeline_image
     - name: operator_path
       description: path indicating the location of the certified operator within the repository
-    - name: catalog_operator_path
-      description: path indicating the location of the catalog operator within the repository
       default: ""
     - name: cert_project_required
       description: A flag determines whether a cert project ID needs to be present
@@ -35,11 +33,7 @@ spec:
         fi
         if [ "$(params.operator_path)" != "" ]; then
           PKG_PATH="$(params.operator_path)"
-        elif [ "$(params.catalog_operator_path)" != "" ]; then
-          OPERATOR_NAME=$(echo $(params.catalog_operator_path) | cut -d ',' -f 1 | cut -d '/' -f 2)
-          PKG_PATH=operators/$OPERATOR_NAME
-        else
-          echo "Bundle path is missing."
+          echo "Operator path is missing."
           exit 1
         fi
 

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/read-config.yaml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/read-config.yaml
@@ -14,10 +14,6 @@ spec:
       description: |
         Path to an operator within the git repository where the config is expected.
 
-    - name: catalog_operator_path
-      description: path indicating the location of the catalog operator within the repository
-      default: ""
-
   results:
     - name: upgrade-graph-mode
       description: "A graph update mode that defines how channel graphs are updated"
@@ -38,11 +34,8 @@ spec:
 
         if [ "$(params.operator_path)" != "" ]; then
           PKG_PATH="$(params.operator_path)"
-        elif [ "$(params.catalog_operator_path)" != "" ]; then
-          OPERATOR_NAME=$(echo $(params.catalog_operator_path) | cut -d ',' -f 1 | cut -d '/' -f 2)
-          PKG_PATH=operators/$OPERATOR_NAME
         else
-          echo "Bundle path is missing."
+          echo "Operator path is missing."
           exit 1
         fi
 

--- a/operator-pipeline-images/operatorcert/parsed_file.py
+++ b/operator-pipeline-images/operatorcert/parsed_file.py
@@ -187,15 +187,24 @@ class ParserResults:
         Args:
             result: Dictionary with the detected changes
         """
-        if len(added_bundles := result.get("added_bundles", [])) == 1:
-            operator_name, bundle_version = added_bundles[0].split("/")
-        elif len(affected_operators := result.get("affected_operators", [])) == 1:
-            # no bundle was added (i.e.: only ci.yaml was added/modified/deleted)
+
+        operator_name = ""
+        bundle_version = ""
+
+        affected_operators = result.get("affected_operators", [])
+        affected_bundles = result.get("affected_bundles", [])
+        affected_catalog_operators = result.get("affected_catalog_operators", [])
+
+        if affected_operators:
             operator_name = affected_operators[0]
-            bundle_version = ""
-        else:
-            operator_name = ""
-            bundle_version = ""
+
+        if affected_bundles:
+            _, bundle_version = affected_bundles[0].split("/")
+
+        if affected_catalog_operators and operator_name == "":
+            # Even if the change affects only files in catalogs/ we still need to know
+            # what operator is affected by the change when accessing info in the operator's ci.yaml
+            operator_name = affected_catalog_operators[0][1]
 
         result["operator_name"] = operator_name
         result["bundle_version"] = bundle_version

--- a/operator-pipeline-images/tests/entrypoints/test_detect_changed_operators.py
+++ b/operator-pipeline-images/tests/entrypoints/test_detect_changed_operators.py
@@ -732,11 +732,11 @@ def test_ParserRules_validate_removal_fbc_fail(
     [
         pytest.param(
             {
-                "added_bundles": ["operator-e2e/0.0.101"],
+                "affected_bundles": ["operator-e2e/0.0.101"],
                 "affected_operators": ["operator-e2e"],
             },
             {
-                "added_bundles": ["operator-e2e/0.0.101"],
+                "affected_bundles": ["operator-e2e/0.0.101"],
                 "affected_operators": ["operator-e2e"],
                 "operator_name": "operator-e2e",
                 "bundle_version": "0.0.101",
@@ -747,11 +747,11 @@ def test_ParserRules_validate_removal_fbc_fail(
         ),
         pytest.param(
             {
-                "added_bundles": [],
+                "affected_bundles": [],
                 "affected_operators": ["operator-e2e"],
             },
             {
-                "added_bundles": [],
+                "affected_bundles": [],
                 "affected_operators": ["operator-e2e"],
                 "operator_name": "operator-e2e",
                 "bundle_version": "",
@@ -762,11 +762,11 @@ def test_ParserRules_validate_removal_fbc_fail(
         ),
         pytest.param(
             {
-                "added_bundles": [],
+                "affected_bundles": [],
                 "affected_operators": [],
             },
             {
-                "added_bundles": [],
+                "affected_bundles": [],
                 "affected_operators": [],
                 "operator_name": "",
                 "bundle_version": "",
@@ -774,6 +774,23 @@ def test_ParserRules_validate_removal_fbc_fail(
                 "bundle_path": "",
             },
             id="No bundle added or operator affected",
+        ),
+        pytest.param(
+            {
+                "affected_bundles": [],
+                "affected_operators": [],
+                "affected_catalog_operators": [("v4.16", "operator-e2e")],
+            },
+            {
+                "affected_bundles": [],
+                "affected_operators": [],
+                "affected_catalog_operators": [("v4.16", "operator-e2e")],
+                "operator_name": "operator-e2e",
+                "bundle_version": "",
+                "operator_path": "operators/operator-e2e",
+                "bundle_path": "",
+            },
+            id="Catalog operator affected",
         ),
     ],
 )


### PR DESCRIPTION
After merging #721 the integration test for the FBC catalog changes started to fail because those changes are not being auto-merged anymore due to the fact that operator_path is not set.

With this change, operator_name and operator_path are always set to point to the operator being updated, no matter what kind of change is being performed.

For PRs that do not affect any operator, bundle or catalog, operator_name and operator_path will remain empty, preventing automatic merges, which is still the right behaviour in that context.