### PR TITLE
[ISV-5446] static check for catalog bundle images

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -664,6 +664,8 @@ spec:
           value: "$(tasks.detect-changes.results.added_operator)"
         - name: bundle_version
           value: "$(tasks.detect-changes.results.added_bundle)"
+        - name: affected_catalog_operators
+          value: "$(tasks.detect-changes.results.affected_catalog_operators)"
         - name: github_token_secret_name
           value: "$(params.github_token_secret_name)"
         - name: github_token_secret_key

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/parse-repo-changes.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/parse-repo-changes.yml
@@ -36,7 +36,7 @@ spec:
       description: Comma separated list of catalogs with added or modified operator
     - name: affected_catalog_operators
       description: |
-        Comma separated list of operators added/updater/deleted inside
+        Comma separated list of operators added/updated/deleted inside
         a catalogs directory structure
     - name: deleted_catalog_operators
       description: |

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/run-static-tests.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/run-static-tests.yml
@@ -19,6 +19,9 @@ spec:
     - name: bundle_version
       description: Version of the bundle under test.
 
+    - name: affected_catalog_operators
+      description: All catalog operators affected with the change.
+
     - name: github_token_secret_key
       description: The key within the Kubernetes Secret that contains the GitHub token.
       default: token
@@ -60,8 +63,8 @@ spec:
         #!/usr/bin/env bash
         set -xe
 
-        if [ -z "$(params.bundle_path)" ]; then
-          echo "No bundle added or changed, skipping tests"
+        if [ -z "$(params.bundle_path)" ] && [ -z "$(params.affected_catalog_operators)" ]; then
+          echo "No bundle or catalog added/changed, skipping tests"
           echo -n "" | tee $(results.messages_count.path)
           echo -n "" | tee $(results.failures_count.path)
           exit 0
@@ -86,7 +89,8 @@ spec:
           --output-file "$JSON_RESULTS_FILE" \
           --repo-path "$(workspaces.source.path)" \
           --suites "$(params.test_suites)" $EXTRA_ARGS \
-          "$(params.operator_name)" "$(params.bundle_version)"
+          "$(params.operator_name)" "$(params.bundle_version)" \
+          "$(params.affected_catalog_operators)"
 
         jq . <$JSON_RESULTS_FILE
         jq -r '(.outputs//[])|length' <$JSON_RESULTS_FILE \

--- a/operator-pipeline-images/Dockerfile
+++ b/operator-pipeline-images/Dockerfile
@@ -70,7 +70,7 @@ COPY ./operator-pipeline-images ./operator-pipeline-images
 RUN pip3 install --no-cache-dir pdm
 # install dependencies in virtual environment
 COPY ./pdm.lock ./pyproject.toml ./README.md ./
-RUN pdm venv create 3.12 && pdm install --no-lock --no-editable \
+RUN pdm venv create 3.12 && pdm install --frozen-lockfile --no-editable \
         --group operatorcert-dev
 
 ENV VIRTUAL_ENV=/home/user/.venv

--- a/operator-pipeline-images/operatorcert/entrypoints/static_tests.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/static_tests.py
@@ -5,7 +5,7 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
-from operator_repo import Repo
+from operator_repo import Repo, OperatorCatalogList
 from operator_repo.checks import Fail, run_suite
 from operatorcert.logger import setup_logger
 from operatorcert.utils import SplitArgs
@@ -49,19 +49,21 @@ def setup_argparser() -> argparse.ArgumentParser:
     parser.add_argument("--verbose", action="store_true", help="Verbose output")
     parser.add_argument("operator")
     parser.add_argument("bundle")
+    parser.add_argument("affected_catalogs")
 
     return parser
 
 
-def check_bundle(
+def execute_checks(  # pylint: disable=too-many-arguments
     repo_path: str,
     operator_name: str,
     bundle_version: str,
+    affected_catalogs: str,
     suite_names: List[str],
     skip_tests: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """
-    Run a check suite against the given bundle and return warnings and
+    Run a check suite against the given target and return warnings and
     failures in a format inspired by the operator-sdk bundle validate
     tool's JSON output format
 
@@ -69,6 +71,7 @@ def check_bundle(
         repo_path (str): path to the root of the operator repository
         operator_name (str): name of the operator
         bundle_version (str): version of the bundle to check
+        affected_catalogs (str): Coma separated list of affected catalogs
         suite_name (str): name of the suite to use
         skip_tests (Optional[List]): List of checks to skip
 
@@ -77,13 +80,25 @@ def check_bundle(
     """
     repo = Repo(repo_path)
     operator = repo.operator(operator_name)
-    bundle = operator.bundle(bundle_version)
+    bundle = operator.bundle(bundle_version) if bundle_version else None
+    catalogs = OperatorCatalogList(
+        [
+            catalog
+            for catalog in operator.all_operator_catalogs()
+            if catalog in affected_catalogs.split(",")
+        ]
+    )
 
     outputs = []
     passed = True
 
     for suite_name in suite_names:
-        for result in run_suite([bundle, operator], suite_name, skip_tests=skip_tests):
+        for result in run_suite(
+            # do only catalog checks if bundle is not provided
+            [bundle, operator] if bundle else [catalogs],
+            suite_name,
+            skip_tests=skip_tests,
+        ):
             if isinstance(result, Fail):
                 passed = False
             item = {
@@ -113,8 +128,13 @@ def main() -> None:
     setup_logger(level=log_level)
 
     # Logic
-    result = check_bundle(
-        args.repo_path, args.operator, args.bundle, args.suites, args.skip_tests
+    result = execute_checks(
+        args.repo_path,
+        args.operator,
+        args.bundle,
+        args.affected_catalogs,
+        args.suites,
+        args.skip_tests,
     )
 
     if args.output_file:

--- a/operator-pipeline-images/operatorcert/static_tests/common/catalog.py
+++ b/operator-pipeline-images/operatorcert/static_tests/common/catalog.py
@@ -1,0 +1,55 @@
+"""A common test suite for file based catalog"""
+
+from collections.abc import Iterator
+
+from operator_repo import OperatorCatalog, OperatorCatalogList
+from operator_repo.checks import CheckResult, Fail
+
+
+def _get_bundle_registries_from_catalog(catalog: OperatorCatalog) -> list[str]:
+    """Get bundle images from catalog"""
+    catalog_content = catalog.catalog_content
+    bundle_images = []
+    for item in catalog_content:
+        if isinstance(item, dict):
+            if item.get("schema") == "olm.bundle":
+                if image := item.get("image"):
+                    bundle_images.append(image)
+
+    return bundle_images
+
+
+def _filter_invalid_images(
+    bundle_images: list[str], allowed_registries: list[str]
+) -> list[str]:
+    """Filter out invalid images"""
+    invalid_images = []
+    for image in bundle_images:
+        if not any(image.startswith(registry) for registry in allowed_registries):
+            invalid_images.append(image)
+
+    return invalid_images
+
+
+def check_bundle_images_in_fbc(
+    operator_catalogs: OperatorCatalogList,
+) -> Iterator[CheckResult]:
+    """Validate if bundle image reference in fbc is in allowed registry"""
+
+    allowed_registries = None
+    for catalog in operator_catalogs:
+        if not isinstance(allowed_registries, list):
+            # get config only once
+            allowed_registries = catalog.repo.config.get(
+                "allowed_bundle_registries", []
+            )
+        if not allowed_registries:
+            # nothing to check if no registry restriction is defined
+            break
+        bundle_images = _get_bundle_registries_from_catalog(catalog)
+        invalid_images = _filter_invalid_images(bundle_images, allowed_registries)
+        if invalid_images:
+            yield Fail(
+                f"Invalid bundle image(s) found in {str(catalog)}: "
+                f"{', '.join(invalid_images)}"
+            )

--- a/operator-pipeline-images/tests/entrypoints/test_static_tests.py
+++ b/operator-pipeline-images/tests/entrypoints/test_static_tests.py
@@ -5,18 +5,20 @@ import pytest
 from operator_repo import Repo
 from operator_repo.checks import Fail, Warn
 from operatorcert.entrypoints import static_tests
-from tests.utils import bundle_files, create_files
+from tests.utils import bundle_files, catalog_files, create_files
 
 
 @pytest.mark.parametrize(
-    "check_results, expected",
+    "check_results, bundle, expected",
     [
         (
             [],
+            "0.0.1",
             {"passed": True, "outputs": []},
         ),
         (
             [Warn("foo")],
+            "0.0.1",
             {
                 "passed": True,
                 "outputs": [
@@ -26,6 +28,7 @@ from tests.utils import bundle_files, create_files
         ),
         (
             [Fail("bar", check="baz")],
+            "",
             {
                 "passed": False,
                 "outputs": [
@@ -40,6 +43,7 @@ from tests.utils import bundle_files, create_files
         ),
         (
             [Warn("foo"), Fail("bar")],
+            "0.0.1",
             {
                 "passed": False,
                 "outputs": [
@@ -58,40 +62,55 @@ from tests.utils import bundle_files, create_files
     ],
 )
 @patch("operatorcert.entrypoints.static_tests.run_suite")
-def test_check_bundle(
-    mock_run_suite: MagicMock, tmp_path: Any, check_results: Any, expected: Any
+def test_execute_checks(
+    mock_run_suite: MagicMock,
+    tmp_path: Any,
+    bundle: str,
+    check_results: Any,
+    expected: Any,
 ) -> None:
     operator_name = "test-operator"
-    bundle_version = "0.0.1"
-    create_files(tmp_path, bundle_files(operator_name, bundle_version))
+    bundle_version = bundle
+    affected_catalogs = "v4.14/test-operator"
+    create_files(
+        tmp_path,
+        bundle_files(operator_name, "0.0.1"),
+        catalog_files("v4.14", "test-operator"),
+    )
 
     repo = Repo(tmp_path)
 
     mock_run_suite.return_value = iter(check_results)
-    result = static_tests.check_bundle(
-        str(repo.root), operator_name, bundle_version, ["dummy_suite"]
+    result = static_tests.execute_checks(
+        str(repo.root),
+        operator_name,
+        bundle_version,
+        affected_catalogs,
+        ["dummy_suite"],
     )
     assert result == expected
 
 
-@patch("operatorcert.entrypoints.static_tests.check_bundle")
+@patch("operatorcert.entrypoints.static_tests.execute_checks")
 @patch("operatorcert.entrypoints.static_tests.setup_logger")
 def test_static_tests_main(
-    mock_logger: MagicMock, mock_check_bundle: MagicMock, capsys: Any, tmpdir: Any
+    mock_logger: MagicMock, mock_execute_checks: MagicMock, capsys: Any, tmpdir: Any
 ) -> None:
     args = [
         "static-tests",
         "--repo-path=/tmp/repo",
         "test-operator",
         "0.0.1",
+        ["v4.14/test-operator"],
     ]
-    mock_check_bundle.return_value = {"foo": ["bar"]}
+    mock_execute_checks.return_value = {"foo": ["bar"]}
     with patch("sys.argv", args):
         static_tests.main()
-    mock_check_bundle.assert_called_once_with(
+    mock_execute_checks.assert_called_once_with(
         "/tmp/repo",
         "test-operator",
         "0.0.1",
+        ["v4.14/test-operator"],
         ["operatorcert.static_tests.community", "operatorcert.static_tests.common"],
         [],
     )
@@ -99,7 +118,7 @@ def test_static_tests_main(
     mock_logger.assert_called_once_with(level="INFO")
 
     mock_logger.reset_mock()
-    mock_check_bundle.reset_mock()
+    mock_execute_checks.reset_mock()
 
     out_file = tmpdir / "out.json"
     out_file_name = str(out_file)
@@ -109,17 +128,19 @@ def test_static_tests_main(
         "--skip-tests=check_123,check_456",
         "other-test-operator",
         "0.0.2",
+        ["v4.14/test-operator"],
         "--suites=other_suite",
         f"--output-file={out_file_name}",
         "--verbose",
     ]
-    mock_check_bundle.return_value = {"bar": ["baz"]}
+    mock_execute_checks.return_value = {"bar": ["baz"]}
     with patch("sys.argv", args):
         static_tests.main()
-    mock_check_bundle.assert_called_once_with(
+    mock_execute_checks.assert_called_once_with(
         "/tmp/other_repo",
         "other-test-operator",
         "0.0.2",
+        ["v4.14/test-operator"],
         ["other_suite"],
         ["check_123", "check_456"],
     )

--- a/operator-pipeline-images/tests/static_tests/common/test_catalog.py
+++ b/operator-pipeline-images/tests/static_tests/common/test_catalog.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from operator_repo import OperatorCatalogList, Repo
+from operatorcert.static_tests.common.catalog import check_bundle_images_in_fbc
+from tests.utils import bundle_files, catalog_files, create_files
+
+
+@pytest.mark.parametrize(
+    ["config", "expected_results"],
+    [
+        (
+            {},
+            set(),
+        ),
+        (
+            {
+                "allowed_bundle_registries": ["quay.io/org-foo/", "quay.io/org-bar/"],
+            },
+            set(),
+        ),
+        (
+            {
+                "allowed_bundle_registries": ["quay.io/org-foo/"],
+            },
+            {
+                "Invalid bundle image(s) found in OperatorCatalog(v4.14/fake-operator)"
+                ": quay.io/org-bar/registry/bundle@sha256:123"
+            },
+        ),
+    ],
+    ids=[
+        "Config not set",
+        "All registries allowed",
+        "Registry not allowed",
+    ],
+)
+def test_check_bundle_images_in_fbc(
+    tmp_path: Path,
+    config: dict[str, Any],
+    expected_results: set[str],
+) -> None:
+    catalog_content = (
+        {
+            "schema": "olm.bundle",
+            "image": "quay.io/org-foo/registry/bundle@sha256:123",
+        },
+        {
+            "schema": "olm.bundle",
+            "image": "quay.io/org-bar/registry/bundle@sha256:123",
+        },
+    )
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator", content=catalog_content),
+        bundle_files("fake-operator", "0.0.1"),
+        {"config.yaml": config},
+    )
+    repo = Repo(tmp_path)
+    catalog = repo.catalog("v4.14")
+    operator_catalog = catalog.operator_catalog("fake-operator")
+    catalogs = OperatorCatalogList([operator_catalog])
+    assert {x.reason for x in check_bundle_images_in_fbc(catalogs)} == expected_results

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "operatorcert-dev", "tox"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:a385bde57b243f82841b52066f918192d661f4b83315cc1f6462b9d6f25ca3cb"
+content_hash = "sha256:4dad87868d0b1ed61d007fbde6b6d9f5189cb8c372a37f92b97b262e4def902e"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -1043,11 +1043,11 @@ files = [
 
 [[package]]
 name = "operator-repo"
-version = "0.4.3"
+version = "0.4.7"
 requires_python = ">=3.9"
 git = "https://github.com/mporrato/operator-repo.git"
-ref = "v0.4.3"
-revision = "01d7095a0c5c0a40466839454c005b6a95c20f74"
+ref = "v0.4.7"
+revision = "277471a08a7e9f06169925fcf25b039ac70c4677"
 summary = "Library and utilities to handle repositories of kubernetes operators"
 groups = ["default"]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "PyGithub<2.0,>=1.59.0",
     "GitPython>=3.1.37",
     "semver>=3.0.1",
-    "operator-repo @ git+https://github.com/mporrato/operator-repo.git@v0.4.3",
+    "operator-repo @ git+https://github.com/mporrato/operator-repo.git@v0.4.7",
     "urllib3>=2.2.2",
     "openshift-client>=2.0.4",
     "pydantic>=2.10.0",


### PR DESCRIPTION
This PR adds logic to validate file based catalogs in static checks, with first fbc check `check_bundle_images_in_fbc`.

Example pipeline run [can be found here](https://github.com/redhat-openshift-ecosystem/community-operators-pipeline-preprod/pull/315). The validation is done thanks to config.yaml key [allowed_bundle_registries](https://github.com/redhat-openshift-ecosystem/community-operators-pipeline-preprod/blob/f834b495bfa2ecb41bd656addad1947c414c10c3/config.yaml#L17). In the test run two catalogs were updated, but only one failure is detected, as one of the bundles use allowed registry.

If the key `allowed_bundle_registries` is missing in config.yaml, then the  bundle image validation is internally skipped (without the config the new check is turned off).

Closes ISV-5446