### PR TITLE
Fix cert-project-check and release pipeline

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-index.yml
@@ -71,17 +71,17 @@ spec:
 
         ENV=$(params.environment)
         INDEX_IMAGES="$(params.index_images)"
+        if [[ $ENV != "prod" ]]; then
+            # Replace registry urls with stage urls when in preprod
+            INDEX_IMAGES=${INDEX_IMAGES//registry.redhat.io/registry.stage.redhat.io}
+        fi
+
         if [[ $ENV == "dev" || $ENV == "qa" ]]; then
             echo "Adding bundle to an index is a NOOP for dev and qa environments at this time."
             echo -n "success" | tee "$(results.status.path)"
             # output dummy/test values for following tasks
-            echo -n "$(params.bundle_pullspec)" | tee "$(workspaces.output.path)/index-image-paths.txt"
+            echo -n "placeholder" | tee "$(workspaces.output.path)/index-image-paths.txt"
             exit 0
-        fi
-
-        if [[ $ENV != "prod" ]]; then
-            # Replace registry urls with stage urls when in preprod
-            INDEX_IMAGES=${INDEX_IMAGES//registry.redhat.io/registry.stage.redhat.io}
         fi
 
         EXTRA_ARGS=""

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/build-fbc-index-images.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/build-fbc-index-images.yml
@@ -75,14 +75,16 @@ spec:
 
         ENV=$(params.environment)
         INDEX_IMAGES="$(params.index_images)"
-        if [[ $ENV == "dev" || $ENV == "qa" ]]; then
-            echo "Adding FBC fragment to an index is a NOOP for dev and qa environments at this time."
-            exit 0
-        fi
-
         if [[ $ENV != "prod" ]]; then
             # Replace registry urls with stage urls when in preprod
             INDEX_IMAGES=${INDEX_IMAGES//registry.redhat.io/registry.stage.redhat.io}
+        fi
+
+        if [[ $ENV == "dev" || $ENV == "qa" ]]; then
+            echo "Adding FBC fragment to an index is a NOOP for dev and qa environments at this time."
+            # output dummy/test values for following tasks
+            echo -n "placeholder" | tee "$(workspaces.output.path)/fbc-index-image-paths.txt"
+            exit 0
         fi
 
         add-fbc-fragments-to-index \
@@ -117,14 +119,16 @@ spec:
 
         ENV=$(params.environment)
         INDEX_IMAGES="$(params.index_images)"
-        if [[ $ENV == "dev" || $ENV == "qa" ]]; then
-            echo "Adding FBC fragment to an index is a NOOP for dev and qa environments at this time."
-            exit 0
-        fi
-
         if [[ $ENV != "prod" ]]; then
             # Replace registry urls with stage urls when in preprod
             INDEX_IMAGES=${INDEX_IMAGES//registry.redhat.io/registry.stage.redhat.io}
+        fi
+
+        if [[ $ENV == "dev" || $ENV == "qa" ]]; then
+            echo "Adding FBC fragment to an index is a NOOP for dev and qa environments at this time."
+            # output dummy/test values for following tasks
+            echo -n "placeholder" | tee "$(workspaces.output.path)/fbc-index-image-paths.txt"
+            exit 0
         fi
 
         rm-operator-from-index  \

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/cert-project-check.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/cert-project-check.yml
@@ -31,13 +31,13 @@ spec:
           echo -n "" | tee $(results.certification_project_id.path)
           exit 0
         fi
-        if [ "$(params.operator_path)" != "" ]; then
-          PKG_PATH="$(params.operator_path)"
+
+        if [ -z "$(params.operator_path)" ]; then
           echo "Operator path is missing."
           exit 1
         fi
 
-        CI_FILE_PATH="$PKG_PATH/ci.yaml"
+        CI_FILE_PATH="$(params.operator_path)/ci.yaml"
 
         CERT_PROJECT_ID=$(cat $CI_FILE_PATH | yq -r '.cert_project_id | select (.!=null)')
 

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/get-manifest-digests.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/get-manifest-digests.yml
@@ -31,7 +31,7 @@ spec:
         # output dummy/test values for signing purposes
         if [[ $ENV == "dev" || $ENV == "qa" ]]; then
           echo -n "registry.redhat.io/redhat/test-operator-index:v4.9" | tee "$(results.docker_references.path)"
-          echo "$(params.index_image_paths)" | awk -F '+' '{print $2}' | tee "$(results.manifest_digests.path)"
+          echo "" | tee "$(results.manifest_digests.path)"
           echo "Getting manifest digests is a NOOP for dev and qa environments at this time."
           exit 0
         fi


### PR DESCRIPTION
An `else` condition in cert-project-check was removed by mistake in #727: the check is now fixed.

Also fixed a failure in the release pipeline when the PR only affects catalogs of an FBC-enabled operator.