### PR TITLE
Helper github function for integration tests

### DIFF
--- a/operator-pipeline-images/operatorcert/__init__.py
+++ b/operator-pipeline-images/operatorcert/__init__.py
@@ -12,7 +12,7 @@ from urllib.parse import urljoin
 
 import yaml
 from dateutil.parser import isoparse
-from operatorcert import github, pyxis
+from operatorcert import pyxis
 from operatorcert.utils import find_file
 
 # Bundle annotations

--- a/operator-pipeline-images/operatorcert/github.py
+++ b/operator-pipeline-images/operatorcert/github.py
@@ -272,3 +272,67 @@ def add_or_remove_labels(  # pylint: disable=too-many-locals
 
     add_labels_to_pull_request(pull_request, labels_to_add)
     remove_labels_from_pull_request(pull_request, labels_to_remove)
+
+
+def open_pull_request(  # pylint: disable=too-many-arguments
+    github_client: Github,
+    repository_name: str,
+    title: str,
+    body: str,
+    head: str,
+    base: str,
+) -> PullRequest.PullRequest:
+    """Open a new Github pull request in the given repository.
+
+    Args:
+        github_client (Github): A Github API client
+        repository_name (str): A repository name in the format "organization/repository"
+        title (str): A title for the pull request
+        body (str): A body text for the pull request
+        head (str): A git reference for the PR head (e.g. a branch name)
+        base (str): A git reference for the PR base (e.g. a branch name)
+
+    Returns:
+        PullRequest.PullRequest: A Github pull request object
+    """
+    repository = github_client.get_repo(repository_name)
+    pull_request = repository.create_pull(title=title, body=body, head=head, base=base)
+    return pull_request
+
+
+def get_pull_request_by_number(
+    github_client: Github,
+    repository_name: str,
+    pr_number: int,
+) -> PullRequest.PullRequest:
+    """
+    Get a Github pull request by number and repository name.
+
+    Args:
+        github_client (Github): A Github API client
+        repository_name (str): A repository name in the format "organization/repository"
+        pr_number (int): A pull request number
+
+    Returns:
+        PullRequest.PullRequest: A Github pull request object
+    """
+    repository = github_client.get_repo(repository_name)
+    pull_request = repository.get_pull(pr_number)
+    return pull_request
+
+
+def close_pull_request(
+    pull_request: PullRequest.PullRequest,
+) -> PullRequest.PullRequest:
+    """
+    Close a Github pull request.
+
+    Args:
+        pull_request (PullRequest.PullRequest): A Github pull request object
+        that should be closed
+
+    Returns:
+        PullRequest: A Github pull request object after closing
+    """
+    pull_request.edit(state="closed")
+    return pull_request

--- a/operator-pipeline-images/tests/test_github.py
+++ b/operator-pipeline-images/tests/test_github.py
@@ -183,3 +183,49 @@ def test_remove_labels_from_pull_request() -> None:
     mock_pull_request.remove_from_labels.assert_has_calls(
         [call("label1"), call("label2")]
     )
+
+
+def test_open_pull_request() -> None:
+    mock_client = MagicMock()
+    mock_repo = MagicMock()
+    mock_pull_request = MagicMock()
+
+    mock_client.get_repo.return_value = mock_repo
+    mock_repo.create_pull.return_value = mock_pull_request
+
+    resp = github.open_pull_request(
+        mock_client, "repo_name", "title", "body", "branch", "base"
+    )
+
+    mock_client.get_repo.assert_called_once_with("repo_name")
+    mock_repo.create_pull.assert_called_once_with(
+        title="title", body="body", head="branch", base="base"
+    )
+
+    assert resp == mock_pull_request
+
+
+def test_get_pull_request_by_number() -> None:
+    mock_client = MagicMock()
+    mock_repo = MagicMock()
+    mock_pull_request = MagicMock()
+
+    mock_client.get_repo.return_value = mock_repo
+    mock_repo.get_pull.return_value = mock_pull_request
+
+    resp = github.get_pull_request_by_number(mock_client, "repo_name", 1)
+
+    mock_client.get_repo.assert_called_once_with("repo_name")
+    mock_repo.get_pull.assert_called_once_with(1)
+
+    assert resp == mock_pull_request
+
+
+def test_close_pull_request() -> None:
+    mock_pull_request = MagicMock()
+
+    resp = github.close_pull_request(mock_pull_request)
+
+    mock_pull_request.edit.assert_called_once_with(state="closed")
+
+    assert resp == mock_pull_request


### PR DESCRIPTION
These helper functions allows integration tests to open a pull request and manipulate with it. The github API exposes a full PR object that can be used across all tests.

JIRA: ISV-5278