### PR TITLE
update preflight sha for 1.11.1 release

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -7,7 +7,7 @@ spec:
   params:
     - name: pipeline_image
     - name: base_image
-      default: quay.io/redhat-isv/preflight-test@sha256:3f5b988200a3fd490e0a102a4851e0a81f2f41e724e7482a726b79b9d5ccd3b6
+      default: quay.io/redhat-isv/preflight-test@sha256:2d57b1bc66de91470886762be5dfa14e48c64e3174c5c80b2c45b05906ad4c1e
       description: Preflight image used
     - name: package_name
       description: Package name for the Operator under test


### PR DESCRIPTION
```
❯ crane digest quay.io/redhat-isv/preflight-test:1.10.2
sha256:3f5b988200a3fd490e0a102a4851e0a81f2f41e724e7482a726b79b9d5ccd3b6

❯ crane digest quay.io/redhat-isv/preflight-test:1.11.1
sha256:2d57b1bc66de91470886762be5dfa14e48c64e3174c5c80b2c45b05906ad4c1e
```