### PR TITLE
Link catalog PR in summary comment

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -1229,6 +1229,9 @@ spec:
         - name: source
           workspace: repository
           subPath: src
+        - name: output
+          workspace: results
+          subPath: summary
 
     # merge PR
     - name: merge-pr

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -712,6 +712,9 @@ spec:
         - name: source
           workspace: repository
           subPath: src
+        - name: output
+          workspace: results
+          subPath: summary
         - name: ssh-directory
           workspace: ssh-dir
 

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-fbc.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-fbc.yml
@@ -53,6 +53,8 @@ spec:
 
   workspaces:
     - name: source
+    - name: output
+      description: Scratch space and storage for the comment and related data
     - name: ssh-directory
       optional: true
 
@@ -154,9 +156,12 @@ spec:
         If you have any questions or need modifications, please let us know!
         EOL
 
+        mkdir -p "$(workspaces.output.path)/release_info"
         # A new pull request is created with FBC addition
         gh pr create \
           --base "$(params.git_base_branch)" \
           --head $FBC_UPDATE_BRANCH \
           --title "Auto FBC release $(params.operator_name) $(params.operator_version)" \
-          --body-file pr_comment.md
+          --body-file pr_comment.md > "$(workspaces.output.path)/release_info/fbc_pr_url.txt"
+
+        echo "FBC PR created: $(cat "$(workspaces.output.path)/release_info/fbc_pr_url.txt")"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
@@ -160,7 +160,18 @@ spec:
           # Add info how to update catalog for FBC bundles
           if [[ "$fbc_enabled" == "true" && -f "$RELEASE_INFO_DIR_PATH/released_bundle.txt" ]]; then
             echo -e "\n## Catalog update\n" >> "$PR_NAME/comment.md"
-            echo -e "Operator bundle using FBC mode has been released.\nTo add bundle to FBC templates, follow [this guide](https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_workflow/#adding-new-bundle-to-catalog) to create a new PR with catalog changes." >> "$PR_NAME/comment.md"
+            if [[ -f "$RELEASE_INFO_DIR_PATH/fbc_pr_url.txt" ]]; then
+              PR_URL=$(cat "$RELEASE_INFO_DIR_PATH/fbc_pr_url.txt")
+
+              cat >> "$PR_NAME/comment.md" <<EOF
+        Automated release to the File-Based Catalog has been enabled for this bundle
+
+        A new pull request has been created to update the catalog with the new bundle. You can find the PR here: $PR_URL.
+        EOF
+
+            else
+              echo -e "Operator bundle using FBC mode has been released.\nTo add bundle to FBC templates, follow [this guide](https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_workflow/#adding-new-bundle-to-catalog) to create a new PR with catalog changes." >> "$PR_NAME/comment.md"
+            fi
           fi
         fi
 


### PR DESCRIPTION
When a release pipeline opens a new pull request with a catalog changes the summary comment now contains a information and link to the new PR instead of manual instruction.

The comment is only visible when auto-release is enabled.

JIRA: ISV-5662

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes