### PR TITLE
FBC make uses catalog mapping instead of hardcoded version

### DIFF
--- a/fbc/Makefile
+++ b/fbc/Makefile
@@ -4,12 +4,6 @@
 # The makefile should be placed in the root of the operator repository.
 # for example at: <operator-repo>/operators/<operator-name>/Makefile
 
-# A user can customize "catalog" target to generate the operator catalog in a way
-# that suits the operator.
-# OPM allows for the generation of catalogs using different templates.
-# - basic: generates a basic catalog
-# - semver: generates a catalog with semver versioning
-
 PWD=$(shell pwd)
 OPERATOR_NAME=$(shell basename $(PWD))
 TOPDIR=$(abspath $(dir $(PWD))/../)
@@ -20,21 +14,12 @@ export PATH := $(BINDIR):$(PATH)
 # A place to store the generated catalogs
 CATALOG_DIR=${TOPDIR}/catalogs
 
-# A place to store the operator catalog templates
-OPERATOR_CATALOG_TEMPLATE_DIR = ${PWD}/catalog-templates
-
 # The operator pipeline image to use for the fbc-onboarding target
 OPERATOR_PIPELINE_IMAGE ?= quay.io/redhat-isv/operator-pipelines-images:released
 
 # Define the paths for both auth files
 DOCKER_CONFIG := $(HOME)/.docker/config.json
 CONTAINERS_AUTH := $(XDG_RUNTIME_DIR)/containers/auth.json
-
-# A list of OCP versions to generate catalogs for
-# This list can be customized to include the versions that are relevant to the operator
-# DO NOT change this line (except for the versions) if you want to take advantage
-# of the automated catalog promotion
-OCP_VERSIONS=$(shell echo "v4.12 v4.13 v4.14 v4.15 v4.16 v4.17" )
 
 
 .PHONY: fbc-onboarding
@@ -61,60 +46,56 @@ fbc-onboarding: clean
 			--cache-dir /workspace/.catalog_cache
 
 .PHONY: catalogs
-# replace this stub with one customized to serve your needs ... some examples below
 
-# here are a few examples of different approaches to fulfilling this target
-# comment out / customize the one that makes the most sense, or use them as examples in defining your own
-#
-# --- BASIC TEMPLATE ---
-catalogs: basic
-#
-# --- SEMVER TEMPLATE ---
-#catalogs: semver
-
-
-# basic target provides an example FBC generation from a `basic` template type.
-# this example takes a single file as input and generates a well-formed FBC operator contribution as an output
-.PHONY: basic
-basic: ${BINDIR}/opm clean
-	for version in $(OCP_VERSIONS); do \
-		mkdir -p ${CATALOG_DIR}/$${version}/${OPERATOR_NAME}/ && \
-		${BINDIR}/opm alpha render-template basic -o yaml ${OPERATOR_CATALOG_TEMPLATE_DIR}/$${version}.yaml > ${CATALOG_DIR}/$${version}/${OPERATOR_NAME}/catalog.yaml; \
-	done
-
-
-# semver target provides an example FBC generation from a `semver` template type.
-# this example takes a single file as input and generates a well-formed FBC operator contribution as an output
-.PHONY: semver
-semver: ${BINDIR}/opm clean
-	for version in $(OCP_VERSIONS); do \
-		mkdir -p ${CATALOG_DIR}/$${version}/${OPERATOR_NAME}/ && \
-		${BINDIR}/opm alpha render-template semver -o yaml  ${OPERATOR_CATALOG_TEMPLATE_DIR}/$${version}.yaml > ${CATALOG_DIR}/$${version}/${OPERATOR_NAME}/catalog.yaml; \
-	done
+# Catalogs are generated based on the mapping in ci.yaml file
+# The example of the mapping is:
+# fbc:
+#   enabled: true
+#   catalog_mapping:
+#     - template_name: basic.yaml
+#       catalog_names: ["v4.14", "v4.15", "v4.16"]
+#       type: olm.template.basic
+#     - template_name: semver.yaml
+#       catalog_names: ["v4.13", "v4.17"]
+#       type: olm.semver
+catalogs: ${BINDIR}/render_catalogs.sh ${BINDIR}/opm ${BINDIR}/yq clean
+	@echo "Rendering catalogs from templates"
+	@${BINDIR}/render_catalogs.sh
 
 
 # validate-catalogs target illustrates FBC validation
 # all FBC must pass opm validation in order to be able to be used in a catalog
 .PHONY: validate-catalogs
 validate-catalogs: ${BINDIR}/opm
-	for version in $(OCP_VERSIONS); do \
-		${BINDIR}/opm validate $(CATALOG_DIR)/$${version}/${OPERATOR_NAME} && echo "$${version} catalog validation passed" || echo "$${version} catalog validation failed"; \
-	done
+	@find ${TOPDIR}/catalogs -type d -name fbc-test-operator -exec \
+		sh -c '${BINDIR}/opm validate $$(dirname "{}") && echo "✅ Catalog validation passed: {}" || echo "❌ Catalog validation failed: {}"' \;
 
 .PHONY: create-catalog-dir
 create-catalog-dir:
-	mkdir -p $(CATALOG_DIR)
+	@mkdir -p $(CATALOG_DIR)
 
 .PHONY: clean
 clean: create-catalog-dir
-	find $(CATALOG_DIR) -type d -name ${OPERATOR_NAME} -exec rm -rf {} +
+	@echo "Cleaning up the operator catalogs from $(CATALOG_DIR)"
+	@find $(CATALOG_DIR) -type d -name ${OPERATOR_NAME} -exec rm -rf {} +
 
 
 OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(shell uname -m | sed 's/x86_64/amd64/')
 
-# Automatically download the opm binary
+# Automatically download the binaries and scripts and place them in the bin directory
 OPM_VERSION ?= v1.46.0
 ${BINDIR}/opm:
 	if [ ! -d ${BINDIR} ]; then mkdir -p ${BINDIR}; fi
 	curl -sLO https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$(OS)-$(ARCH)-opm && chmod +x $(OS)-$(ARCH)-opm && mv $(OS)-$(ARCH)-opm ${BINDIR}/opm
+
+YQ_VERSION ?= v4.45.1
+${BINDIR}/yq:
+	if [ ! -d ${BINDIR} ]; then mkdir -p ${BINDIR}; fi
+	curl -sLO https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(OS)_$(ARCH) && mv yq_$(OS)_$(ARCH) ${BINDIR}/yq && chmod +x ${BINDIR}/yq
+
+${BINDIR}/render_catalogs.sh:
+	if [ ! -d ${BINDIR} ]; then mkdir -p ${BINDIR}; fi
+	curl -sLO https://raw.githubusercontent.com/redhat-openshift-ecosystem/operator-pipelines/main/fbc/render_catalogs.sh
+	mv render_catalogs.sh ${BINDIR}/render_catalogs.sh
+	chmod +x ${BINDIR}/render_catalogs.sh

--- a/fbc/render_catalogs.sh
+++ b/fbc/render_catalogs.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+YAML_FILE="ci.yaml"
+OPERATOR_NAME=$(basename $(pwd))
+TOPDIR=$(dirname $( dirname  $(pwd)  ) )
+
+# Extract mappings using yq with structured formatting
+mappings=$("$TOPDIR"/bin/yq eval -o=json '.fbc.catalog_mapping[]' "$YAML_FILE" | jq -c '.')
+
+# Iterate over mappings
+echo "$mappings" | while IFS= read -r mapping; do
+    template_name=$(echo "$mapping" | jq -r '.template_name')
+    type=$(echo "$mapping" | jq -r '.type')
+    catalog_names=$(echo "$mapping" | jq -r '.catalog_names[]')
+
+    echo "- Processing template: $template_name (Type: $type)"
+
+    # Select command based on type
+    if [[ "$type" == "olm.template.basic" ]]; then
+        output=$("$TOPDIR"/bin/opm alpha render-template basic -o yaml catalog-templates/"$template_name")
+    elif [[ "$type" == "olm.semver" ]]; then
+        output=$("$TOPDIR"/bin/opm alpha render-template semver -o yaml catalog-templates/"$template_name")
+    else
+        echo "Unknown type: $type"
+        exit 1
+    fi
+
+    # Check if command succeeded
+    if [[ $? -ne 0 ]]; then
+        echo "Error processing $template_name"
+        exit 1
+    fi
+
+    # Copy output to each catalog directory
+    for catalog in $catalog_names; do
+        catalog_path="$TOPDIR/catalogs/$catalog/$OPERATOR_NAME"
+        mkdir -p "$catalog_path"
+        echo "$output" > "$catalog_path/catalog.yaml"
+        echo " ✅ Template rendered to $catalog_path/catalog.yaml"
+    done
+done


### PR DESCRIPTION
A makefile that generates FBC catalogs was previously using hard coded ocp version. This mechanism has been replaced by the new template to catalog mapping available in ci.yaml file.

When rendering a catalog using Makefile the mapping determines which catalogs are produced.

JIRA: ISV-5505

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes