### PR TITLE
Add --retry-times to a skopeo commands

### DIFF
--- a/ansible/roles/index_signature_verification/files/tasks/verify-index-signatures.yml
+++ b/ansible/roles/index_signature_verification/files/tasks/verify-index-signatures.yml
@@ -73,7 +73,7 @@ spec:
         for image in $(cat image-tags.txt); do
           dest=$(echo -n $image | base64)
           echo "Inspecting $image"
-          skopeo inspect --raw docker://$image > $dest.json
+          skopeo inspect --retry-times 5 --raw docker://$image > $dest.json
         done
 
     - name: get-digest-pull-specs

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/copy-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/copy-image.yml
@@ -58,6 +58,7 @@ spec:
         CONNECT_REPO_PATH="$(params.connect_registry)/$(params.vendor_label)/$(params.repo_name)"
 
         skopeo copy \
+          --retry-times 5 \
           --src-authfile $SRC_AUTHFILE \
           --dest-authfile $DEST_AUTHFILE \
           docker://$(params.src_image) \
@@ -65,12 +66,13 @@ spec:
 
 
         skopeo copy \
+          --retry-times 5 \
           --src-authfile $SRC_AUTHFILE \
           --dest-authfile $DEST_AUTHFILE \
           docker://$(params.src_image) \
           docker://"$(params.dest_image_registry_namespace_certproject):latest"
 
-        DIGEST=$(skopeo inspect --authfile $DEST_AUTHFILE docker://$(params.dest_image_registry_namespace_certproject):$(params.dest_image_tag) | jq -r .Digest)
+        DIGEST=$(skopeo inspect --retry-times 5 --authfile $DEST_AUTHFILE docker://$(params.dest_image_registry_namespace_certproject):$(params.dest_image_tag) | jq -r .Digest)
         echo -n $DIGEST | tee $(results.container_digest.path)
         echo "- $CONNECT_REPO_PATH:$(params.dest_image_tag)" | tee "$RELEASE_INFO_DIR_PATH/released_bundle.txt"
         echo -n "$CONNECT_REPO_PATH@${DIGEST}" > $(results.image_pullspec.path)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/get-manifest-digests.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/get-manifest-digests.yml
@@ -46,7 +46,7 @@ spec:
 
             DIGEST=$(echo $i | awk -F '+' '{print $2}')
 
-            MANIFEST_LIST=$(skopeo inspect --raw docker://$DIGEST)
+            MANIFEST_LIST=$(skopeo inspect --retry-times 5 --raw docker://$DIGEST)
             MANIFEST_LIST=$(echo $MANIFEST_LIST | jq -r '.manifests[].digest')
 
             # create comma separated index images that match each digest

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-pyxis-data.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-pyxis-data.yml
@@ -77,6 +77,7 @@ spec:
         IMAGE_PULL_SPEC="$(params.internal_registry)/$(params.internal_repository)@$(params.container_digest)"
 
         skopeo inspect \
+          --retry-times 5 \
           --no-tags \
           --authfile $(workspaces.registry-credentials.path)/.dockerconfigjson \
           docker://$IMAGE_PULL_SPEC > $(workspaces.image-data.path)/skopeo-inspect.json

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-index.yml
@@ -122,6 +122,7 @@ spec:
           # Add version tag to an index
           skopeo \
             --command-timeout 300s copy \
+            --retry-times 5 \
             --format v2s2 --all \
             --src-no-creds \
             --dest-creds $QUAY_USER:$QUAY_TOKEN \
@@ -131,6 +132,7 @@ spec:
           # Add permanent tag to an index
           skopeo \
             --command-timeout 300s copy \
+            --retry-times 5 \
             --format v2s2 --all \
             --src-no-creds \
             --dest-creds $QUAY_USER:$QUAY_TOKEN \

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/tag-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/tag-image.yml
@@ -28,6 +28,7 @@ spec:
 
         for tag in "${TAGS[@]}" ; do
             skopeo copy \
+              --retry-times 5 \
               --authfile "${AUTHFILE}" \
               "docker://${REF}" \
               "docker://${UNTAGGED_REF}:${tag}"

--- a/operator-pipeline-images/operatorcert/utils.py
+++ b/operator-pipeline-images/operatorcert/utils.py
@@ -216,6 +216,8 @@ def copy_images_to_destination(
         cmd = [
             "skopeo",
             "copy",
+            "--retry-times",
+            "5",
             f"docker://{response.get('index_image_resolved')}",
             f"docker://{destination}:{version}{tag_suffix}",
         ]

--- a/operator-pipeline-images/tests/test_utils.py
+++ b/operator-pipeline-images/tests/test_utils.py
@@ -160,6 +160,8 @@ def test_copy_images_to_destination(mock_subprocess: MagicMock) -> None:
         [
             "skopeo",
             "copy",
+            "--retry-times",
+            "5",
             "docker://quay.io/qwe/asd@sha256:1234",
             "docker://quay.io/foo/bar:v4.12-foo",
             "--authfile",

--- a/scripts/community-quay-migration.py
+++ b/scripts/community-quay-migration.py
@@ -278,6 +278,8 @@ def copy_tag(
     cmd = [
         "skopeo",
         "copy",
+        "--retry-times",
+        "5",
         f"docker://{QUAY_HOST}/{src_namespace}/{src_repo}:{src_tag}",
         f"docker://{QUAY_HOST}/{dest_namespace}/{dest_repo}:{dest_tag}",
         "--all",


### PR DESCRIPTION
Sometimes a registry returns an invalid code that causes a whole pipeline to fail. Adding this flag should fix majority of these temporary failures.

JIRA: ISV-4789