### PR TITLE
Create channel if not exists in basic template

### DIFF
--- a/operator-pipeline-images/tests/entrypoints/test_add_bundle_to_fbc.py
+++ b/operator-pipeline-images/tests/entrypoints/test_add_bundle_to_fbc.py
@@ -113,7 +113,7 @@ def test_BasicCatalogTemplate_amend(
     basic_catalog_template: add_bundle_to_fbc.BasicTemplate,
 ) -> None:
     release_config = {
-        "channels": ["alpha"],
+        "channels": ["alpha", "beta"],
         "replaces": "fake-replaces",
         "skipRange": "fake-range",
         "skips": "fake-skips",
@@ -173,6 +173,22 @@ def test_BasicCatalogTemplate_amend(
             {
                 "image": "quay.io/fake-bundle:1",
                 "schema": "olm.bundle",
+            },
+            {
+                "entries": [
+                    {
+                        "name": "fake-bundle-2",
+                        # Values below don't make sense
+                        # in the context of the catalog graph but it covers the
+                        # usecase of adding a bundle to new channel
+                        "replaces": "fake-replaces",
+                        "skipRange": "fake-range",
+                        "skips": "fake-skips",
+                    },
+                ],
+                "name": "beta",
+                "package": "fake-operator",
+                "schema": "olm.channel",
             },
             {
                 "image": "quay.io/fake-bundle:2",


### PR DESCRIPTION
The auto-release FBC script skipped channels in case they didn't exist. The new code change checks if a requested channel given by the release config exists and if not, create it and add a bundle to it.

JIRA: ISV-5670

Closes #791

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes