### PR TITLE
fix: Skip operator test in case it gets removed from repository

### DIFF
--- a/operator-pipeline-images/operatorcert/static_tests/community/operator.py
+++ b/operator-pipeline-images/operatorcert/static_tests/community/operator.py
@@ -21,6 +21,7 @@ def check_operator_name_unique(operator: Operator) -> Iterator[CheckResult]:
         yield Fail(f"Bundles use multiple operator names: {names}")
 
 
+@skip_fbc
 def check_ci_upgrade_graph(operator: Operator) -> Iterator[CheckResult]:
     """Ensure the operator has a valid upgrade graph for ci.yaml"""
     upgrade_graph = operator.config.get("updateGraph")

--- a/operator-pipeline-images/tests/data/test_catalog.yaml
+++ b/operator-pipeline-images/tests/data/test_catalog.yaml
@@ -1,4 +1,5 @@
 # yamllint disable rule:indentation
+# yamllint disable rule:line-length
 ---
 defaultChannel: alpha
 icon:


### PR DESCRIPTION
Static check used to fail on PRs that removed the resource in a PR. This is not an intended behaviour and pipeline should not fail for such a PRs.

This commit extends a logic how resources for static checks are collected and check their presence before submitting them to test suite.

JIRA: ISV-5515

An example of pipeline that removes the whole operator and static tests still pass: https://github.com/Allda/community-operators-pipeline-preprod/pull/15

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes