### PR TITLE
[ISV-5271] Add retry mechanism for podman pull

### DIFF
--- a/ansible/roles/index_signature_verification/files/tasks/verify-index-signatures.yml
+++ b/ansible/roles/index_signature_verification/files/tasks/verify-index-signatures.yml
@@ -15,10 +15,10 @@ spec:
       default: "quay.io/redhat-isv/operator-pipelines-images:released"
     - name: podman_image
       description: Podman image
-      default: "registry.redhat.io/ubi9/podman:9.1.0"
+      default: "registry.redhat.io/ubi9/podman:9.5"
     - name: skopeo_image
       description: Skopeo image
-      default: "registry.redhat.io/ubi9/skopeo:9.1.0"
+      default: "registry.redhat.io/ubi9/skopeo:9.5"
     - name: indices_api
       description: Pyxis API endpoint for Operator index images
       default: https://catalog.redhat.com/api/containers/v1/operators/indices

--- a/ansible/roles/index_signature_verification/files/tasks/verify-index-signatures.yml
+++ b/ansible/roles/index_signature_verification/files/tasks/verify-index-signatures.yml
@@ -116,8 +116,10 @@ spec:
 
                 sleep $wait_time
                 wait_time=$((wait_time * 2))
-            done
 
-            echo "ERROR: Podman pull failed."
-            exit 1
+                if [ $i -eq $max_retries ]; then
+                    echo "ERROR: Podman pull failed after $max_retries attempts."
+                    exit 1
+                fi
+            done
         done

--- a/ansible/roles/index_signature_verification/files/tasks/verify-index-signatures.yml
+++ b/ansible/roles/index_signature_verification/files/tasks/verify-index-signatures.yml
@@ -103,6 +103,21 @@ spec:
 
         cp /etc/containers/policy.json /tmp/
         podman image trust set --policypath=/tmp/policy.json -f /mnt/keys/pub.gpg registry.redhat.io
+
+        max_retries=5
+
         for pull_spec in $(cat image-digests.txt); do
-            podman pull --signature-policy=/tmp/policy.json $pull_spec
+            wait_time=1
+            for ((i=1; i<=max_retries; i++)); do
+                podman pull --retry 0 --signature-policy=/tmp/policy.json $pull_spec
+                if [ $? -eq 0 ]; then
+                    break
+                fi
+
+                sleep $wait_time
+                wait_time=$((wait_time * 2))
+            done
+
+            echo "ERROR: Podman pull failed."
+            exit 1
         done

--- a/ansible/roles/index_signature_verification/tasks/main.yml
+++ b/ansible/roles/index_signature_verification/tasks/main.yml
@@ -70,6 +70,11 @@
       kind: TriggerBinding
       metadata:
         name: index-signature-verification-pipeline-trigger-binding
+      spec:
+        params:
+          # Tekton fails with BadRequest when no params are supplied
+          - name: "tekton"
+            value: "moment"
 
 - name: Create TriggerTemplate
   kubernetes.core.k8s:


### PR DESCRIPTION
This PR adds a retry mechanism for the podman pull command in the index-signature-verification pipeline. The UBI images were also updated to the latest versions. The changes have been tested on the stage cluster. After this is merged, I will deploy the changes to the prod cluster.

### Merge Request Checklists

- [x] Development is done in feature branches
- [x] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [x] Code changes are covered with unit and integration tests.
- [x] Code passes all automated code tests:
    - [x] Linting
    - [x] Code formatter - Black
    - [x] Security scanners
    - [x] Unit tests
    - [ ] Integration tests
- [x] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes