### PR TITLE
updating fbc validate cmd to iterate over catalogs

### DIFF
--- a/fbc/Makefile
+++ b/fbc/Makefile
@@ -97,7 +97,9 @@ semver: ${BINDIR}/opm clean
 # all FBC must pass opm validation in order to be able to be used in a catalog
 .PHONY: validate-catalogs
 validate-catalogs: ${BINDIR}/opm
-	${BINDIR}/opm validate $(CATALOG_DIR) && echo "catalog validation passed" || echo "catalog validation failed"
+	for version in $(OCP_VERSIONS); do \
+		${BINDIR}/opm validate $(CATALOG_DIR)/$${version}/${OPERATOR_NAME} && echo "$${version} catalog validation passed" || echo "$${version} catalog validation failed"; \
+	done
 
 .PHONY: create-catalog-dir
 create-catalog-dir:


### PR DESCRIPTION
- Updating the `validate-catalogs` to iterate over a list of catalogs, and only check one specific operator, instead of all operator catalogs, which was causing errors.

Previous code threw this error
```
 make validate-catalogs 
/home/acornett/go/src/github.com/acornett21/certified-operators/bin/opm validate /home/acornett/go/src/github.com/acornett21/certified-operators/catalogs && echo "catalog validation passed" || echo "catalog validation failed"
FATA[0000] duplicate package "operator-certification-operator" 
catalog validation failed
```

New code execution looks like this
```
 make validate-catalogs 
for version in v4.12 v4.13 v4.14 v4.15 v4.16 v4.17; do \
        /home/acornett/go/src/github.com/acornett21/certified-operators/bin/opm validate /home/acornett/go/src/github.com/acornett21/certified-operators/catalogs/${version}/couchbase-enterprise-certified && echo "${version} catalog validation passed" || echo "catalog validation failed"; \
done
v4.12 catalog validation passed
v4.13 catalog validation passed
v4.14 catalog validation passed
v4.15 catalog validation passed
v4.16 catalog validation passed
v4.17 catalog validation passed
```