### PR TITLE
Wait for pipeline run in integration tests

### DIFF
--- a/ansible/roles/integration_tests/files/wait_for_pipelinerun.sh
+++ b/ansible/roles/integration_tests/files/wait_for_pipelinerun.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+PIPELINE_RUN_NAME=$1
+NAMESPACE=$2
+
+if [ -z "$PIPELINE_RUN_NAME" ] || [ -z "$NAMESPACE" ]; then
+echo "Usage: $0 <pipeline-run-name> <namespace>"
+exit 1
+fi
+
+get_pipeline_status() {
+    oc get pipelinerun "$PIPELINE_RUN_NAME" -n "$NAMESPACE" -o json | jq -r '.status.conditions[] | select(.type=="Succeeded") | .status'
+}
+
+while true; do
+    STATUS=$(get_pipeline_status)
+
+    if [ "$STATUS" == "True" ]; then
+        echo "PipelineRun $PIPELINE_RUN_NAME succeeded."
+        exit 0
+    elif [ "$STATUS" == "False" ]; then
+        echo "PipelineRun $PIPELINE_RUN_NAME failed."
+        exit 1
+    else
+        echo "PipelineRun $PIPELINE_RUN_NAME is still running..."
+    fi
+    sleep 20
+done

--- a/ansible/roles/integration_tests/tasks/check_pipeline_run.yml
+++ b/ansible/roles/integration_tests/tasks/check_pipeline_run.yml
@@ -13,7 +13,7 @@
           - "suffix={{ suffix }}"
       register: pipeline_run
       until: pipeline_run.resources | length > 0
-      retries: 5
+      retries: 10
       delay: 5
       failed_when: pipeline_run.resources | length == 0
 
@@ -21,25 +21,35 @@
       ansible.builtin.debug:
         var: pipeline_run.resources[0].metadata.name
 
+    - name: "Wait for the run of {{ pipeline_name }}"
+      ansible.builtin.shell: |
+        ./wait_for_pipelinerun.sh \
+          {{ pipeline_run.resources[0].metadata.name }} \
+          {{ oc_namespace }}
+      args:
+        executable: /bin/bash
+        chdir: "{{ temp_tools_dir.path }}"
+      register: pipeline_run_wait
+      failed_when: false
+      timeout: 5400  # 90 minutes
+      changed_when: false
 
-    - name: "Follow the run logs of {{ pipeline_name }}"
+    - name: "Get pipelinerun logs - {{ pipeline_name }}"
       ansible.builtin.shell: |
         ./tkn pipeline logs \
           {{ pipeline_name }} \
           {{ pipeline_run.resources[0].metadata.name }} \
-          --namespace {{ oc_namespace }} \
-          --follow
+          --namespace {{ oc_namespace }}
       args:
         executable: /bin/bash
         chdir: "{{ temp_tools_dir.path }}"
-      register: pipeline_run_log
-      retries: 5
-      until: pipeline_run_log.rc == 0
+      no_log: true
+      register: pipeline_run_logs
       changed_when: false
 
-    - name: Output the run logs of {{ pipeline_name }}
+    - name: "Print pipelinerun logs - {{ pipeline_name }}"
       ansible.builtin.debug:
-        msg: "{{ pipeline_run_log.stdout_lines }}"
+        var: pipeline_run_logs.stdout_lines
 
     - name: Verify successful run of {{ pipeline_name }}
       kubernetes.core.k8s_info:

--- a/ansible/roles/integration_tests/tasks/tools.yml
+++ b/ansible/roles/integration_tests/tasks/tools.yml
@@ -23,3 +23,12 @@
         remote_src: true
         include:
           - opm
+
+    - name: Copy a local scripts to the host
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: "{{ temp_tools_dir.path }}"
+        mode: a+x
+
+      with_items:
+        - "files/wait_for_pipelinerun.sh"


### PR DESCRIPTION
A new step in integration step is added to wait for pipeline to finish. Previously this was handled by the tekton cmd which was not reliable and often got stuck.

JIRA: ISV-5237