### PR TITLE
Add helper functions for bundle image

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -7,6 +7,14 @@ rules:
     max: 180
   document-start:
     level: error
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  braces:
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
 
 ignore:
   - .tox/

--- a/ansible/roles/integration_tests/tasks/check_bundle_existence_in_index_image.yml
+++ b/ansible/roles/integration_tests/tasks/check_bundle_existence_in_index_image.yml
@@ -12,19 +12,19 @@
           ansible.builtin.file:
             path: "{{ tmp_folder }}"
             state: directory
-            mode: 0777
+            mode: "0777"
 
         - name: Create directory for registry credentials
           ansible.builtin.file:
             path: "{{ tmp_folder }}/registry_certs/"
             state: directory
-            mode: 0777
+            mode: "0777"
 
         - name: Save credentials to file
           no_log: true
           ansible.builtin.copy:
             dest: "{{ tmp_folder }}/registry_certs/config.json"
-            mode: 0777
+            mode: "0777"
             content: |
               {
                   "auths": {

--- a/ansible/roles/integration_tests/tasks/test_data.yml
+++ b/ansible/roles/integration_tests/tasks/test_data.yml
@@ -8,7 +8,7 @@
   ansible.builtin.template:
     src: ci.yaml.j2
     dest: "{{ git_temp_dir.path }}/ci.yaml"
-    mode: 0644
+    mode: "0644"
   changed_when: true
 
 - name: Prepare ci.yaml in target branch

--- a/operator-pipeline-images/operatorcert/bundle.py
+++ b/operator-pipeline-images/operatorcert/bundle.py
@@ -1,0 +1,215 @@
+"""A module for working with bundle images."""
+
+import json
+import logging
+import os
+import shutil
+import tempfile
+from typing import Any, Optional
+
+import yaml
+from operatorcert import utils
+
+LOGGER = logging.getLogger("operator-cert")
+
+
+class BundleImage:
+    """
+    A class representing a bundle image. The class provides methods to work with
+    the bundle image content.
+    """
+
+    def __init__(
+        self, image_pullspec: str, auth_file_path: Optional[str] = None
+    ) -> None:
+        self.image_pullspec = image_pullspec
+        self.auth_file_path = auth_file_path
+
+        self._inspect_data: dict[str, Any] = {}
+        self._content_path = ""
+
+    def __str__(self) -> str:
+        """
+        A string representation of the bundle image pull spec.
+
+        Returns:
+            str: A bundle image pull spec.
+        """
+        return self.image_pullspec
+
+    def __repr__(self) -> str:
+        """
+        A representation of a BundleImage object.
+
+        Returns:
+            str: A representation of a BundleImage object.
+        """
+        return f"BundleImage({self.image_pullspec})"
+
+    def __del__(self) -> None:
+        """
+        A method to clean up the content path.
+        """
+        if not self._content_path:
+            return
+        if os.path.exists(self._content_path):
+            shutil.rmtree(self._content_path, ignore_errors=True)
+
+    @property
+    def content_path(self) -> str:
+        """
+        A property to get the content path of the bundle image. The content path is
+        a directory where the bundle image content is extracted.
+
+        Returns:
+            str: A path to the content directory.
+        """
+        if not self._content_path:
+            # Create a temporary directory and copy and extract the image
+            self._content_path = tempfile.mkdtemp()
+            self._copy_and_extract_image()
+        return self._content_path
+
+    def _copy_and_extract_image(self) -> None:
+        """
+        A method to copy and extract the bundle image content to a local temporary
+        directory.
+        """
+        # Copy the image to the content path and extract the content
+        # only if the content path is not set.
+        self._copy_image()
+        self._extract_content()
+
+    @property
+    def inspect_data(self) -> dict[str, Any]:
+        """
+        A property to get the inspect data of the bundle image. The inspect data
+        is a dictionary with the image metadata retrieved using the `skopeo inspect`
+
+        Returns:
+            dict[str, Any]: A dictionary with the image metadata.
+        """
+        if not self._inspect_data:
+            command = [
+                "skopeo",
+                "inspect",
+                "--no-tags",
+                f"docker://{self.image_pullspec}",
+            ]
+            if self.auth_file_path:
+                command.extend(["--authfile", self.auth_file_path])
+
+            output = utils.run_command(command)
+            self._inspect_data = json.loads(output.stdout.decode("utf-8"))
+        return self._inspect_data
+
+    def _copy_image(self) -> None:
+        """
+        A method to copy the bundle image to a local directory using the `skopeo copy`
+        """
+        command = [
+            "skopeo",
+            "copy",
+            f"docker://{self.image_pullspec}",
+            f"dir:{self.content_path}",
+        ]
+        if self.auth_file_path:
+            command.extend(["--authfile", self.auth_file_path])
+
+        utils.run_command(command)
+
+    def _extract_content(self) -> None:
+        """
+        A method to extract the bundle image content to the content path. The method
+        extracts the content of the first layer of the image. Bundle images should
+        have just one layer wchich contains the bundle content including metadata
+        adn manifests.
+        """
+        # there should be just one layer in the bundle image
+        layer_to_extract = self.manifest_file.get("layers")[0].get("digest")
+        layer_to_extract = layer_to_extract.removeprefix("sha256:")
+        command = [
+            "tar",
+            "-xvf",
+            os.path.join(self.content_path, layer_to_extract),
+        ]
+        utils.run_command(command, cwd=self.content_path)
+
+    @property
+    def labels(self) -> dict[str, str]:
+        """
+        A property to get the labels of the bundle image.
+
+        Returns:
+            dict[str, str]: A dictionary with the image labels.
+        """
+        return self.inspect_data.get("Labels", {}) or {}
+
+    @property
+    def annotations(self) -> Any:
+        """
+        A property to get the annotations of the bundle image.
+
+        Returns:
+            Any: A dictionary with the image annotations.
+        """
+        return yaml.safe_load(self.get_bundle_file("metadata/annotations.yaml"))
+
+    @property
+    def manifest_file(self) -> Any:
+        """
+        A property to get the manifest.json file of the bundle image.
+
+        Returns:
+            Any: A json loaded manifest file.
+        """
+        with open(
+            os.path.join(self.content_path, "manifest.json"), encoding="utf8"
+        ) as f:
+            manifest = json.load(f)
+        return manifest
+
+    @property
+    def config(self) -> Any:
+        """
+        A property to get the config file of the bundle image.
+
+        Returns:
+            Any: A dictionary with the config file content.
+        """
+        config_file_name = self.manifest_file.get("config", {}).get("digest")
+        config_file_name = config_file_name.removeprefix("sha256:")
+        with open(
+            os.path.join(self.content_path, config_file_name), encoding="utf8"
+        ) as f:
+            config = json.load(f)
+        return config
+
+    def get_bundle_file(self, file_name: str) -> str:
+        """
+        A method to get any file given by argument from the bundle image content.
+
+        Args:
+            file_name (str): A name of the file to get from the bundle image content.
+
+        Returns:
+            str: A content of the file as a string.
+        """
+        with open(os.path.join(self.content_path, file_name), encoding="utf8") as f:
+            return f.read()
+
+    def get_csv_file(self) -> Optional[str]:
+        """
+        A method to get the ClusterServiceVersion file from the bundle image content.
+
+        Returns:
+            Optional[str]: A content of the ClusterServiceVersion file as a string.
+        """
+        for file_name in os.listdir(os.path.join(self.content_path, "manifests")):
+            csv_files_extensions = [
+                "clusterserviceversion.yaml",
+                "clusterserviceversion.yml",
+            ]
+            if file_name.endswith(tuple(csv_files_extensions)):
+                return self.get_bundle_file(os.path.join("manifests", file_name))
+        return None

--- a/operator-pipeline-images/tests/test_bundle.py
+++ b/operator-pipeline-images/tests/test_bundle.py
@@ -1,0 +1,171 @@
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+from operatorcert.bundle import BundleImage
+from pytest import fixture
+
+
+@fixture
+def bundle() -> BundleImage:
+    return BundleImage("quay.io/fake-bundle:v0.0.1", auth_file_path="fake_auth_file")
+
+
+def test_BundleImage(bundle: BundleImage) -> None:
+    assert str(bundle) == "quay.io/fake-bundle:v0.0.1"
+    assert repr(bundle) == "BundleImage(quay.io/fake-bundle:v0.0.1)"
+
+
+@patch("operatorcert.bundle.BundleImage._copy_and_extract_image")
+@patch("operatorcert.bundle.tempfile.mkdtemp")
+def test_Bundle_content_path(
+    mock_tmp: MagicMock, mock_copy_extract: MagicMock, bundle: BundleImage
+) -> None:
+    result = bundle.content_path
+
+    assert result == mock_tmp.return_value
+    mock_copy_extract.assert_called_once()
+
+
+@patch("operatorcert.bundle.utils.run_command")
+def test_BundleImage_inspect_data(mock_command: MagicMock, bundle: BundleImage) -> None:
+    mock_command.return_value.stdout = b"{}"
+    result = bundle.inspect_data
+    mock_command.assert_called_once_with(
+        [
+            "skopeo",
+            "inspect",
+            "--no-tags",
+            "docker://quay.io/fake-bundle:v0.0.1",
+            "--authfile",
+            "fake_auth_file",
+        ]
+    )
+
+    assert result == {}
+
+
+@patch("operatorcert.bundle.BundleImage._extract_content")
+@patch("operatorcert.bundle.BundleImage._copy_image")
+def test_BundleImage__copy_and_extract_image(
+    mock_copy: MagicMock, mock_extract: MagicMock, bundle: BundleImage
+) -> None:
+    bundle._copy_and_extract_image()
+
+    mock_copy.assert_called_once()
+    mock_extract.assert_called_once()
+
+
+@patch("operatorcert.bundle.utils.run_command")
+def test_BundleImage__copy_image(mock_command: MagicMock, bundle: BundleImage) -> None:
+    bundle._content_path = "fake_path"
+    bundle._copy_image()
+
+    mock_command.assert_called_once_with(
+        [
+            "skopeo",
+            "copy",
+            "docker://quay.io/fake-bundle:v0.0.1",
+            "dir:fake_path",
+            "--authfile",
+            "fake_auth_file",
+        ]
+    )
+
+
+@patch("operatorcert.bundle.BundleImage.manifest_file")
+@patch("operatorcert.bundle.utils.run_command")
+def test_BundleImage__extract_content(
+    mock_command: MagicMock, mock_manifest_file: MagicMock, bundle: BundleImage
+) -> None:
+    mock_manifest_file.get.return_value = [{"digest": "sha256:fake_digest"}]
+    bundle._content_path = "fake_path"
+
+    bundle._extract_content()
+
+    mock_command.assert_called_once_with(
+        ["tar", "-xvf", "fake_path/fake_digest"], cwd="fake_path"
+    )
+
+
+def test_BundleImage_labels(bundle: BundleImage) -> None:
+    bundle._inspect_data = {"Labels": {"foo": "bar"}}
+    result = bundle.labels
+
+    assert result == {"foo": "bar"}
+
+
+@patch("operatorcert.bundle.json.load")
+def test_BundleImage_manifest_file(mock_json: MagicMock, bundle: BundleImage) -> None:
+
+    bundle._content_path = "fake_path"
+    mock_open = mock.mock_open()
+    mock_json.return_value = {"foo": "bar"}
+
+    with mock.patch("builtins.open", mock_open):
+        result = bundle.manifest_file
+
+        mock_open.assert_called_once_with("fake_path/manifest.json", encoding="utf8")
+        mock_json.assert_called_once_with(mock_open.return_value)
+        assert result == {"foo": "bar"}
+
+
+@patch("operatorcert.bundle.json.load")
+@patch("operatorcert.bundle.BundleImage.manifest_file")
+@patch("operatorcert.bundle.utils.run_command")
+def test_BundleImage_config(
+    mock_command: MagicMock,
+    mock_manifest_file: MagicMock,
+    mock_json: MagicMock,
+    bundle: BundleImage,
+) -> None:
+    mock_manifest_file.get.return_value = {"digest": "sha256:fake_digest"}
+    bundle._content_path = "fake_path"
+
+    mock_open = mock.mock_open()
+    mock_json.return_value = {"foo": "bar"}
+
+    with mock.patch("builtins.open", mock_open):
+        result = bundle.config
+
+    assert result == {"foo": "bar"}
+    mock_open.assert_called_once_with("fake_path/fake_digest", encoding="utf8")
+
+
+def test_BundleImage_get_bundle_file(bundle: BundleImage) -> None:
+    bundle._content_path = "fake_path"
+
+    mock_open = mock.mock_open()
+    mock_open.return_value.read.return_value = "bar"
+    with mock.patch("builtins.open", mock_open):
+        result = bundle.get_bundle_file("fake_file")
+
+    assert result == "bar"
+    mock_open.assert_called_once_with("fake_path/fake_file", encoding="utf8")
+
+
+@patch("operatorcert.bundle.BundleImage.get_bundle_file")
+@patch("operatorcert.bundle.os.listdir")
+def test_BundleImage_get_csv_file(
+    mock_list_dir: MagicMock, mock_bundle_file: MagicMock, bundle: BundleImage
+) -> None:
+    bundle._content_path = "fake_path"
+    mock_list_dir.return_value = ["fake_file"]
+
+    result = bundle.get_csv_file()
+
+    assert result is None
+
+    mock_list_dir.return_value = ["foo.clusterserviceversion.yaml"]
+
+    result = bundle.get_csv_file()
+    assert result == mock_bundle_file.return_value
+
+    mock_bundle_file.assert_called_once_with("manifests/foo.clusterserviceversion.yaml")
+
+
+def test_BundleImage_annotations(bundle: BundleImage) -> None:
+    bundle.get_bundle_file = MagicMock(return_value="foo: bar")  # type: ignore
+    result = bundle.annotations
+
+    assert result == {"foo": "bar"}
+    bundle.get_bundle_file.assert_called_once_with("metadata/annotations.yaml")


### PR DESCRIPTION
A new class BundleImage is introduced that represents a bundle image. The class will be used in integration test to verify its content is as expected. The class contains a generic method to get a metadata and simplifies a way how to extract it.

JIRA: ISV-5280

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes