### PR TITLE
[ISV-5644] Fix link to GitHub PR

### DIFF
--- a/operator-pipeline-images/operatorcert/entrypoints/github_pr.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/github_pr.py
@@ -164,8 +164,8 @@ def main() -> None:  # pragma: no cover
         args.title,
         pr_body,
     )
-    url = response.get("url")
-    LOGGER.info("Pull request URL: %s", url)
+    pr_url = response.get("html_url")
+    LOGGER.info("Pull request URL: %s", pr_url)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
Ci pipeline now adds correct Github PR link.

Changes were tested [here](https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/2279) where  hosted pipeline was stopped early so it is not overwriting link in test results.


### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes