### PR TITLE
Fix Makefiles for fbc operator

### DIFF
--- a/fbc/Makefile
+++ b/fbc/Makefile
@@ -67,7 +67,7 @@ catalogs: ${BINDIR}/render_catalogs.sh ${BINDIR}/opm ${BINDIR}/yq clean
 # all FBC must pass opm validation in order to be able to be used in a catalog
 .PHONY: validate-catalogs
 validate-catalogs: ${BINDIR}/opm
-	@find ${TOPDIR}/catalogs -type d -name fbc-test-operator -exec \
+	@find ${TOPDIR}/catalogs -type d -name ${OPERATOR_NAME} -exec \
 		sh -c '${BINDIR}/opm validate $$(dirname "{}") && echo "✅ Catalog validation passed: {}" || echo "❌ Catalog validation failed: {}"' \;
 
 .PHONY: create-catalog-dir


### PR DESCRIPTION
There was a copy/paste bug that uses hardcoded operator name in Makefile. This commit fixes it.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes