### PR TITLE
Update build signing bundle action

### DIFF
--- a/.github/workflows/build-signing-bundle.yml
+++ b/.github/workflows/build-signing-bundle.yml
@@ -4,7 +4,7 @@ name: Build signing bundle
 on:  # yamllint disable-line rule:truthy
   workflow_run:
     workflows:
-      - validation
+      - Build and test
     branches:
       - main
     types:


### PR DESCRIPTION
The action now depends on a new build and validation step. The previous validation action was removed recently.