### PR TITLE
[ISV-5374] Add check to suggest FBC for non-FBC operators

### DIFF
--- a/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
+++ b/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
@@ -444,14 +444,19 @@ def check_replaces_availability(bundle: Bundle) -> Iterator[CheckResult]:
 
 
 NON_FBC_SUGGESTION = (
-    "This operator does not use File Based Catalog (FBC). "
-    "Consider migrating to FBC for better maintainability: "
-    "https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_onboarding/"
+    "[File Based Catalog (FBC)]"
+    "(https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/5031#discussion-7097441) "
+    "is a new way to manage operator metadata. "
+    "This operator does not use FBC. Consider [migrating]"
+    "(https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_onboarding/) "
+    "for better maintainability."
 )
 NON_FBC_WARNING = (
-    "This operator does not use File Based Catalog (FBC). "
-    "It is recommended for new operators to start directly with FBC: "
-    "https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_workflow/ "
+    "[File Based Catalog (FBC)]"
+    "(https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/5031#discussion-7097441) "
+    "is a new way to manage operator metadata. "
+    "This operator does not use FBC and it is recommended for new operators to [start directly with FBC]"
+    "(https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_workflow/). "
     "The use of FBC will be mandatory for new operators from February 2025."
 )
 

--- a/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
+++ b/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
@@ -445,7 +445,8 @@ def check_replaces_availability(bundle: Bundle) -> Iterator[CheckResult]:
 
 NON_FBC_SUGGESTION = (
     "[File Based Catalog (FBC)]"
-    "(https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/5031#discussion-7097441) "
+    "(https://github.com/redhat-openshift-ecosystem/community-operators-prod/"
+    "discussions/5031#discussion-7097441) "
     "is a new way to manage operator metadata. "
     "This operator does not use FBC. Consider [migrating]"
     "(https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_onboarding/) "
@@ -453,9 +454,11 @@ NON_FBC_SUGGESTION = (
 )
 NON_FBC_WARNING = (
     "[File Based Catalog (FBC)]"
-    "(https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/5031#discussion-7097441) "
+    "(https://github.com/redhat-openshift-ecosystem/community-operators-prod/"
+    "discussions/5031#discussion-7097441) "
     "is a new way to manage operator metadata. "
-    "This operator does not use FBC and it is recommended for new operators to [start directly with FBC]"
+    "This operator does not use FBC and it is recommended for new operators to "
+    "[start directly with FBC]"
     "(https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_workflow/). "
     "The use of FBC will be mandatory for new operators from February 2025."
 )

--- a/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
+++ b/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
@@ -441,3 +441,36 @@ def check_replaces_availability(bundle: Bundle) -> Iterator[CheckResult]:
         f"`{replaces_bundle}` - `{replaces_ocp_version_str}`"
     )
     yield from []
+
+
+NON_FBC_SUGGESTION = (
+    "This operator does not use File Based Catalog (FBC). "
+    "Consider migrating to FBC for better maintainability: "
+    "https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_onboarding/"
+)
+NON_FBC_WARNING = (
+    "This operator does not use File Based Catalog (FBC). "
+    "It is recommended for new operators to start directly with FBC: "
+    "https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_workflow/ "
+    "The use of FBC will be mandatory for new operators from February 2025."
+)
+
+
+@skip_fbc
+def check_using_fbc(bundle: Bundle) -> Iterator[CheckResult]:
+    """
+    This check is used only for non-FBC bundles and suggests
+    using the File Based Catalog for new Operators
+    or recommends migrating existing Operators to FBC.
+
+    Args:
+        bundle (Bundle): Tested operator bundle
+    """
+    all_bundles = set(bundle.operator.all_bundles())
+    other_bundles = all_bundles - {bundle}
+    if other_bundles:
+        # not a first bundle, existing operator
+        yield Warn(NON_FBC_SUGGESTION)
+    else:
+        # TODO: change to Fail when FBC mandatory for new operators
+        yield Warn(NON_FBC_WARNING)

--- a/operator-pipeline-images/tests/static_tests/community/test_bundle.py
+++ b/operator-pipeline-images/tests/static_tests/community/test_bundle.py
@@ -684,7 +684,7 @@ def test_check_replaces_availability(
                 bundle_files("hello", "0.0.1"),
             ],
             ("hello", "0.0.1"),
-            "It is recommended for new operators to start directly with FBC",
+            "is recommended for new operators",
             id="New bundle warning",
         ),
         pytest.param(
@@ -693,7 +693,7 @@ def test_check_replaces_availability(
                 bundle_files("hello", "0.0.2"),
             ],
             ("hello", "0.0.2"),
-            "Consider migrating to FBC for better maintainability",
+            "This operator does not use FBC. Consider",
             id="Updating existing operator",
         ),
     ],

--- a/pdm.lock
+++ b/pdm.lock
@@ -533,13 +533,13 @@ files = [
 
 [[package]]
 name = "filelock"
-version = "3.16.0"
+version = "3.16.1"
 requires_python = ">=3.8"
 summary = "A platform independent file lock."
 groups = ["tox"]
 files = [
-    {file = "filelock-3.16.0-py3-none-any.whl", hash = "sha256:f6ed4c963184f4c84dd5557ce8fece759a3724b37b80c6c4f20a2f63a4dc6609"},
-    {file = "filelock-3.16.0.tar.gz", hash = "sha256:81de9eb8453c769b63369f87f11131a7ab04e367f8d97ad39dc230daa07e3bec"},
+    {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
+    {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
 ]
 
 [[package]]
@@ -864,13 +864,13 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.3.2"
+version = "4.3.6"
 requires_python = ">=3.8"
 summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 groups = ["operatorcert-dev", "tox"]
 files = [
-    {file = "platformdirs-4.3.2-py3-none-any.whl", hash = "sha256:eb1c8582560b34ed4ba105009a4badf7f6f85768b30126f351328507b2beb617"},
-    {file = "platformdirs-4.3.2.tar.gz", hash = "sha256:9e5e27a08aa095dd127b9f2e764d74254f482fef22b0970773bfba79d091ab8c"},
+    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
+    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ files = [
 
 [[package]]
 name = "pyproject-api"
-version = "1.7.1"
+version = "1.8.0"
 requires_python = ">=3.8"
 summary = "API to interact with the python pyproject.toml based projects"
 groups = ["tox"]
@@ -1093,8 +1093,8 @@ dependencies = [
     "tomli>=2.0.1; python_version < \"3.11\"",
 ]
 files = [
-    {file = "pyproject_api-1.7.1-py3-none-any.whl", hash = "sha256:2dc1654062c2b27733d8fd4cdda672b22fe8741ef1dde8e3a998a9547b071eeb"},
-    {file = "pyproject_api-1.7.1.tar.gz", hash = "sha256:7ebc6cd10710f89f4cf2a2731710a98abce37ebff19427116ff2174c9236a827"},
+    {file = "pyproject_api-1.8.0-py3-none-any.whl", hash = "sha256:3d7d347a047afe796fd5d1885b1e391ba29be7169bd2f102fcd378f04273d228"},
+    {file = "pyproject_api-1.8.0.tar.gz", hash = "sha256:77b8049f2feb5d33eefcc21b57f1e279636277a8ac8ad6b5871037b243778496"},
 ]
 
 [[package]]
@@ -1530,7 +1530,7 @@ files = [
 
 [[package]]
 name = "tox"
-version = "4.18.1"
+version = "4.23.2"
 requires_python = ">=3.8"
 summary = "tox is a generic virtualenv management and test command line tool"
 groups = ["tox"]
@@ -1538,17 +1538,18 @@ dependencies = [
     "cachetools>=5.5",
     "chardet>=5.2",
     "colorama>=0.4.6",
-    "filelock>=3.15.4",
+    "filelock>=3.16.1",
     "packaging>=24.1",
-    "platformdirs>=4.2.2",
+    "platformdirs>=4.3.6",
     "pluggy>=1.5",
-    "pyproject-api>=1.7.1",
+    "pyproject-api>=1.8",
     "tomli>=2.0.1; python_version < \"3.11\"",
-    "virtualenv>=20.26.3",
+    "typing-extensions>=4.12.2; python_version < \"3.11\"",
+    "virtualenv>=20.26.6",
 ]
 files = [
-    {file = "tox-4.18.1-py3-none-any.whl", hash = "sha256:35d472032ee1f73fe20c3e0e73d7073a4e85075c86ff02c576f9fc7c6a15a578"},
-    {file = "tox-4.18.1.tar.gz", hash = "sha256:3c0c96bc3a568a5c7e66387a4cfcf8c875b52e09f4d47c9f7a277ec82f1a0b11"},
+    {file = "tox-4.23.2-py3-none-any.whl", hash = "sha256:452bc32bb031f2282881a2118923176445bac783ab97c874b8770ab4c3b76c38"},
+    {file = "tox-4.23.2.tar.gz", hash = "sha256:86075e00e555df6e82e74cfc333917f91ecb47ffbc868dcafbd2672e332f4a2c"},
 ]
 
 [[package]]
@@ -1624,7 +1625,7 @@ name = "typing-extensions"
 version = "4.12.2"
 requires_python = ">=3.8"
 summary = "Backported and Experimental Type Hints for Python 3.8+"
-groups = ["operatorcert-dev"]
+groups = ["operatorcert-dev", "tox"]
 files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
@@ -1643,8 +1644,8 @@ files = [
 
 [[package]]
 name = "virtualenv"
-version = "20.26.4"
-requires_python = ">=3.7"
+version = "20.27.1"
+requires_python = ">=3.8"
 summary = "Virtual Python Environment builder"
 groups = ["tox"]
 dependencies = [
@@ -1654,8 +1655,8 @@ dependencies = [
     "platformdirs<5,>=3.9.1",
 ]
 files = [
-    {file = "virtualenv-20.26.4-py3-none-any.whl", hash = "sha256:48f2695d9809277003f30776d155615ffc11328e6a0a8c1f0ec80188d7874a55"},
-    {file = "virtualenv-20.26.4.tar.gz", hash = "sha256:c17f4e0f3e6036e9f26700446f85c76ab11df65ff6d8a9cbfad9f71aabfcf23c"},
+    {file = "virtualenv-20.27.1-py3-none-any.whl", hash = "sha256:f11f1b8a29525562925f745563bfd48b189450f61fb34c4f9cc79dd5aa32a1f4"},
+    {file = "virtualenv-20.27.1.tar.gz", hash = "sha256:142c6be10212543b32c6c45d3d3893dff89112cc588b7d0879ae5a1ec03a47ba"},
 ]
 
 [[package]]


### PR DESCRIPTION
This PR is adding warning to the static check suite when bundle is added/updated. This check distinguish between new operator (first bundle) and already existing.

Example warning can be found in [this PR stasic checks summary](https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/1987#issuecomment-2443618861).