### PR TITLE
[ISV-5341] fix broken link in the pipeline summary

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
@@ -128,7 +128,7 @@ spec:
 
         if [[ "$ORGANIZATION" == "community-operators" ]]
         then
-          DOC_LINK="https://redhat-openshift-ecosystem.github.io/community-operators-prod/"
+          DOC_LINK="https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/contributing-prerequisites/"
         else
           DOC_LINK="https://github.com/redhat-openshift-ecosystem/certification-releases/blob/main/4.9/ga/troubleshooting.md"
         fi


### PR DESCRIPTION
This PR fixes the link in operator pipelines repo. Link redirects users to the 1st point of our documentation, from which they can move on to how the bundle should be created. Seemed to me like a good start since we do not have similar troubleshooting guide as we have for certified/marketplace operators. 
Actual point of reference is then updated in the PR template in 2nd [PR](https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/5557) that also fixes non-existent links in community-pipeline-prod repo.

---
Closes [ISV-5341](https://issues.redhat.com/browse/ISV-5341)
