### PR TITLE
Add catalog mapping validation

### DIFF
--- a/docs/users/static_checks.md
+++ b/docs/users/static_checks.md
@@ -134,9 +134,32 @@ operator catalog(s) use allowed image registry. Allowed registries are configure
 in `(repo_root)/config.yaml` under the key `allowed_bundle_registries`.
 
 #### check_schema_bundle_release_config
-The test validates the `release-config.yaml` file against the schema. The schema
-the file including the schema is described [here](./fbc_autorelease.md#release-configyaml).
+The test validates the `release-config.yaml` file against the schema. The file description
+including the schema definition can be found [here](./fbc_autorelease.md#release-configyaml).
 
+#### check_schema_operator_ci_config
+The test validates the `ci.yaml` file against the schema. The schema definition can
+be found[here](https://github.com/redhat-openshift-ecosystem/operator-pipelines/blob/main/operator-pipeline-images/operatorcert/schemas/ci-schema.json).
+
+#### check_catalog_usage_ci_config
+The test makes sure the `fbc.catalog_mapping` in `ci.yaml` file is not mapping a single
+catalog to multiple catalog templates. The test will fail if the same catalog is used
+in multiple templates.
+
+Example of the `ci.yaml` file where `v4.14` catalog is used in two different templates.
+```yaml
+---
+fbc:
+  enabled: true
+
+  catalog_mapping:
+    - template_name: basic.yaml
+      catalog_names: ["v4.14", "v4.15", "v4.16"]
+      type: olm.template.basic
+    - template_name: semver.yaml
+      catalog_names: ["v4.13", "v4.14"] # The 4.14 is already used in the basic.yaml template
+      type: olm.semver
+```
 ## Running tests locally
 
 ```bash

--- a/operator-pipeline-images/operatorcert/schemas/ci-schema.json
+++ b/operator-pipeline-images/operatorcert/schemas/ci-schema.json
@@ -1,66 +1,79 @@
 {
-    "title": "ci.yaml validation schema",
-    "description": "json schema validating the ci.yaml",
-    "type": "object",
-    "additionaProperties": true,
-    "properties": {
-        "updateGraph": {
-            "description": "Name of the update strategy for the operator",
-            "type": "string"
+  "title": "ci.yaml validation schema",
+  "description": "json schema validating the ci.yaml",
+  "type": "object",
+  "additionaProperties": true,
+  "properties": {
+    "updateGraph": {
+      "description": "Name of the update strategy for the operator",
+      "type": "string",
+      "enum": [
+        "replaces-mode",
+        "semver-mode"
+      ]
+    },
+    "reviewers": {
+      "description": "List of authorized GitHub usernames who can approve the PR in community repository",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "merge": {
+      "description": "Flag that determines whether the PR is set to auto-merge. Valid only for Red Hat ISVs.",
+      "type": "boolean"
+    },
+    "cert_project_id": {
+      "description": "Certification Project ID linked with the operator.  Valid only for Red Hat ISVs.",
+      "type": "string"
+    },
+    "fbc": {
+      "description": "Config set for FBC-enabled operator bundles",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Flag that determines whether the operator uses FBC delivery method",
+          "type": "boolean"
         },
-        "reviewers": {
-            "description": "List of authorized GitHub usernames",
-            "type": "array",
-            "items": {
-                "type": "string"
-            },
-            "minItems": 1
-        },
-        "merge": {
-            "description": "Flag that determines whether the PR is set to auto-merge",
-            "type": "boolean"
-        },
-        "cert_project_id": {
-            "description": "Certification Project ID linked with the operator",
-            "type": "string"
-        },
-        "fbc": {
-            "description": "Config set for FBC-enabled operator bundles",
+        "catalog_mapping": {
+          "description": "Catalog Mapping according to provided templates types",
+          "type": "array",
+          "items": {
             "type": "object",
             "properties": {
-                "enabled": {
-                    "description": "Flag that determines whether the operator uses FBC delivery method",
-                    "type": "boolean"
-                },
-                "catalog_mapping": {
-                    "description": "Catalog Mapping accoering to provided templates types",
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "template_name": {
-                                "description": "Name of the catalog template file",
-                                "type": "string"
-                            },
-                            "catalog_names": {
-                                "description": "List of the catalogs",
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                },
-                                "minItems": 1
-                            },
-                            "type": {
-                                "description": "Type of template schema",
-                                "type": "string",
-                                "enum": ["olm.template.basic", "olm.semver"]
-                            }
-                        },
-                        "required": [ "template_name", "type", "catalog_names" ]
-                    }
+              "template_name": {
+                "description": "Name of the catalog template file within the ./catalog-templates directory",
+                "type": "string"
+              },
+              "catalog_names": {
+                "description": "List of the catalogs as defined in /catalogs directory",
+                "uniqueItems": true,
+                "type": "array",
+                "items": {
+                  "type": "string"
                 },
                 "minItems": 1
-            }
+              },
+              "type": {
+                "description": "Type of olm template schema",
+                "type": "string",
+                "enum": [
+                  "olm.template.basic",
+                  "olm.semver"
+                ]
+              }
+            },
+            "required": [
+              "template_name",
+              "type",
+              "catalog_names"
+            ]
+          }
         }
+      }
     }
+  }
 }
+

--- a/operator-pipeline-images/operatorcert/schemas/release-config-schema.json
+++ b/operator-pipeline-images/operatorcert/schemas/release-config-schema.json
@@ -1,6 +1,7 @@
 {
   "title": "release-config.yaml schema",
   "description": "json schema for release-config.yaml",
+  "additionalProperties": false,
   "type": "object",
   "properties": {
     "merge": {
@@ -44,11 +45,17 @@
             "type": "string"
           }
         },
-        "required": [ "template_name", "channels" ]
+        "required": [
+          "template_name",
+          "channels"
+        ]
       },
       "minItems": 1,
       "uniqueItems": true
     }
   },
-  "required": [ "catalog_templates" ]
+  "required": [
+    "catalog_templates"
+  ]
 }
+

--- a/operator-pipeline-images/operatorcert/static_tests/common/operator.py
+++ b/operator-pipeline-images/operatorcert/static_tests/common/operator.py
@@ -2,15 +2,15 @@
 
 import json
 import os
-
+from collections import defaultdict
 from collections.abc import Iterator
-from jsonschema.validators import Draft202012Validator
 
+from jsonschema.validators import Draft202012Validator
 from operator_repo import Operator
 from operator_repo.checks import CheckResult, Fail
 
 
-def check_validate_schema_ci_config(
+def check_schema_operator_ci_config(
     operator: Operator,
 ) -> Iterator[CheckResult]:
     """
@@ -28,3 +28,27 @@ def check_validate_schema_ci_config(
             "Operator's 'ci.yaml' contains invalid data "
             f"which does not comply with the schema: {ve.message}"
         )
+
+
+def check_catalog_usage_ci_config(operator: Operator) -> Iterator[CheckResult]:
+    """
+    Check if the catalog mapping in the ci.yaml is consistent and
+    does not contain duplicates or multiple templates for the same catalog.
+    """
+    fbc_catalog_mapping = operator.config.get("fbc", {}).get("catalog_mapping", [])
+    if not fbc_catalog_mapping:
+        return
+    catalog_to_template_mapping: dict[str, list[str]] = defaultdict(list)
+    for template in fbc_catalog_mapping:
+        catalogs = template.get("catalog_names", [])
+        template_name = template.get("template_name")
+
+        for catalog in catalogs:
+            catalog_to_template_mapping[catalog].append(template_name)
+
+    for catalog, templates in catalog_to_template_mapping.items():
+        if len(templates) > 1:
+            yield Fail(
+                f"Operator's 'ci.yaml' contains multiple templates '{templates}' "
+                f"for the same catalog '{catalog}'."
+            )

--- a/operator-pipeline-images/tests/static_tests/common/test_bundle.py
+++ b/operator-pipeline-images/tests/static_tests/common/test_bundle.py
@@ -503,6 +503,12 @@ def test_check_bundle_release_config(
                     "which does not comply with the schema: "
                     "'catalog_templates' is a required property",
                 ),
+                (
+                    Fail,
+                    "Bundle's 'release-config.yaml' contains invalid data which does not "
+                    "comply with the schema: Additional properties are not allowed ('key' "
+                    "was unexpected)",
+                ),
             },
             id="fail: release config without catalog_templates",
         ),

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "operatorcert-dev", "tox"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:c3980d49c0faded3fcf7b7f57f48dd473c897ee117ad5f3a88c23712d297d684"
+content_hash = "sha256:d32b7a87f705a713d9c90ccec15848511c83155e55d0fb2d7b63e832fe3f69f3"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -1221,11 +1221,11 @@ files = [
 
 [[package]]
 name = "operator-repo"
-version = "0.4.11"
+version = "0.4.12"
 requires_python = ">=3.9"
 git = "https://github.com/mporrato/operator-repo.git"
-ref = "v0.4.11"
-revision = "a8f91489019730024df156b8403c6506e826cb6d"
+ref = "v0.4.12"
+revision = "b0d2185b2c356a6fd0dc50b716e30d385479ce74"
 summary = "Library and utilities to handle repositories of kubernetes operators"
 groups = ["default"]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "PyGithub<2.0,>=1.59.0",
     "GitPython>=3.1.37",
     "semver>=3.0.1",
-    "operator-repo @ git+https://github.com/mporrato/operator-repo.git@v0.4.11",
+    "operator-repo @ git+https://github.com/mporrato/operator-repo.git@v0.4.12",
     "urllib3>=2.2.2",
     "openshift-client>=2.0.4",
     "pydantic>=2.10.0",


### PR DESCRIPTION
There are couple of rules for the catalog mapping from ci.yaml file now:
 - catalog names can't contain duplicated entries
 - catalog can't be use in relation to multiple templates

On top of the new validation there is also additional rule that doesn't allow additional properties in release-config.yaml file.

JIRA: ISV-5503

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes