### PR TITLE
update preflight sha for 1.10.1 release

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:e4707e5f3a61c737c9b5f04d2ebe45675fde2d1c72b65df9152e8a053acd6c61
+      default: quay.io/redhat-isv/preflight-test@sha256:9bbe458f4a141a26e7267758af13b114119e396f98f20e53cc03c521d4c75661
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
```
❯ crane digest quay.io/opdev/preflight:1.10.0
sha256:e4707e5f3a61c737c9b5f04d2ebe45675fde2d1c72b65df9152e8a053acd6c61

~ 
❯ crane digest quay.io/opdev/preflight:1.10.1
sha256:9bbe458f4a141a26e7267758af13b114119e396f98f20e53cc03c521d4c75661
```