### PR TITLE
Skip yamllint for removed bundles

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/operator-pipeline-event-listener.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-pipeline-event-listener.yml
@@ -87,7 +87,6 @@
                             && body.action == "closed"
                             && body.pull_request.base.ref == "{{ branch }}"
                             && body.pull_request.merged == true
-                            && body.sender.login == "rh-operator-bundle-bot"
                           )
                 bindings:
                   - ref: operator-release-pipeline-trigger-binding

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -175,7 +175,9 @@ spec:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
         - name: args
-          value: ["-d {extends: default, rules: {line-length: {max: 180, level: warning}, indentation: {indent-sequences: whatever}}}", "$(params.bundle_path)"]
+          value: "-d {extends: default, rules: {line-length: {max: 180, level: warning}, indentation: {indent-sequences: whatever}}}"
+        - name: path
+          value: "$(params.bundle_path)"
       workspaces:
         - name: shared-workspace
           workspace: pipeline

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -322,11 +322,9 @@ spec:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
         - name: args
-          value:
-            [
-              "-d {extends: default, rules: {line-length: {max: 180, level: warning}, indentation: {indent-sequences: whatever}}}",
-              "$(tasks.detect-changes.results.bundle_path)",
-            ]
+          value: "-d {extends: default, rules: {line-length: {max: 180, level: warning}, indentation: {indent-sequences: whatever}}}"
+        - name: path
+          value: "$(tasks.detect-changes.results.bundle_path)"
       workspaces:
         - name: shared-workspace
           workspace: repository

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
@@ -34,6 +34,8 @@ spec:
         set -xe
         if [[ -z "$(params.operator_path)" ]]; then
           echo -n false > "$(results.bool_merge.path)"
+        elif [[ ! -f "$(params.operator_path)/ci.yaml" ]]; then
+          echo -n false > "$(results.bool_merge.path)"
         else
           BOOL_MERGE=$(yq -r '.merge!=false' < "$(params.operator_path)/ci.yaml")
 

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/read-config.yaml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/read-config.yaml
@@ -41,7 +41,13 @@ spec:
 
         CONFIG_PATH="$PKG_PATH/ci.yaml"
 
-        if [[ ! -f "$CONFIG_PATH" ]]; then
+        if [[ ! -d "$PKG_PATH" ]]; then
+            echo "Operator directory is removed."
+            echo -n "" | tee $(results.upgrade-graph-mode.path)
+            echo -n "true" | tee $(results.fbc-enabled.path)
+            echo -n "true" | tee "$(workspaces.output.path)/fbc_enabled"
+            exit 0
+        elif [[ ! -f "$CONFIG_PATH" ]]; then
             echo "Config file $CONFIG_PATH does not exist or no bundle affected."
             echo -n "replaces" | tee $(results.upgrade-graph-mode.path)
             echo -n "false" | tee $(results.fbc-enabled.path)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/yaml-lint.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/yaml-lint.yml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: yaml-lint
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Code Quality
@@ -19,14 +19,23 @@ spec:
   params:
     - name: pipeline_image
     - name: args
-      type: array
+      type: string
       description: extra args needs to append
-      default: ["--help"]
+      default: "--help"
+    - name: path
+      type: string
+      description: path to the directory containing the YAML files
   steps:
     - name: lint-yaml-files
       image: "$(params.pipeline_image)"
       workingDir: $(workspaces.shared-workspace.path)
-      command:
-        - yamllint
-      args:
-        - $(params.args)
+      script: |
+        #!/usr/bin/env bash
+        set -xe
+
+        # Check if a path exists and skip the linting if it does not
+        if [ ! -e "$(params.path)" ]; then
+          echo "A path $(params.path) does not exist. Nothing to check..."
+          exit 0
+        fi
+        yamllint "$(params.path)" "$(params.args)"

--- a/operator-pipeline-images/operatorcert/parsed_file.py
+++ b/operator-pipeline-images/operatorcert/parsed_file.py
@@ -46,6 +46,9 @@ class AffectedBundleCollection:
             "added_bundles": [f"{x}/{y}" for x, y in self.added],
             "modified_bundles": [f"{x}/{y}" for x, y in self.modified],
             "deleted_bundles": [f"{x}/{y}" for x, y in self.deleted],
+            "added_or_modified_bundles": [
+                f"{x}/{y}" for x, y in self.added | self.modified
+            ],
         }
 
 
@@ -74,6 +77,7 @@ class AffectedOperatorCollection:
             "added_operators": list(self.added),
             "modified_operators": list(self.modified),
             "deleted_operators": list(self.deleted),
+            "added_or_modified_operators": list(self.added | self.modified),
         }
 
 
@@ -192,14 +196,14 @@ class ParserResults:
         bundle_version = ""
 
         affected_operators = result.get("affected_operators", [])
-        affected_bundles = result.get("affected_bundles", [])
+        added_or_modified_bundles = result.get("added_or_modified_bundles", [])
         affected_catalog_operators = result.get("affected_catalog_operators", [])
 
         if affected_operators:
             operator_name = affected_operators[0]
 
-        if affected_bundles:
-            _, bundle_version = affected_bundles[0].split("/")
+        if added_or_modified_bundles:
+            _, bundle_version = added_or_modified_bundles[0].split("/")
 
         if affected_catalog_operators and operator_name == "":
             # Even if the change affects only files in catalogs/ we still need to know

--- a/operator-pipeline-images/tests/entrypoints/test_detect_changed_operators.py
+++ b/operator-pipeline-images/tests/entrypoints/test_detect_changed_operators.py
@@ -49,9 +49,11 @@ from operatorcert.parsed_file import (
             "db1a066",
             {
                 "affected_operators": ["operator-e2e"],
+                "added_or_modified_operators": ["operator-e2e"],
                 "added_operators": ["operator-e2e"],
                 "affected_bundles": ["operator-e2e/0.0.100"],
                 "added_bundles": ["operator-e2e/0.0.100"],
+                "added_or_modified_bundles": ["operator-e2e/0.0.100"],
             },
             id="Add new bundle for new operator",
         ),
@@ -62,9 +64,11 @@ from operatorcert.parsed_file import (
             "6a75661",
             {
                 "affected_operators": ["operator-e2e"],
+                "added_or_modified_operators": ["operator-e2e"],
                 "modified_operators": ["operator-e2e"],
                 "affected_bundles": ["operator-e2e/0.0.101"],
                 "added_bundles": ["operator-e2e/0.0.101"],
+                "added_or_modified_bundles": ["operator-e2e/0.0.101"],
             },
             id="Add new bundle for existing operator",
         ),
@@ -76,6 +80,7 @@ from operatorcert.parsed_file import (
             "6a75661",
             {
                 "affected_operators": ["operator-e2e", "operator-clone-e2e"],
+                "added_or_modified_operators": ["operator-e2e", "operator-clone-e2e"],
                 "added_operators": ["operator-clone-e2e"],
                 "modified_operators": ["operator-e2e"],
                 "affected_bundles": [
@@ -83,6 +88,10 @@ from operatorcert.parsed_file import (
                     "operator-clone-e2e/0.0.100",
                 ],
                 "added_bundles": ["operator-e2e/0.0.101", "operator-clone-e2e/0.0.100"],
+                "added_or_modified_bundles": [
+                    "operator-e2e/0.0.101",
+                    "operator-clone-e2e/0.0.100",
+                ],
             },
             id="Add bundles for multiple operators",
         ),
@@ -96,12 +105,17 @@ from operatorcert.parsed_file import (
             {
                 "extra_files": ["empty.txt", "operators/empty.txt"],
                 "affected_operators": ["operator-e2e", "operator-clone-e2e"],
+                "added_or_modified_operators": ["operator-e2e", "operator-clone-e2e"],
                 "modified_operators": ["operator-e2e", "operator-clone-e2e"],
                 "affected_bundles": [
                     "operator-e2e/0.0.101",
                     "operator-clone-e2e/0.0.100",
                 ],
                 "modified_bundles": [
+                    "operator-e2e/0.0.101",
+                    "operator-clone-e2e/0.0.100",
+                ],
+                "added_or_modified_bundles": [
                     "operator-e2e/0.0.101",
                     "operator-clone-e2e/0.0.100",
                 ],
@@ -117,6 +131,7 @@ from operatorcert.parsed_file import (
             {
                 "extra_files": ["empty.txt", "operators/empty.txt"],
                 "affected_operators": ["operator-e2e"],
+                "added_or_modified_operators": ["operator-e2e"],
                 "modified_operators": ["operator-e2e"],
                 "affected_bundles": ["operator-e2e/0.0.101"],
                 "deleted_bundles": ["operator-e2e/0.0.101"],
@@ -130,6 +145,7 @@ from operatorcert.parsed_file import (
             "2c06647",
             {
                 "affected_operators": ["operator-clone-e2e"],
+                "added_or_modified_operators": ["operator-clone-e2e"],
                 "modified_operators": ["operator-clone-e2e"],
             },
             id="Add ci.yaml to an operator",
@@ -247,6 +263,7 @@ from operatorcert.parsed_file import (
             "244d87b92",
             {
                 "affected_operators": ["operator-e2e"],
+                "added_or_modified_operators": ["operator-e2e"],
                 "modified_operators": ["operator-e2e"],
             },
             id="Add catalog template to operator-e2e",
@@ -295,10 +312,12 @@ def test_detect_changes(
     default_expected: dict[str, Any] = {
         "extra_files": [],
         "affected_operators": [],
+        "added_or_modified_operators": [],
         "added_operators": [],
         "modified_operators": [],
         "deleted_operators": [],
         "affected_bundles": [],
+        "added_or_modified_bundles": [],
         "added_bundles": [],
         "modified_bundles": [],
         "deleted_bundles": [],
@@ -734,10 +753,14 @@ def test_ParserRules_validate_removal_fbc_fail(
             {
                 "affected_bundles": ["operator-e2e/0.0.101"],
                 "affected_operators": ["operator-e2e"],
+                "added_or_modified_operators": ["operator-e2e"],
+                "added_or_modified_bundles": ["operator-e2e/0.0.101"],
             },
             {
                 "affected_bundles": ["operator-e2e/0.0.101"],
                 "affected_operators": ["operator-e2e"],
+                "added_or_modified_operators": ["operator-e2e"],
+                "added_or_modified_bundles": ["operator-e2e/0.0.101"],
                 "operator_name": "operator-e2e",
                 "bundle_version": "0.0.101",
                 "operator_path": "operators/operator-e2e",


### PR DESCRIPTION
In case a bundle is removed the files don't exist in the repository
anymore and it doesn't make sense to run yamllint.

The change parser also needs to distinguish between added, modified, and
removed operators and bundles. Each of these categories needs to be
treated differently.

JIRA: ISV-5466