### PR TITLE
Add Tekton-lint to tox configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 ssh-secret.yml
 registry-secret.yml
 kubeconfig
-# results 
-test_results.json 
+# results
+test_results.json
 results_exists
 test_logs_id
 test_result_id
@@ -55,6 +55,7 @@ htmlcov/
 .nox/
 .coverage
 .coverage.*
+coverage.*
 .cache
 nosetests.xml
 coverage.xml
@@ -150,3 +151,7 @@ ansible/vault-password*
 .pdm-python
 
 integration-tests-config.yaml
+
+node_modules/
+package-lock.json
+package.json

--- a/.tektonlintrc.yaml
+++ b/.tektonlintrc.yaml
@@ -1,0 +1,8 @@
+---
+globs:
+  - ansible/roles/operator-pipeline/templates/openshift/tasks/*
+  - ansible/roles/operator-pipeline/templates/openshift/pipelines/*
+rules:
+  # Due to a historical reasons, the pipeline uses snake_case for the
+  # Tekton resources. This rule is disabled to avoid false positives.
+  prefer-kebab-case: off

--- a/.yamllint
+++ b/.yamllint
@@ -20,3 +20,4 @@ ignore:
   - .tox/
   - ansible/vaults/
   - .venv
+  - node_modules/

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -342,10 +342,6 @@ spec:
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
-        - name: bundle_version
-          value: "$(tasks.bundle-path-validation.results.bundle_version)"
-        - name: package_name
-          value: "$(tasks.bundle-path-validation.results.package_name)"
         - name: bundle_index_image
           value: *bundleIndexImage
         - name: bundle_image

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -292,10 +292,6 @@ spec:
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
-        - name: head_commit
-          value: "$(params.git_commit)"
-        - name: base_commit
-          value: "$(params.git_commit_base)"
         - name: request_url
           value: "$(params.git_pr_url)"
         - name: github_token_secret_name
@@ -935,8 +931,6 @@ spec:
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
-        - name: fbc_enabled
-          value: "$(tasks.read-config.results.fbc-enabled)"
         - name: ocp_version
           value: "$(tasks.get-supported-versions.results.max_supported_ocp_version)"
         - name: bundle_pullspec

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -197,10 +197,6 @@ spec:
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
-        - name: head_commit
-          value: "$(params.git_commit)"
-        - name: base_commit
-          value: "$(params.git_commit_base)"
         - name: request_url
           value: "$(params.git_pr_url)"
         - name: github_token_secret_name
@@ -387,10 +383,6 @@ spec:
           value: "$(tasks.detect-changes.results.added_bundle)"
         - name: cert_project_id
           value: "$(tasks.certification-project-check.results.certification_project_id)"
-        - name: public_registry
-          value: "$(params.dest_registry)"
-        - name: public_repository
-          value: "$(tasks.get-pyxis-certification-data.results.vendor_label)/$(tasks.get-pyxis-certification-data.results.repo_name)"
         - name: docker_config_file_name
           value: ".dockerconfigjson"
         - name: pyxis_url

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/acquire-lock.yaml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/acquire-lock.yaml
@@ -20,6 +20,7 @@ spec:
     - name: create-lease
       image: "$(params.pipeline_image)"
       script: |
+        #! /usr/bin/env bash
         set -xe
 
         calculate_duration_in_seconds() {

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/buildah.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/buildah.yml
@@ -57,6 +57,7 @@ spec:
       name: build
       computeResources: {}
       script: |
+        #! /usr/bin/env bash
         set -xe
 
         if [ -z "$(params.CONTEXT)" ]; then

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/copy-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/copy-image.yml
@@ -32,6 +32,7 @@ spec:
     - name: skopeo-copy
       image: "$(params.pipeline_image)"
       script: |
+        #! /usr/bin/env bash
         set -xe
 
         if [[ "$(params.dest_image_tag)" == "" ]]; then

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/get-manifest-digests.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/get-manifest-digests.yml
@@ -23,6 +23,7 @@ spec:
     - name: podman-manifest-inspect
       image: "$(params.pipeline_image)"
       script: |
+        #! /usr/bin/env bash
         set -xe
 
         ENV=$(params.environment)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
@@ -31,6 +31,7 @@ spec:
       image: "$(params.pipeline_image)"
       workingDir: $(workspaces.source.path)
       script: |
+        #! /usr/bin/env bash
         set -xe
         if [[ -z "$(params.operator_path)" ]]; then
           echo -n false > "$(results.bool_merge.path)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/parse-repo-changes.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/parse-repo-changes.yml
@@ -6,10 +6,6 @@ metadata:
 spec:
   params:
     - name: pipeline_image
-    - name: head_commit
-      description: Commit ID of the head of the PR
-    - name: base_commit
-      description: Commit ID of the base of the PR
     - name: request_url
       description: URL of the GitHub pull request we want to check
       type: string

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/preflight.yml
@@ -9,10 +9,6 @@ spec:
     - name: base_image
       default: quay.io/redhat-isv/preflight-test@sha256:2d57b1bc66de91470886762be5dfa14e48c64e3174c5c80b2c45b05906ad4c1e
       description: Preflight image used
-    - name: package_name
-      description: Package name for the Operator under test
-    - name: bundle_version
-      description: Version of the bundle under test
     - name: bundle_index_image
       description: The Operator index image which includes the bundle
     - name: bundle_image

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-pyxis-data.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-pyxis-data.yml
@@ -28,12 +28,6 @@ spec:
     - name: cert_project_id
       description: Identifier of certification project from Red Hat Connect
 
-    - name: public_registry
-      description: External hostname of the registry
-
-    - name: public_repository
-      description: External repository name (namespace/name)
-
     - name: docker_config_file_name
       description: Path to the file containing the registry credentials in json format
 
@@ -72,6 +66,7 @@ spec:
     - name: skopeo-inspect
       image: "$(params.skopeo_image)"
       script: |
+        #! /usr/bin/env bash
         set -xe
 
         IMAGE_PULL_SPEC="$(params.internal_registry)/$(params.internal_repository)@$(params.container_digest)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/release-locks.yaml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/release-locks.yaml
@@ -15,6 +15,7 @@ spec:
     - name: delete-lease
       image: "$(params.pipeline_image)"
       script: |
+        #! /usr/bin/env bash
         set -xe
 
         oc delete lease -l owner-id="$(params.lease-owner)" --ignore-not-found=true

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/tag-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/tag-image.yml
@@ -19,6 +19,7 @@ spec:
     - name: skopeo-copy
       image: "$(params.pipeline_image)"
       script: |
+        #! /usr/bin/env bash
         set -xe
 
         REF="$(params.image)"

--- a/tox.ini
+++ b/tox.ini
@@ -99,3 +99,14 @@ commands = ansible-galaxy collection install -r ansible/playbooks/requirements.y
            ansible-lint ansible/roles \
            --exclude ansible/roles/config_ocp_cluster/files \
            ansible/roles/index_signature_verification/files
+
+# Tekton lint is experimental and may not be supported in the future.
+# However, it is useful to have it here for now for manual testing.
+# It is not included in the default testenv and is not triggered by the
+# default tox command or Github Actions.
+# To run it, use `tox -e tekton-lint`
+# The linter doesn't support the tekton bundle yet, so it raises few false positives.
+# The issue is tracked here: https://github.com/IBM/tekton-lint/issues/118
+[testenv:tekton-lint]
+allowlist_externals = npx
+commands = npx @ibm/tekton-lint@latest


### PR DESCRIPTION
Tekton lint validates Tekton tasks and pipeline and suggest improvements. This commit contains a basic configuration of the linter in the tox and also fixes all violations.

The linter is not enable by the default because it crashes on definitions that uses a tekton bundles. Due to this restriction it only serves as optional tool.

JIRA: ISV-5288

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes