### PR TITLE
fix: merge default and channels in check_pruned_graph check

### DIFF
--- a/operator-pipeline-images/operatorcert/static_tests/isv/bundle.py
+++ b/operator-pipeline-images/operatorcert/static_tests/isv/bundle.py
@@ -32,6 +32,9 @@ def check_pruned_graph(bundle: Bundle) -> Iterator[CheckResult]:
 
     if skip_range and not replaces:
         channels = bundle.channels
+        if bundle.default_channel:
+            channels.add(bundle.default_channel)
+
         operator = bundle.operator
 
         for channel in channels:


### PR DESCRIPTION
The check skipped the default channel when checking for pruned update graph. This caused the test to skip certain corner cases when pipeline let graph to be pruned.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes