### PR TITLE
Merge operator_repo library into operator-pipelines repo

### DIFF
--- a/operator-pipeline-images/operatorcert/entrypoints/add_bundle_to_fbc.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/add_bundle_to_fbc.py
@@ -8,9 +8,9 @@ import os
 from abc import ABC, abstractmethod
 from typing import Any
 
-from operator_repo import Bundle, Operator, Repo
 from operatorcert import utils
 from operatorcert.logger import setup_logger
+from operatorcert.operator_repo import Bundle, Operator, Repo
 from ruamel.yaml import YAML
 
 LOGGER = logging.getLogger("operator-cert")
@@ -146,7 +146,7 @@ class CatalogTemplate(ABC):
             self.template_type,
             "-o",
             "yaml",
-            self.template_path,
+            str(self.template_path),
         ]
 
         response = utils.run_command(command)
@@ -228,11 +228,11 @@ class BasicTemplate(CatalogTemplate):
             "name": self.operator.operator_name,
             "defaultChannel": channels[0]["name"],
         }
-        bundle = {"schema": "olm.bundle", "image": bundle_pullspec}
+        bundle_obj = {"schema": "olm.bundle", "image": bundle_pullspec}
 
         self._template = {
             "schema": "olm.template.basic",
-            "entries": [package] + channels + [bundle],
+            "entries": [package] + channels + [bundle_obj],
         }
 
     @staticmethod

--- a/operator-pipeline-images/operatorcert/entrypoints/build_scratch_catalog.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/build_scratch_catalog.py
@@ -7,9 +7,9 @@ import tempfile
 from typing import Any
 
 import yaml
-from operator_repo import Repo, Bundle
 from operatorcert import buildah, opm
 from operatorcert.logger import setup_logger
+from operatorcert.operator_repo import Bundle, Repo
 
 LOGGER = logging.getLogger("operator-cert")
 

--- a/operator-pipeline-images/operatorcert/entrypoints/check_permissions.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/check_permissions.py
@@ -8,10 +8,10 @@ import urllib
 from typing import Any
 
 from github import Auth, Github, UnknownObjectException
-from operator_repo import Operator
-from operator_repo import Repo as OperatorRepo
 from operatorcert import pyxis
 from operatorcert.logger import setup_logger
+from operatorcert.operator_repo import Operator
+from operatorcert.operator_repo import Repo as OperatorRepo
 from operatorcert.utils import run_command
 
 LOGGER = logging.getLogger("operator-cert")
@@ -380,9 +380,9 @@ def extract_operators_from_catalog(
     """
     operators = set()
     for catalog_operator in catalog_operators:
-        catalog, operator = catalog_operator.split("/")
+        catalog, operator_name = catalog_operator.split("/")
         # We need to get the operator from the catalog to get the actual operator
-        operator = head_repo.catalog(catalog).operator_catalog(operator).operator
+        operator = head_repo.catalog(catalog).operator_catalog(operator_name).operator
         operators.add(operator)
     return operators
 

--- a/operator-pipeline-images/operatorcert/entrypoints/detect_changed_operators.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/detect_changed_operators.py
@@ -9,8 +9,8 @@ import re
 from typing import Optional
 
 from github import Auth, Github
-from operator_repo import Repo as OperatorRepo
 from operatorcert.logger import setup_logger
+from operatorcert.operator_repo import Repo as OperatorRepo
 from operatorcert.parsed_file import (
     AffectedBundleCollection,
     AffectedCatalogCollection,

--- a/operator-pipeline-images/operatorcert/entrypoints/fbc_onboarding.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/fbc_onboarding.py
@@ -7,8 +7,8 @@ from typing import Any, Dict, Optional
 
 import requests
 import yaml
-from operator_repo import Operator, Repo
 from operatorcert.logger import setup_logger
+from operatorcert.operator_repo import Operator, Repo
 from operatorcert.utils import run_command
 
 LOGGER = logging.getLogger("operator-cert")
@@ -246,9 +246,9 @@ def render_fbc_from_template(operator: Operator, version: str) -> None:
             "basic",
             "-o",
             "yaml",
-            os.path.join(operator.root, CATALOG_TEMPLATES_DIR, f"v{version}.yaml"),
+            os.path.join(str(operator.root), CATALOG_TEMPLATES_DIR, f"v{version}.yaml"),
         ],
-        cwd=operator.root,
+        cwd=str(operator.root),
     )
 
     catalogs_path = os.path.join(operator.root, "../../catalogs")

--- a/operator-pipeline-images/operatorcert/entrypoints/preflight_result_filter.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/preflight_result_filter.py
@@ -6,8 +6,8 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from operatorcert.logger import setup_logger
+from operatorcert.operator_repo import Repo as OperatorRepo
 from operatorcert.utils import SplitArgs
-from operator_repo import Repo as OperatorRepo
 
 LOGGER = logging.getLogger("operator-cert")
 

--- a/operator-pipeline-images/operatorcert/entrypoints/static_tests.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/static_tests.py
@@ -5,9 +5,9 @@ import json
 import logging
 from typing import Any, Dict, List, Optional
 
-from operator_repo import Repo, OperatorCatalogList
-from operator_repo.checks import Fail, run_suite
 from operatorcert.logger import setup_logger
+from operatorcert.operator_repo import OperatorCatalogList, Repo
+from operatorcert.operator_repo.checks import Fail, run_suite
 from operatorcert.utils import SplitArgs
 
 LOGGER = logging.getLogger("operator-cert")
@@ -70,7 +70,7 @@ def get_objects_to_test(
     Returns:
         List[Any]: List of objects to test
     """
-    test_objects = []
+    test_objects: list[Any] = []
 
     # In case any of the resources is being removed in the pull request
     # We need to skip the test for that resource

--- a/operator-pipeline-images/operatorcert/operator_repo/__init__.py
+++ b/operator-pipeline-images/operatorcert/operator_repo/__init__.py
@@ -1,0 +1,14 @@
+"""
+A main module for operator_repo sub package
+"""
+
+from .core import Bundle, Catalog, Operator, OperatorCatalog, OperatorCatalogList, Repo
+
+__all__ = [
+    "Repo",
+    "Operator",
+    "Bundle",
+    "Catalog",
+    "OperatorCatalog",
+    "OperatorCatalogList",
+]

--- a/operator-pipeline-images/operatorcert/operator_repo/checks/__init__.py
+++ b/operator-pipeline-images/operatorcert/operator_repo/checks/__init__.py
@@ -1,0 +1,162 @@
+"""
+A test suite for operator repositories
+"""
+
+import importlib
+import logging
+import traceback
+from collections.abc import Callable, Iterable
+from inspect import getmembers, isfunction
+from typing import Any, List, Optional, Union
+
+from .. import Bundle, Operator, OperatorCatalogList, Repo
+
+log = logging.getLogger(__name__)
+
+
+class CheckResult:
+    """
+    Generic result from a static check
+    """
+
+    severity: int = 0
+    kind: str = "unknown"
+    check: Optional[str]
+    origin: Optional[Union[Repo, Operator, Bundle]]
+    reason: str
+
+    def __init__(
+        self,
+        reason: str,
+        check: Optional[str] = None,
+        origin: Optional[Union[Repo, Operator, Bundle]] = None,
+    ):
+        self.origin = origin
+        self.check = check
+        self.reason = reason
+
+    def __str__(self) -> str:
+        return f"{self.kind}: {self.check}({self.origin}): {self.reason}"
+
+    def __repr__(self) -> str:
+        return f"{self.kind}({self.check}, {self.origin}, {self.reason})"
+
+    def __int__(self) -> int:
+        return self.severity
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+        return (self.kind, self.reason, self.check, self.origin) == (
+            other.kind,
+            other.reason,
+            other.check,
+            other.origin,
+        )
+
+    def __ne__(self, other: Any) -> bool:
+        return not self == other
+
+    def __lt__(self, other: Any) -> bool:
+        return int(self) < int(other)
+
+    def __hash__(self) -> int:
+        return hash((self.kind, self.reason, self.check, self.origin))
+
+
+class Warn(CheckResult):
+    """
+    A non-fatal problem
+    """
+
+    # pylint: disable=too-few-public-methods
+    severity = 40
+    kind = "warning"
+
+
+class Fail(CheckResult):
+    """
+    A critical problem
+    """
+
+    # pylint: disable=too-few-public-methods
+    severity = 90
+    kind = "failure"
+
+
+SUPPORTED_TYPES = [
+    ("operator", Operator),
+    ("operator_catalogs", OperatorCatalogList),
+    ("bundle", Bundle),
+]
+Check = Callable[
+    [Union[Repo, Operator, OperatorCatalogList, Bundle]], Iterable[CheckResult]
+]
+
+
+def get_checks(
+    suite_name: str = "operatorcert.operator_repo.checks",
+    skip_tests: Optional[List[str]] = None,
+) -> dict[str, list[Check]]:
+    """
+    Return all the discovered checks in the given suite, grouped by resource type
+    """
+    if skip_tests is None:
+        skip_tests = []
+    result: dict[str, list[Check]] = {}
+    for module_name, _ in SUPPORTED_TYPES:
+        result[module_name] = []
+        try:
+            module = importlib.import_module(f"{suite_name}.{module_name}")
+            for check_name, check in getmembers(module, isfunction):
+                if check_name.startswith("check_"):
+                    log.debug(
+                        "Detected %s check with name %s in %s",
+                        module_name,
+                        check_name,
+                        suite_name,
+                    )
+                    if check_name in skip_tests:
+                        log.debug("Skipping %s check", check_name)
+                        continue
+                    result[module_name].append(check)
+        except ModuleNotFoundError:
+            pass
+    return result
+
+
+def run_check(
+    check: Check, target: Union[Repo, Operator, Bundle]
+) -> Iterable[CheckResult]:
+    """
+    Run a check against a resource yielding all the problems found
+    """
+    log.debug("Running %s check on %s", check.__name__, target)
+    try:
+        for result in check(target):
+            result.check = check.__name__
+            result.origin = target
+            yield result
+    except Exception:  # pylint: disable=broad-except
+        log.exception("Error running %s check on %s", check.__name__, target)
+        yield Fail(
+            traceback.format_exc(),
+            check=check.__name__,
+            origin=target,
+        )
+
+
+def run_suite(
+    targets: Iterable[Union[Repo, Operator, Bundle]],
+    suite_name: str = "operatorcert.operator_repo.checks",
+    skip_tests: Optional[list[str]] = None,
+) -> Iterable[CheckResult]:
+    """
+    Run all the checks in a suite against a collection of resources
+    """
+    checks = get_checks(suite_name, skip_tests=skip_tests)
+    for target in targets:
+        for target_type_name, target_type in SUPPORTED_TYPES:
+            if isinstance(target, target_type):
+                for check in checks.get(target_type_name, []):
+                    yield from run_check(check, target)

--- a/operator-pipeline-images/operatorcert/operator_repo/cli.py
+++ b/operator-pipeline-images/operatorcert/operator_repo/cli.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+CLI tool to handle operator repositories
+"""
+
+import argparse
+import logging
+import sys
+from collections.abc import Iterator
+from itertools import chain
+from pathlib import Path
+from typing import Optional, Union
+
+from .checks import get_checks, run_suite
+from .core import Bundle, Operator, Repo
+from .exceptions import OperatorRepoException
+
+
+def parse_target(repo: Repo, target: str) -> Union[Operator, Bundle]:
+    """
+    Parse a target string and return the corresponding object
+
+    Args:
+        repo (Repo): Operator repository objects
+        target (str): A string representing an operator or bundle
+
+    Returns:
+        Union[Operator, Bundle]: An operator or bundle object given the target string
+    """
+    if "/" in target:
+        operator_name, operator_version = target.split("/", 1)
+        return repo.operator(operator_name).bundle(operator_version)
+    return repo.operator(target)
+
+
+def indent(depth: int) -> str:
+    """
+    Indentation helper
+
+    Args:
+        depth (int): A depth level of the indentation
+
+    Returns:
+        str: An indentation string
+    """
+    return "  " * depth
+
+
+def show_repo(repo: Repo, recursive: bool = False, depth: int = 0) -> None:
+    """
+    Show the contents of the repository
+
+    Args:
+        repo (Repo): An instance of the Repo class
+        recursive (bool, optional): A flag determins if a print goes to deeper level.
+        Defaults to False.
+        depth (int, optional): A current recusion depth. Defaults to 0.
+    """
+    print(indent(depth) + str(repo))
+    for operator in repo:
+        if recursive:
+            show_operator(operator, recursive, depth + 1)
+        else:
+            print(indent(depth + 1) + str(operator))
+
+
+def show_operator(operator: Operator, recursive: bool = False, depth: int = 0) -> None:
+    """
+    Show the contents of the operator
+
+    Args:
+        operator (Operator): An instance of the Operator class
+        recursive (bool, optional): A flag determins if a print goes to deeper level.
+        Defaults to False.
+        depth (int, optional): A current recusion depth. Defaults to 0.
+    """
+    print(indent(depth) + str(operator))
+    for bundle in operator:
+        if recursive:
+            show_bundle(bundle, depth + 1)
+        else:
+            print(indent(depth + 1) + str(bundle))
+    # list also the operator catalogs if exist
+    for operator_catalog in operator.all_operator_catalogs():
+        print(indent(depth + 1) + str(operator_catalog))
+
+
+def show_bundle(bundle: Bundle, depth: int = 0) -> None:
+    """
+    Show the contents of the bundle
+
+    Args:
+        bundle (Bundle): An instance of the Bundle class
+        depth (int, optional): A current recusion depth. Defaults to 0.
+    """
+    print(indent(depth) + str(bundle))
+    csv_annotations = bundle.csv.get("metadata", {}).get("annotations", {})
+    info = [
+        ("Description", csv_annotations.get("description", "")),
+        ("Name", f"{bundle.csv_operator_name}.v{bundle.csv_operator_version}"),
+        ("Channels", ", ".join(bundle.channels)),
+        ("Default channel", bundle.default_channel),
+        ("Container image", csv_annotations.get("containerImage", "")),
+        ("Replaces", bundle.csv.get("spec", {}).get("replaces", "")),
+        ("Skips", bundle.csv.get("spec", {}).get("skips", [])),
+    ]
+    max_width = max(len(key) for key, _ in info)
+    for key, value in info:
+        message = f"{key.ljust(max_width + 1)}: {value}"
+        print(indent(depth + 1) + message)
+
+
+def show(target: Union[Repo, Operator, Bundle], recursive: bool = False) -> None:
+    """
+    Show the contents of the target
+
+    Args:
+        target (Union[Repo, Operator, Bundle]): An instance of the Repo, Operator
+        or Bundle class
+        recursive (bool, optional): A recusive flag. Defaults to False.
+    """
+    if isinstance(target, Repo):
+        show_repo(target, recursive, 0)
+    elif isinstance(target, Operator):
+        show_operator(target, recursive, 1 * recursive)
+    elif isinstance(target, Bundle):
+        show_bundle(target, 2 * recursive)
+
+
+def action_list(repo: Repo, *what: str, recursive: bool = False) -> None:
+    """
+    List the contents of the repository
+
+    Args:
+        repo (Repo): An instance of the Repo class
+        what (str): A list of names of the operators or bundles to list
+        recursive (bool, optional): A recursion flag. Defaults to False.
+    """
+    if what:
+        targets: Iterator[Union[Repo, Operator, Bundle]] = (
+            parse_target(repo, x) for x in what
+        )
+    else:
+        targets = iter([repo])
+    for target in targets:
+        show(target, recursive)
+
+
+def _walk(target: Union[Operator, Bundle]) -> Iterator[Union[Operator, Bundle]]:
+    """
+    Walk through the target and yield all operators and bundles
+
+    Args:
+        target (Union[Operator, Bundle]): An instance of the Operator or Bundle class
+
+    Yields:
+        Iterator[Union[Operator, Bundle]]: An operator or bundle object
+    """
+    yield target
+    if isinstance(target, Operator):
+        yield from target.all_bundles()
+
+
+def action_check(repo: Repo, suite: str, *what: str, recursive: bool = False) -> None:
+    """
+    Check the validity of the operators or bundles
+
+    Args:
+        repo (Repo): An instance of the Repo class
+        suite (str): A path to the check suite
+        recursive (bool, optional): Recusion flag. Defaults to False.
+    """
+    if what:
+        targets: Iterator[Union[Operator, Bundle]] = (
+            parse_target(repo, x) for x in what
+        )
+    else:
+        targets = repo.all_operators()
+    if recursive:
+        all_targets: Iterator[Union[Operator, Bundle]] = chain.from_iterable(
+            _walk(x) for x in targets
+        )
+    else:
+        all_targets = targets
+    for result in run_suite(all_targets, suite_name=suite):
+        print(result)
+
+
+def action_check_list(suite: str) -> None:
+    """
+    List available checks
+
+    Args:
+        suite (str): A path to the check suite
+    """
+    for check_type_name, checks in get_checks(suite).items():
+        print(f"{check_type_name} checks:")
+        for check in checks:
+            display_name = check.__name__.removeprefix("check_")
+            print(f" - {display_name}: {check.__doc__}")
+
+
+def _get_repo(path: Optional[Path] = None) -> Repo:
+    """
+    Get an instance of the Repo class from the given path
+
+    Args:
+        path (Optional[Path], optional): A local path to repository. Defaults to None.
+
+    Returns:
+        Repo: A Repo object
+    """
+    if not path:
+        path = Path.cwd()
+    try:
+        return Repo(path)
+    except OperatorRepoException:
+        print(f"{path} is not a valid operator repository")
+        sys.exit(1)
+
+
+def main() -> None:
+    """
+    Main function for the CLI tool
+    """
+    main_parser = argparse.ArgumentParser(
+        description="Operator repository manipulation tool",
+    )
+    main_parser.add_argument(
+        "-r", "--repo", help="path to the root of the operator repository", type=Path
+    )
+    main_parser.add_argument(
+        "-v", "--verbose", action="count", default=0, help="increase log verbosity"
+    )
+    main_subparsers = main_parser.add_subparsers(dest="action")
+
+    # list
+    list_parser = main_subparsers.add_parser(
+        "list", aliases=["ls"], help="list contents of repo, operators or bundles"
+    )
+    list_parser.add_argument(
+        "-R", "--recursive", action="store_true", help="descend the tree"
+    )
+    list_parser.add_argument(
+        "target",
+        nargs="*",
+        help="name of the repos or bundles to list; if omitted, list the contents of the repo",
+    )
+
+    # check_bundle
+    check_parser = main_subparsers.add_parser(
+        "check",
+        help="check validity of an operator or bundle",
+    )
+    check_parser.add_argument(
+        "-s",
+        "--suite",
+        default="operatorcert.static_tests.common",
+        help="check suite to use",
+    )
+    check_parser.add_argument(
+        "-l", "--list", action="store_true", help="list available checks"
+    )
+    check_parser.add_argument(
+        "-R", "--recursive", action="store_true", help="descend the tree"
+    )
+    check_parser.add_argument(
+        "target",
+        nargs="*",
+        help="name of the operators or bundles to check",
+    )
+
+    args = main_parser.parse_args()
+
+    verbosity = {0: logging.ERROR, 1: logging.WARNING, 2: logging.INFO}
+    log = logging.getLogger(__package__)
+    log.setLevel(verbosity.get(args.verbose, logging.DEBUG))
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(name)-12s %(levelname)-8s %(message)s")
+    )
+    log.addHandler(handler)
+
+    if args.action in ("list", "ls"):
+        action_list(_get_repo(args.repo), *args.target, recursive=args.recursive)
+    elif args.action == "check":
+        if args.list:
+            action_check_list(args.suite)
+        else:
+            action_check(
+                _get_repo(args.repo),
+                args.suite,
+                *args.target,
+                recursive=args.recursive,
+            )
+    else:
+        main_parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/operator-pipeline-images/operatorcert/operator_repo/core.py
+++ b/operator-pipeline-images/operatorcert/operator_repo/core.py
@@ -1,0 +1,964 @@
+"""
+Definition of Repo, Operator, Bundle, Catalog and CatalogOperator classes
+"""
+
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from functools import cached_property, total_ordering
+from pathlib import Path
+from typing import Any, Optional, SupportsIndex, Union
+
+from semantic_version import NpmSpec, Version
+
+from .exceptions import (
+    InvalidBundleException,
+    InvalidCatalogException,
+    InvalidOperatorCatalogException,
+    InvalidOperatorException,
+    InvalidRepoException,
+)
+from .utils import load_multidoc_yaml, load_yaml
+
+log = logging.getLogger(__name__)
+
+
+@total_ordering
+class Bundle:
+    """
+    An operator bundle as specified in
+    https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md
+    """
+
+    METADATA_DIR = "metadata"
+    MANIFESTS_DIR = "manifests"
+
+    def __init__(
+        self, bundle_path: Union[str, Path], operator: Optional["Operator"] = None
+    ):
+        log.debug("Loading bundle at %s", bundle_path)
+        self._bundle_path = Path(bundle_path).resolve()
+        if not self.probe(self._bundle_path):
+            raise InvalidBundleException(f"Not a valid bundle: {self._bundle_path}")
+        self.operator_version = self._bundle_path.name
+        self.operator_name = self._bundle_path.parent.name
+        self._manifests_path = self._bundle_path / self.MANIFESTS_DIR
+        self._metadata_path = self._bundle_path / self.METADATA_DIR
+        self._parent = operator
+
+    @cached_property
+    def annotations(self) -> dict[str, Any]:
+        """
+        :return: The content of the "annotations" field in metadata/annotations.yaml
+        """
+        return self.load_metadata("annotations.yaml").get("annotations", {}) or {}
+
+    @cached_property
+    def dependencies(self) -> list[Any]:
+        """
+        :return: The content of the "dependencies" field in metadata/dependencies.yaml
+        """
+        return self.load_metadata("dependencies.yaml").get("dependencies", []) or []
+
+    @cached_property
+    def csv(self) -> dict[str, Any]:
+        """
+        :return: The content of the CSV file for the bundle
+        """
+        csv = load_yaml(self.csv_file_name)
+        if not isinstance(csv, dict):
+            raise InvalidBundleException(f"Invalid CSV contents ({self.csv_file_name})")
+        return csv
+
+    @cached_property
+    def release_config(self) -> Any:
+        """
+        :return: The content of the "release-config.yaml" file in the bundle directory
+        """
+        path = self._bundle_path / "release-config.yaml"
+        if not path.is_file():
+            return None
+        return load_yaml(path)
+
+    @property
+    def metadata_operator_name(self) -> str:
+        """
+        :return: The operator name as defined in the annotations file
+        """
+        return str(
+            self.annotations.get("operators.operatorframework.io.bundle.package.v1", "")
+        )
+
+    @cached_property
+    def csv_full_name(self) -> tuple[str, str]:
+        """
+        :return: A tuple containing operator name and bundle version
+        extracted from the bundle's csv file
+        """
+        try:
+            csv_full_name = self.csv["metadata"]["name"]
+            name, version = csv_full_name.split(".", 1)
+            return name, version.lstrip("v")
+        except (KeyError, ValueError) as exc:
+            raise InvalidBundleException(
+                f"CSV for {self} has invalid .metadata.name"
+            ) from exc
+
+    @property
+    def csv_operator_name(self) -> str:
+        """
+        :return: The operator name from the csv file
+        """
+        name, _ = self.csv_full_name
+        return name
+
+    @property
+    def csv_operator_version(self) -> str:
+        """
+        :return: The bundle version from the csv file
+        """
+        _, version = self.csv_full_name
+        return version
+
+    @classmethod
+    def probe(cls, path: Path) -> bool:
+        """
+        :return: True if path looks like a bundle
+        """
+        return (
+            path.is_dir()
+            and (path / cls.MANIFESTS_DIR).is_dir()
+            and (path / cls.METADATA_DIR).is_dir()
+        )
+
+    @property
+    def root(self) -> Path:
+        """
+        :return: The path to the root of the bundle
+        """
+        return self._bundle_path
+
+    @property
+    def operator(self) -> "Operator":
+        """
+        :return: The Operator object the bundle belongs to
+        """
+        if self._parent is None:
+            self._parent = Operator(self._bundle_path.parent)
+        return self._parent
+
+    def load_metadata(self, filename: str) -> dict[str, Any]:
+        """
+        Load and parse a yaml file from the metadata directory of the bundle
+        :param filename: Name of the file
+        :return: The parsed content of the file
+        """
+        try:
+            content = load_yaml(self._metadata_path / filename)
+            if not isinstance(content, dict):
+                if content is None:
+                    return {}
+                raise InvalidBundleException(f"Invalid {filename} contents")
+            return content
+        except FileNotFoundError:
+            return {}
+
+    @cached_property
+    def csv_file_name(self) -> Path:
+        """
+        :return: The path of the CSV file for the bundle
+        """
+        for suffix in ["yaml", "yml"]:
+            try:
+                return next(
+                    self._manifests_path.glob(f"*.clusterserviceversion.{suffix}")
+                )
+            except StopIteration:
+                continue
+        raise InvalidBundleException(
+            f"CSV file for {self.operator_name}/{self.operator_version} not found"
+        )
+
+    @property
+    def channels(self) -> set[str]:
+        """
+        :return: Set of channels the bundle belongs to
+        """
+        try:
+            return {
+                x.strip()
+                for x in self.annotations[
+                    "operators.operatorframework.io.bundle.channels.v1"
+                ].split(",")
+            }
+        except KeyError:
+            return set()
+
+    @property
+    def default_channel(self) -> Optional[str]:
+        """
+        :return: Default channel for the bundle
+        """
+        try:
+            return str(
+                self.annotations[
+                    "operators.operatorframework.io.bundle.channel.default.v1"
+                ]
+            ).strip()
+        except KeyError:
+            return None
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+        if self.csv_operator_name != other.csv_operator_name:
+            return False
+        try:
+            return Version(  # type: ignore
+                self.csv_operator_version.lstrip("v")
+            ) == Version(other.csv_operator_version.lstrip("v"))
+        except ValueError:
+            log.warning(
+                "Can't compare bundle versions %s and %s as semver: using lexical order instead",
+                self,
+                other,
+            )
+            return self.csv_operator_version == other.csv_operator_version
+
+    def __ne__(self, other: Any) -> bool:
+        return not self == other
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"< not supported between instances of '{self.__class__.__name__}'"
+                f" and '{other.__class__.__name__}"
+            )
+        if self.csv_operator_name != other.csv_operator_name:
+            return self.csv_operator_name < other.csv_operator_name
+        try:
+            return Version(self.csv_operator_version.lstrip("v")) < Version(  # type: ignore
+                other.csv_operator_version.lstrip("v")
+            )
+        except ValueError:
+            log.warning(
+                "Can't compare bundle versions %s and %s as semver: using lexical order instead",
+                self,
+                other,
+            )
+            return self.csv_operator_version < other.csv_operator_version
+
+    def __hash__(self) -> int:
+        return hash((self.operator_name, self.operator_version))
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}({self.operator_name}/{self.operator_version})"
+        )
+
+
+@total_ordering
+class Operator:
+    """An operator containing a collection of bundles"""
+
+    _bundle_cache: dict[str, Bundle]
+
+    CONFIG_FILE = "ci.yaml"
+
+    def __init__(self, operator_path: Union[str, Path], repo: Optional["Repo"] = None):
+        log.debug("Loading operator at %s", operator_path)
+        self._operator_path = Path(operator_path).resolve()
+        if not self.probe(self._operator_path):
+            raise InvalidOperatorException(
+                f"Not a valid operator: {self._operator_path}"
+            )
+        self.operator_name = self._operator_path.name
+        self._parent = repo
+        self._bundle_cache = {}
+
+    @cached_property
+    def config(self) -> Any:
+        """
+        :return: The contents of the ci.yaml for the operator
+        """
+        try:
+            return load_yaml(self._operator_path / self.CONFIG_FILE)
+        except FileNotFoundError:
+            log.info("No ci.yaml found for %s", self)
+            return {}
+
+    @classmethod
+    def probe(cls, path: Path) -> bool:
+        """
+        :return: True if path looks like an operator
+        """
+        return path.is_dir() and (
+            # At least one bundle or a ci.yaml file is required to consider
+            # a directory an operator
+            any(Bundle.probe(x) for x in path.iterdir())
+            or (path / cls.CONFIG_FILE).is_file()
+        )
+
+    @property
+    def root(self) -> Path:
+        """
+        :return: The path to the root of the operator
+        """
+        return self._operator_path
+
+    @property
+    def repo(self) -> "Repo":
+        """
+        :return: The Repo object the operator belongs to
+        """
+        if self._parent is None:
+            self._parent = Repo(self._operator_path.parent.parent)
+        return self._parent
+
+    def all_catalogs(self) -> Iterator["Catalog"]:
+        """
+        :return: All the catalogs containing the operator
+        """
+        for catalog in self.repo.all_catalogs():
+            if catalog.has(self.operator_name):
+                yield catalog
+
+    def all_operator_catalogs(self) -> Iterator["OperatorCatalog"]:
+        """
+        :return: All operator catalogs
+        """
+        for catalog in self.repo.all_catalogs():
+            if catalog.has(self.operator_name):
+                yield catalog.operator_catalog(self.operator_name)
+
+    def all_bundles(self) -> Iterator[Bundle]:
+        """
+        :return: All the bundles for the operator
+        """
+        for version_path in self._operator_path.iterdir():
+            try:
+                yield self._bundle_cache[version_path.name]
+            except KeyError:
+                if Bundle.probe(version_path):
+                    yield self.bundle(version_path.name)
+
+    def bundle_path(self, operator_version: str) -> Path:
+        """
+        Return the path where a bundle for the given version
+        would be located
+        :param operator_version: Version of the bundle
+        :return: Path to the bundle
+        """
+        return self._operator_path / operator_version
+
+    def bundle(self, operator_version: str) -> Bundle:
+        """
+        Load the bundle for the given version
+        :param operator_version: Version of the bundle
+        :return: The loaded bundle
+        """
+        try:
+            return self._bundle_cache[operator_version]
+        except KeyError:
+            bundle = Bundle(self.bundle_path(operator_version), self)
+            self._bundle_cache[operator_version] = bundle
+            return bundle
+
+    def has(self, operator_version: str) -> bool:
+        """
+        Check if the operator has a bundle for the given version
+        :param operator_version: Version to check for
+        :return: True if the operator contains a bundle for such version
+        """
+        return operator_version in self._bundle_cache or Bundle.probe(
+            self.bundle_path(operator_version)
+        )
+
+    @cached_property
+    def channels(self) -> set[str]:
+        """
+        :return: All channels defined by the operator bundles
+        """
+        return {x for y in self.all_bundles() for x in y.channels}
+
+    @cached_property
+    def default_channel(self) -> Optional[str]:
+        """
+        :return: Default channel as defined in
+        https://github.com/operator-framework/operator-registry/blob/master/docs/design/opm-tooling.md
+        """
+        # The default channel for an operator is defined as the default
+        # channel of the highest bundle version
+        try:
+            version_channel_pairs: list[tuple[Union[str, Version], str]] = [
+                (
+                    Version(x.csv_operator_version),
+                    x.default_channel,
+                )
+                for x in self.all_bundles()
+                if x.default_channel is not None
+            ]
+        except ValueError:
+            log.warning(
+                "%s has bundles with non-semver compliant version:"
+                " using lexical order to determine default channel",
+                self,
+            )
+            version_channel_pairs = [
+                (
+                    x.csv_operator_version,
+                    x.default_channel,
+                )
+                for x in self.all_bundles()
+                if x.default_channel is not None
+            ]
+        try:
+            return sorted(version_channel_pairs)[-1][1]
+        except IndexError:
+            return None
+
+    def channel_bundles(self, channel: str) -> list[Bundle]:
+        """
+        :param channel: Name of the channel
+        :return: List of bundles in the given channel
+        """
+        return sorted({x for x in self.all_bundles() if channel in x.channels})
+
+    def head(self, channel: str) -> Optional[Bundle]:
+        """
+        :param channel: Name of the channel
+        :return: Head of the channel
+        """
+        channel_bundles = self.channel_bundles(channel)
+        return None if not channel_bundles else channel_bundles[-1]
+
+    @staticmethod
+    def _resolve_skip_range(
+        channel: str, all_bundles_set: set[Bundle]
+    ) -> dict[Bundle, set[Bundle]]:
+        """
+        Partially resolve the update graph according to field
+        'metadata'.'annotations'.'olm.skipRange'.
+        """
+        edges: dict[Bundle, set[Bundle]] = {}
+        version_to_bundle = {x.csv_operator_version: x for x in all_bundles_set}
+        for bundle in all_bundles_set:
+            if (
+                skip_range := bundle.csv.get("metadata", {})
+                .get("annotations", {})
+                .get("olm.skipRange")
+            ):
+                try:
+                    skip_range_parsed = NpmSpec(skip_range)
+                except ValueError:
+                    log.warning("Invalid skipRange: '%s' is ignored.", skip_range)
+                else:
+                    for (
+                        bundle_version,
+                        potentially_replaced_bundle,
+                    ) in version_to_bundle.items():
+                        if (
+                            Version(bundle_version) in skip_range_parsed
+                            and channel in bundle.channels
+                            and channel in potentially_replaced_bundle.channels
+                        ):
+                            edges.setdefault(potentially_replaced_bundle, set()).add(
+                                bundle
+                            )
+        return edges
+
+    @staticmethod
+    def _replaces_graph(
+        channel: str, bundles: list[Bundle]
+    ) -> dict[Bundle, set[Bundle]]:
+        all_bundles_set = set(bundles)
+        edges: dict[Bundle, set[Bundle]] = Operator._resolve_skip_range(
+            channel, all_bundles_set
+        )
+        version_to_bundle = {x.csv_operator_version: x for x in all_bundles_set}
+        for bundle in all_bundles_set:
+            spec = bundle.csv.get("spec", {})
+            replaces = spec.get("replaces")
+            skips = spec.get("skips", [])
+            previous = set(skips) | {replaces}
+            for replaced_bundle_name in previous:
+                if replaced_bundle_name is None:
+                    continue
+                if "." not in replaced_bundle_name:
+                    raise ValueError(
+                        f"{bundle} has invalid 'replaces' field: '{replaced_bundle_name}'"
+                    )
+                replaced_bundle_version = replaced_bundle_name.split(".", 1)[1]
+                try:
+                    replaced_bundle = version_to_bundle[
+                        replaced_bundle_version.lstrip("v")
+                    ]
+                    if (
+                        channel in bundle.channels
+                        and channel in replaced_bundle.channels
+                    ):
+                        edges.setdefault(replaced_bundle, set()).add(bundle)
+                except KeyError:
+                    pass
+        return edges
+
+    def update_graph(self, channel: str) -> dict[Bundle, set[Bundle]]:
+        """
+        Return the update graph for the given channel
+        :param channel: Name of the channel
+        :return: Update graph edges in the form of a dictionary mapping each bundle
+            to a set of bundles that can replace it
+        """
+        all_bundles = self.channel_bundles(channel)
+        update_strategy = self.config.get("updateGraph", "replaces-mode")
+        if update_strategy == "semver-mode":
+            return {x: {y} for x, y in zip(all_bundles, all_bundles[1:])}
+        if update_strategy == "replaces-mode":
+            return self._replaces_graph(channel, all_bundles)
+        raise NotImplementedError(
+            f"{self}: unsupported updateGraph value: {update_strategy}"
+        )
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+        return self.operator_name == other.operator_name
+
+    def __ne__(self, other: Any) -> bool:
+        return not self == other
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"Can't compare {self.__class__.__name__} to {other.__class__.__name__}"
+            )
+        return self.operator_name < other.operator_name
+
+    def __iter__(self) -> Iterator[Bundle]:
+        yield from self.all_bundles()
+
+    def __hash__(self) -> int:
+        return hash((self.operator_name,))
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.operator_name})"
+
+
+class OperatorCatalog:
+    """
+    Operator catalog class representing a File Based Catalog for given operator
+    """
+
+    CATALOG_NAMES = ("catalog.yaml", "catalog.yml", "catalog.json")
+
+    def __init__(
+        self,
+        operator_catalog_path: Union[str, Path],
+        catalog: Optional["Catalog"] = None,
+    ):
+        log.debug("Loading operator catalog at %s", operator_catalog_path)
+        self._operator_catalog_path = Path(operator_catalog_path).resolve()
+        if not self.probe(self._operator_catalog_path):
+            raise InvalidOperatorCatalogException(
+                f"Not a valid operator catalog: {self._operator_catalog_path}"
+            )
+        self.operator_name = self._operator_catalog_path.name
+        self._parent = catalog
+
+    @classmethod
+    def probe(cls, path: Path) -> bool:
+        """
+        :return: True if path looks like an operator catalog
+        """
+        if not path.is_dir():
+            return False
+        file_names = {file.name for file in path.iterdir()}
+        return path.is_dir() and bool(file_names & set(cls.CATALOG_NAMES))
+
+    @property
+    def root(self) -> Path:
+        """
+        :return: The path to the root of the operator catalog
+        """
+        return self._operator_catalog_path
+
+    @property
+    def repo(self) -> "Repo":
+        """
+        :return: The Repo object the operator belongs to
+        """
+        return self.catalog.repo
+
+    @property
+    def catalog(self) -> "Catalog":
+        """
+        :return: The Catalog object the operator belongs to
+        """
+        if self._parent is None:
+            self._parent = Catalog(self._operator_catalog_path.parent)
+        return self._parent
+
+    @property
+    def operator(self) -> "Operator":
+        """
+        :return: The Operator object the operator catalog belongs to
+        """
+        return self.repo.operator(self.operator_name)
+
+    @property
+    def operator_catalog_name(self) -> str:
+        """
+        :return: The operator catalog name combining the catalog name
+            and the operator name eg.: 'v4.12/operator-x'
+        """
+        return self.catalog.catalog_name + "/" + self.operator_name
+
+    @property
+    def catalog_content_path(
+        self,
+    ) -> Path:
+        """
+        Return the path where a catalog with the given
+        name would be located
+        :param catalog_name: Name of the catalog
+        :return: Path to the catalog
+        """
+        file_names = {file.name for file in self._operator_catalog_path.iterdir()}
+        catalog_name = file_names & set(self.CATALOG_NAMES)
+        return self._operator_catalog_path / list(catalog_name)[0]
+
+    @property
+    def catalog_content(self) -> list[dict[str, Any]]:
+        """
+        Return the catalog content.
+
+        Catalog is represented as a multi document yaml file,
+        therefore the content is represented as a list of dictionaries
+        where each dictionary represents single document in the yaml file.
+
+        :return: The list of dictionaries representing the catalog content
+        """
+        return load_multidoc_yaml(self.catalog_content_path)
+
+    def __eq__(self, other: Any) -> bool:
+        if isinstance(other, str):
+            return self.operator_catalog_name == other
+        if not isinstance(other, self.__class__):
+            return False
+        return self.operator_catalog_name == other.operator_catalog_name
+
+    def __ne__(self, other: Any) -> bool:
+        return not self == other
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"Can't compare {self.__class__.__name__} to {other.__class__.__name__}"
+            )
+        return self.operator_catalog_name < other.operator_catalog_name
+
+    def __hash__(self) -> int:
+        return hash((self.operator_catalog_name,))
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.operator_catalog_name})"
+
+
+@dataclass
+class OperatorCatalogList(list[OperatorCatalog]):
+    """
+    A list of operator catalogs
+    """
+
+    def __init__(self, operator_catalogs: Optional[list[OperatorCatalog]] = None):
+        if operator_catalogs is None:
+            operator_catalogs = []
+        if any(not isinstance(item, OperatorCatalog) for item in operator_catalogs):
+            raise TypeError("All items must be instances of OperatorCatalog")
+        super().__init__(list(set(operator_catalogs)))  # only unique items
+
+    def append(self, item: Any) -> None:
+        if not isinstance(item, OperatorCatalog):
+            raise TypeError(
+                f"Only instances of OperatorCatalog are allowed, got {type(item).__name__}"
+            )
+        if item in self:
+            raise ValueError(f"Duplicate items are not allowed: {item}")
+        super().append(item)
+
+    def extend(self, items: Any) -> None:
+        if any(not isinstance(item, OperatorCatalog) for item in items):
+            raise TypeError("All items must be instances of OperatorCatalog")
+        if any(item in self for item in items):
+            raise ValueError("Duplicate items are not allowed")
+        super().extend(items)
+
+    def insert(self, index: SupportsIndex, item: Any) -> None:
+        if not isinstance(item, OperatorCatalog):
+            raise TypeError(
+                f"Only instances of OperatorCatalog are allowed, got {type(item).__name__}"
+            )
+        if item in self:
+            raise ValueError(f"Duplicate items are not allowed: {item}")
+        super().insert(index, item)
+
+    def __repr__(self) -> str:
+        return f"{list(self.__iter__())}"
+
+
+class Catalog:
+    """
+    Catalog class representing a File Based Catalog of specific version.
+    A Repo can contain multiple Catalogs: for example one Catalog per OpenShift version.
+    An Operator can be published to one or more of the Catalogs of the
+    Repo it belongs to.
+    """
+
+    CATALOG_DIR = "catalogs"
+
+    def __init__(self, catalog_path: Union[str, Path], repo: Optional["Repo"] = None):
+        log.debug("Loading catalog at %s", catalog_path)
+        self._catalog_path = Path(catalog_path).resolve()
+        if not self.probe(self._catalog_path):
+            raise InvalidCatalogException(f"Not a valid catalog: {self._catalog_path}")
+        self.catalog_name = self._catalog_path.name
+        self._parent = repo
+        self._operator_catalog_cache: dict[str, OperatorCatalog] = {}
+
+    @classmethod
+    def probe(cls, path: Path) -> bool:
+        """
+        :return: True if path looks like an catalog
+        """
+        return path.is_dir() and any(OperatorCatalog.probe(x) for x in path.iterdir())
+
+    @property
+    def root(self) -> Path:
+        """
+        :return: The path to the root of the catalog
+        """
+        return self._catalog_path
+
+    @property
+    def repo(self) -> "Repo":
+        """
+        :return: The Repo object the operator belongs to
+        """
+        if self._parent is None:
+            self._parent = Repo(self._catalog_path.parent.parent)
+        return self._parent
+
+    def all_operator_catalogs(self) -> Iterator[OperatorCatalog]:
+        """
+        :return: All the operator catalogs in the catalog
+        """
+        for operator_catalog_path in self._catalog_path.iterdir():
+            try:
+                yield self._operator_catalog_cache[operator_catalog_path.name]
+            except KeyError:
+                if OperatorCatalog.probe(operator_catalog_path):
+                    yield self.operator_catalog(operator_catalog_path.name)
+
+    def operator_catalog_path(self, operator_name: str) -> Path:
+        """
+        Return the path where an operator catalog with the given
+        name would be located
+        :param operator_name: Name of the operator
+        :return: Path to the operator catalog
+        """
+        return self._catalog_path / operator_name
+
+    def operator_catalog(self, operator_name: str) -> OperatorCatalog:
+        """
+        Load the operator catalog with the given name
+        :param operator_name: Name of the operator
+        :return: The loaded operator catalog
+        """
+        try:
+            return self._operator_catalog_cache[operator_name]
+        except KeyError:
+            operator_catalog = OperatorCatalog(
+                self.operator_catalog_path(operator_name), self
+            )
+            self._operator_catalog_cache[operator_name] = operator_catalog
+            return operator_catalog
+
+    def has(self, operator_name: str) -> bool:
+        """
+        Check if the catalog contains an operatorcatalog with the given name
+        :param operator_name: Name of the operator to look for
+        :return: True if the repo contains an operator with the given name
+        """
+        return operator_name in self._operator_catalog_cache or OperatorCatalog.probe(
+            self.operator_catalog_path(operator_name)
+        )
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+        return self.catalog_name == other.catalog_name
+
+    def __ne__(self, other: Any) -> bool:
+        return not self == other
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            raise TypeError(
+                f"Can't compare {self.__class__.__name__} to {other.__class__.__name__}"
+            )
+        return self.catalog_name < other.catalog_name
+
+    def __iter__(self) -> Iterator[OperatorCatalog]:
+        yield from self.all_operator_catalogs()
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.catalog_name})"
+
+
+class Repo:
+    """A repository containing a collection of operators"""
+
+    _operator_cache: dict[str, Operator]
+    _catalog_cache: dict[str, Catalog]
+
+    OPERATORS_DIR = "operators"
+    CATALOGS_DIR = "catalogs"
+
+    def __init__(self, repo_path: Union[str, Path]):
+        log.debug("Loading repo at %s", repo_path)
+        self._repo_path = Path(repo_path).resolve()
+        if not self.probe(self._repo_path):
+            raise InvalidRepoException(
+                f"Not a valid operator repository: {self._repo_path}"
+            )
+        self._operators_path = self._repo_path / self.OPERATORS_DIR
+        self._catalogs_path = self._repo_path / self.CATALOGS_DIR
+
+        self._operator_cache = {}
+        self._catalog_cache = {}
+
+    @cached_property
+    def config(self) -> Any:
+        """
+        :return: The contents of the config.yaml for the repo
+        """
+        try:
+            return load_yaml(self._repo_path / "config.yaml")
+        except FileNotFoundError:
+            log.warning("No config.yaml found for %s", self)
+            return {}
+
+    @classmethod
+    def probe(cls, path: Path) -> bool:
+        """
+        :return: True if path looks like an operator repo
+        """
+        return path.is_dir() and (path / cls.OPERATORS_DIR).is_dir()
+
+    @property
+    def root(self) -> Path:
+        """
+        :return: The path to the root of the repository
+        """
+        return self._repo_path
+
+    def all_catalogs(self) -> Iterator[Catalog]:
+        """
+        :return: All the catalogs in the repo
+        """
+        if not self._catalogs_path.is_dir():
+            return
+        for catalog_path in self._catalogs_path.iterdir():
+            try:
+                yield self._catalog_cache[catalog_path.name]
+            except KeyError:
+                if Catalog.probe(catalog_path):
+                    yield self.catalog(catalog_path.name)
+                else:
+                    print(f"Catalog {catalog_path.name} is not valid")
+
+    def catalog_path(self, catalog_name: str) -> Path:
+        """
+        Return the path where a catalog with the given
+        name would be located
+        :param catalog_name: Name of the catalog
+        :return: Path to the catalog
+        """
+        return self._catalogs_path / catalog_name
+
+    def catalog(self, catalog_name: str) -> Catalog:
+        """
+        Load the catalog with the given name
+        :param catalog_name: Name of the catalog
+        :return: The loaded catalog
+        """
+        try:
+            return self._catalog_cache[catalog_name]
+        except KeyError:
+            catalog = Catalog(self.catalog_path(catalog_name), self)
+            self._catalog_cache[catalog_name] = catalog
+            return catalog
+
+    def all_operators(self) -> Iterator[Operator]:
+        """
+        :return: All the operators in the repo
+        """
+        for operator_path in self._operators_path.iterdir():
+            try:
+                yield self._operator_cache[operator_path.name]
+            except KeyError:
+                if Operator.probe(operator_path):
+                    yield self.operator(operator_path.name)
+
+    def operator_path(self, operator_name: str) -> Path:
+        """
+        Return the path where an operator with the given
+        name would be located
+        :param operator_name: Name of the operator
+        :return: Path to the operator
+        """
+        return self._operators_path / operator_name
+
+    def operator(self, operator_name: str) -> Operator:
+        """
+        Load the operator with the given name
+        :param operator_name: Name of the operator
+        :return: The loaded operator
+        """
+        try:
+            return self._operator_cache[operator_name]
+        except KeyError:
+            operator = Operator(self.operator_path(operator_name), self)
+            self._operator_cache[operator_name] = operator
+            return operator
+
+    def has(self, operator_name: str) -> bool:
+        """
+        Check if the repo contains an operator with the given name
+        :param operator_name: Name of the operator to look for
+        :return: True if the repo contains an operator with the given name
+        """
+        return operator_name in self._operator_cache or Operator.probe(
+            self.operator_path(operator_name)
+        )
+
+    def has_catalog(self, catalog_name: str) -> bool:
+        """
+        Check if the repo contains a catalog with the given name
+        :param catalog_name: Name of the catalog to look for
+        :return: True if the repo contains a catalog with the given name
+        """
+        return catalog_name in self._catalog_cache or Catalog.probe(
+            self.catalog_path(catalog_name)
+        )
+
+    def __iter__(self) -> Iterator[Operator]:
+        yield from self.all_operators()
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+        return self._repo_path == other._repo_path
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self._repo_path})"

--- a/operator-pipeline-images/operatorcert/operator_repo/exceptions.py
+++ b/operator-pipeline-images/operatorcert/operator_repo/exceptions.py
@@ -1,0 +1,27 @@
+"""
+Exceptions
+"""
+
+
+class OperatorRepoException(Exception):
+    """Base exception class"""
+
+
+class InvalidRepoException(OperatorRepoException):
+    """Error caused by an invalid repository structure"""
+
+
+class InvalidOperatorException(OperatorRepoException):
+    """Error caused by an invalid operator"""
+
+
+class InvalidBundleException(OperatorRepoException):
+    """Error caused by an invalid bundle"""
+
+
+class InvalidCatalogException(OperatorRepoException):
+    """Error caused by an invalid catalog"""
+
+
+class InvalidOperatorCatalogException(OperatorRepoException):
+    """Error caused by an invalid operator catalog"""

--- a/operator-pipeline-images/operatorcert/operator_repo/utils.py
+++ b/operator-pipeline-images/operatorcert/operator_repo/utils.py
@@ -1,0 +1,204 @@
+"""
+Utility functions to load yaml files
+"""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+from yaml.composer import ComposerError
+from yaml.parser import ParserError
+
+from .exceptions import OperatorRepoException
+
+log = logging.getLogger(__name__)
+
+
+def _find_yaml(path: Path) -> Path:
+    """
+    Find a YAML file by looking for files with alternate extensions.
+
+    This function searches for a YAML file by trying multiple extensions (.yaml and .yml)
+    and checking if the file exists. It is used to locate YAML files with different possible
+    extensions in order to provide flexibility when specifying file paths.
+
+    Args:
+        path (Path): The path to the file with or without a YAML extension.
+
+    Returns:
+        Path: The path to the found YAML file.
+
+    Raises:
+        FileNotFoundError: If a YAML file with any of the tried extensions cannot be found.
+
+    Example:
+        file_path = Path("my_file.json")
+        yaml_path = _find_yaml(file_path)
+        # If "my_file.yaml" or "my_file.yml" exists, yaml_path will point to the found YAML file.
+        # Otherwise, a FileNotFoundError will be raised.
+    """
+    if path.is_file():
+        return path
+    tries = [path]
+    for alt_extension in [".yaml", ".yml"]:
+        if alt_extension == path.suffix:
+            continue
+        new_path = path.with_suffix(alt_extension)
+        if new_path.is_file():
+            return new_path
+        tries.append(new_path)
+    tries_str = ", ".join([str(x) for x in tries])
+    raise FileNotFoundError(f"Can't find yaml file. Tried: {tries_str}")
+
+
+def _load_yaml_strict(path: Path) -> Any:
+    """
+    Load and parse the contents of a YAML file at the given path.
+
+    This function reads the contents of the specified YAML file and attempts to parse it
+    using the `yaml.safe_load` method. If the YAML document contains multiple documents or
+    if it's not a valid YAML document, exceptions are raised accordingly.
+
+    Args:
+        path (Path): The path to the YAML file to be loaded.
+
+    Returns:
+        Any: The parsed contents of the YAML file.
+
+    Raises:
+        OperatorRepoException: If the YAML file contains multiple documents.
+        OperatorRepoException: If the YAML file is not a valid YAML document.
+
+    Example:
+        yaml_path = Path("my_file.yaml")
+        yaml_content = _load_yaml_strict(yaml_path)
+        # The parsed contents of the YAML file will be stored in the `yaml_content` variable.
+    """
+    log.debug("Loading %s", path)
+    with path.open("r") as yaml_file:
+        try:
+            return yaml.safe_load(yaml_file)
+        except ComposerError as exc:
+            raise OperatorRepoException(
+                f"{path} contains multiple yaml documents"
+            ) from exc
+        except ParserError as exc:
+            raise OperatorRepoException(f"{path} is not a valid yaml document") from exc
+
+
+def load_yaml(path: Path) -> Any:
+    """
+    Load and parse the contents of a YAML file at the given path with alternate extensions.
+
+    Args:
+        path (Path): The path to the file with or without a YAML extension.
+
+    Returns:
+        Any: The parsed contents of the YAML file.
+
+    Raises:
+        OperatorRepoException: If the YAML file contains multiple documents.
+        OperatorRepoException: If the YAML file is not a valid YAML document.
+
+    Example:
+        file_path = Path("my_file.json")
+        yaml_content = load_yaml(file_path)
+        # If "my_file.yaml" or "my_file.yml" exists, the parsed contents of the YAML file
+        # will be stored in the `yaml_content` variable.
+    """
+    return _load_yaml_strict(_find_yaml(path))
+
+
+def _load_multidoc_yaml_strict(path: Path) -> list[Any]:
+    """
+    Load and parse the content of a multi-doc YAML file at the given path.
+
+    This function reads the contents of the specified YAML file and attempts to parse it
+    using the `yaml.safe_load_all` method. If the YAML document is not a valid
+    YAML document, exceptions is raised.
+
+    Args:
+        path (Path): The path to the YAML file to be loaded.
+
+    Returns:
+        list[Any]: The parsed contents of the multi-doc YAML file.
+
+    Raises:
+        OperatorRepoException: If the YAML file is not a valid YAML document.
+
+    Example:
+        yaml_path = Path("my_file.yaml")
+        yaml_content = _load_multidoc_yaml_strict(yaml_path)
+        # The parsed contents of the YAML file will be stored in the `yaml_content` variable.
+    """
+    log.debug("Loading %s", path)
+    with path.open("r") as yaml_file:
+        try:
+            return list(yaml.safe_load_all(yaml_file))
+        except ParserError as exc:
+            raise OperatorRepoException(f"{path} is not a valid yaml document") from exc
+
+
+def load_multidoc_yaml(path: Path) -> list[dict[str, Any]]:
+    """
+    Load and parse the contents of a YAML file at the given path.
+
+    Args:
+        path (Path): The path to the file with or without a YAML extension.
+
+    Returns:
+        list[Any]: The parsed contents of the YAML file. Each element in the list
+            represents a document in the multi-doc YAML file. Be aware that the
+            elements are not guaranteed to be specific types. They can be any valid
+            YAML document - a dictionary, a list, a string, etc.
+
+    Raises:
+        OperatorRepoException: If the YAML file is not a valid YAML document.
+
+    Example:
+        file_path = Path("my_file.json")
+        yaml_content = load_yaml(file_path)
+        # If "my_file.yaml" or "my_file.yml" exists, the parsed contents of the YAML file
+        # will be stored in the `yaml_content` variable.
+    """
+    return _load_multidoc_yaml_strict(_find_yaml(path))
+
+
+def lookup_dict(
+    data: dict[str, Any], path: str, default: Any = None, separator: str = "."
+) -> Any:
+    """
+    Retrieve a value from a nested dictionary using a specific path of keys.
+
+    This function allows you to access a value in a nested dictionary by providing a
+    dot-separated path of keys. If the path exists in the dictionary, the corresponding
+    value is returned. If the path does not exist, the specified default value is returned.
+
+    Args:
+        data (dict): The nested dictionary from which to retrieve the value.
+        path (str): A dot-separated string representing the path to the desired value.
+        default (Any, optional): The value to return if the path does not exist. Defaults to None.
+        separator (str, optional): The separator used to split the path into keys. Defaults to ".".
+
+    Returns:
+        Any: The value at the specified path if found, otherwise the default value.
+
+    Example:
+        data = {
+            "a": {
+                "b": {
+                    "c": 42
+                }
+            }
+        }
+        value = lookup_dict(data, "a.b.c")
+        # value will be 42
+    """
+    keys = path.split(separator)
+    subtree = data
+    for key in keys:
+        if key not in subtree:
+            return default
+        subtree = subtree[key]
+    return subtree

--- a/operator-pipeline-images/operatorcert/parsed_file.py
+++ b/operator-pipeline-images/operatorcert/parsed_file.py
@@ -4,8 +4,8 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
 import yaml
-from operator_repo import OperatorCatalog
-from operator_repo import Repo as OperatorRepo
+from operatorcert.operator_repo import OperatorCatalog
+from operatorcert.operator_repo import Repo as OperatorRepo
 
 
 class ValidationError(Exception):

--- a/operator-pipeline-images/operatorcert/static_tests/common/bundle.py
+++ b/operator-pipeline-images/operatorcert/static_tests/common/bundle.py
@@ -2,13 +2,12 @@
 
 import json
 import os
+from collections.abc import Iterator
 from typing import Any
 
-from collections.abc import Iterator
 from jsonschema.validators import Draft202012Validator
-
-from operator_repo import Bundle
-from operator_repo.checks import CheckResult, Fail, Warn
+from operatorcert.operator_repo import Bundle
+from operatorcert.operator_repo.checks import CheckResult, Fail, Warn
 
 
 def _check_consistency(

--- a/operator-pipeline-images/operatorcert/static_tests/common/operator.py
+++ b/operator-pipeline-images/operatorcert/static_tests/common/operator.py
@@ -6,8 +6,8 @@ from collections import defaultdict
 from collections.abc import Iterator
 
 from jsonschema.validators import Draft202012Validator
-from operator_repo import Operator
-from operator_repo.checks import CheckResult, Fail
+from operatorcert.operator_repo import Operator
+from operatorcert.operator_repo.checks import CheckResult, Fail
 
 
 def check_schema_operator_ci_config(

--- a/operator-pipeline-images/operatorcert/static_tests/common/operator_catalogs.py
+++ b/operator-pipeline-images/operatorcert/static_tests/common/operator_catalogs.py
@@ -2,8 +2,8 @@
 
 from collections.abc import Iterator
 
-from operator_repo import OperatorCatalog, OperatorCatalogList
-from operator_repo.checks import CheckResult, Fail
+from operatorcert.operator_repo import OperatorCatalog, OperatorCatalogList
+from operatorcert.operator_repo.checks import CheckResult, Fail
 
 
 def _get_bundle_registries_from_catalog(catalog: OperatorCatalog) -> list[str]:

--- a/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
+++ b/operator-pipeline-images/operatorcert/static_tests/community/bundle.py
@@ -6,17 +6,17 @@
     (either Fail or Warn) to describe the issues found in the given Bundle.
 """
 
-from bisect import bisect
 import json
 import logging
 import re
 import subprocess
+from bisect import bisect
 from collections.abc import Iterator
 
-from operator_repo import Bundle
-from operator_repo.checks import CheckResult, Fail, Warn
-from operator_repo.utils import lookup_dict
 from operatorcert import utils
+from operatorcert.operator_repo import Bundle
+from operatorcert.operator_repo.checks import CheckResult, Fail, Warn
+from operatorcert.operator_repo.utils import lookup_dict
 from operatorcert.static_tests.helpers import skip_fbc
 from semver import Version
 
@@ -125,7 +125,7 @@ def run_operator_sdk_bundle_validate(
             "validate",
             "-o",
             "json-alpha1",
-            bundle.root,
+            str(bundle.root),
             "--select-optional",
             test_suite_selector,
             f"--optional-values=k8s-version={kube_version_for_deprecation_test}",

--- a/operator-pipeline-images/operatorcert/static_tests/community/operator.py
+++ b/operator-pipeline-images/operatorcert/static_tests/community/operator.py
@@ -9,8 +9,8 @@ and taking an Operator argument and yielding OperatorCheck objects
 from collections.abc import Iterator
 from typing import Dict, Optional
 
-from operator_repo import Operator, Bundle
-from operator_repo.checks import CheckResult, Fail, Warn
+from operatorcert.operator_repo import Bundle, Operator
+from operatorcert.operator_repo.checks import CheckResult, Fail, Warn
 from operatorcert.static_tests.helpers import skip_fbc
 
 

--- a/operator-pipeline-images/operatorcert/static_tests/helpers.py
+++ b/operator-pipeline-images/operatorcert/static_tests/helpers.py
@@ -1,11 +1,10 @@
 """ Static tests helper utilities. """
 
 import logging
-
 from functools import wraps
 from typing import Any, Callable, Iterator
-from operator_repo import Operator, Bundle
 
+from operatorcert.operator_repo import Bundle, Operator
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -32,10 +31,9 @@ def skip_fbc(func: Callable[..., Any]) -> Callable[..., Any]:
         if not config.get("fbc", {}).get("enabled", False):
             yield from func(*args, **kwargs)
         else:
+            operator_name = operator.operator_name if operator else "<unknown>"
             LOGGER.info(
-                "Skipping %s for FBC enabled operator %s",
-                func.__name__,
-                operator.operator_name,
+                "Skipping %s for FBC enabled operator %s", func.__name__, operator_name
             )
         yield from []
 

--- a/operator-pipeline-images/operatorcert/static_tests/isv/bundle.py
+++ b/operator-pipeline-images/operatorcert/static_tests/isv/bundle.py
@@ -2,8 +2,8 @@
 
 from collections.abc import Iterator
 
-from operator_repo import Bundle
-from operator_repo.checks import CheckResult, Fail, Warn
+from operatorcert.operator_repo import Bundle
+from operatorcert.operator_repo.checks import CheckResult, Fail, Warn
 from operatorcert.static_tests.helpers import skip_fbc
 
 PRUNED_GRAPH_ERROR = (

--- a/operator-pipeline-images/tests/entrypoints/test_add_bundle_to_fbc.py
+++ b/operator-pipeline-images/tests/entrypoints/test_add_bundle_to_fbc.py
@@ -213,8 +213,8 @@ def test_BasicCatalogTemplate_render(
 ) -> None:
     mock_open = mock.mock_open()
     basic_catalog_template.operator.operator_name = "fake-operator"
-    basic_catalog_template.operator.repo.root = Path("./")
-    basic_catalog_template.template_path = (
+    basic_catalog_template.operator.repo.root = Path("./")  # type: ignore
+    basic_catalog_template.template_path = Path(
         "operators/fake-operator/catalog-templates/fake-template.yaml"
     )
 

--- a/operator-pipeline-images/tests/entrypoints/test_check_permissions.py
+++ b/operator-pipeline-images/tests/entrypoints/test_check_permissions.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, call, patch
 import operatorcert.entrypoints.check_permissions as check_permissions
 import pytest
 from github import UnknownObjectException
-from operator_repo import Repo as OperatorRepo
-from tests.utils import bundle_files, create_files
+from operatorcert.operator_repo import Repo as OperatorRepo
+from tests.operator_repo import bundle_files, create_files
 
 
 @pytest.fixture

--- a/operator-pipeline-images/tests/entrypoints/test_detect_changed_operators.py
+++ b/operator-pipeline-images/tests/entrypoints/test_detect_changed_operators.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 from git.repo import Repo as GitRepo
-from operator_repo import Repo
 from operatorcert.entrypoints import detect_changed_operators
+from operatorcert.operator_repo import Repo
 from operatorcert.parsed_file import (
     AffectedBundleCollection,
     AffectedCatalogCollection,

--- a/operator-pipeline-images/tests/entrypoints/test_fbc_onboarding.py
+++ b/operator-pipeline-images/tests/entrypoints/test_fbc_onboarding.py
@@ -221,10 +221,12 @@ def test_render_fbc_from_template(
                 "-o",
                 "yaml",
                 os.path.join(
-                    operator.root, fbc_onboarding.CATALOG_TEMPLATES_DIR, "v4.15.yaml"
+                    str(operator.root),
+                    fbc_onboarding.CATALOG_TEMPLATES_DIR,
+                    "v4.15.yaml",
                 ),
             ],
-            cwd=operator.root,
+            cwd=str(operator.root),
         )
         mock_makedir.assert_called_once()
         mock_safe_dump_all.assert_called_once()

--- a/operator-pipeline-images/tests/entrypoints/test_static_tests.py
+++ b/operator-pipeline-images/tests/entrypoints/test_static_tests.py
@@ -2,9 +2,9 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from operator_repo import Repo
-from operator_repo.checks import Fail, Warn
 from operatorcert.entrypoints import static_tests
+from operatorcert.operator_repo import Repo
+from operatorcert.operator_repo.checks import Fail, Warn
 from tests.utils import bundle_files, catalog_files, create_files
 
 

--- a/operator-pipeline-images/tests/operator_repo/__init__.py
+++ b/operator-pipeline-images/tests/operator_repo/__init__.py
@@ -1,30 +1,26 @@
-"""
-    Miscellaneous non-fixture utility functions for tests
-"""
-
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 import yaml
 
 
 def merge(
-    a: Dict[str, Any], b: Dict[str, Any], path: Optional[list[str]] = None
-) -> Dict[str, Any]:
+    dst: dict[Any, Any], src: dict[Any, Any], path: Optional[list[str]] = None
+) -> dict[Any, Any]:
     """
-    Recursively merge two dictionaries, with values from the second dictionary (b)
-    overwriting corresponding values in the first dictionary (a). This function can
+    Recursively merge two dictionaries, with values from the second dictionary (src)
+    overwriting corresponding values in the first dictionary (dst). This function can
     handle nested dictionaries.
 
     Args:
-        a (dict): The base dictionary to merge into.
-        b (dict): The dictionary with values to merge into the base dictionary.
+        dst (dict): The base dictionary to merge into.
+        src (dict): The dictionary with values to merge into the base dictionary.
         path (list of str, optional): A list representing the current path in the recursive merge.
             This argument is used internally for handling nested dictionaries. Users typically
             don't need to provide this argument. Defaults to None.
 
     Returns:
-        dict: The merged dictionary (a) after incorporating values from the second dictionary (b).
+        dict: The merged dictionary (dst) after incorporating values from the second dictionary (src).
 
     Example:
         dict_a = {"key1": 42, "key2": {"subkey1": "value1"}}
@@ -35,18 +31,18 @@ def merge(
     """
     if path is None:
         path = []
-    for key in b:
-        if key in a:
-            if isinstance(a[key], dict) and isinstance(b[key], dict):
-                merge(a[key], b[key], path + [str(key)])
+    for key in src:
+        if key in dst:
+            if isinstance(dst[key], dict) and isinstance(src[key], dict):
+                merge(dst[key], src[key], path + [str(key)])
             else:
-                a[key] = b[key]
+                dst[key] = src[key]
         else:
-            a[key] = b[key]
-    return a
+            dst[key] = src[key]
+    return dst
 
 
-def create_files(path: Union[str, Path], *contents: Dict[str, Any]) -> None:
+def create_files(path: Union[str, Path], *contents: dict[str, Any]) -> None:
     """
     Create files and directories at the specified path based on the provided content.
 
@@ -90,8 +86,10 @@ def create_files(path: Union[str, Path], *contents: Dict[str, Any]) -> None:
                 full_path.mkdir(parents=True, exist_ok=True)
             else:
                 full_path.parent.mkdir(parents=True, exist_ok=True)
-                if isinstance(content, (str, bytes)):
-                    full_path.write_text(content)  # type: ignore
+                if isinstance(content, str):
+                    full_path.write_text(content)
+                elif isinstance(content, bytes):
+                    full_path.write_bytes(content)
                 elif isinstance(content, tuple):
                     full_path.write_text(yaml.safe_dump_all(content))
                 else:
@@ -143,13 +141,15 @@ def catalog_files(
 def bundle_files(
     operator_name: str,
     bundle_version: str,
-    annotations: Optional[Dict[str, Any]] = None,
-    csv: Optional[Dict[str, Any]] = None,
-    other_files: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    annotations: Optional[dict[str, Any]] = None,
+    csv: Optional[dict[str, Any]] = None,
+    other_files: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
     """
-    Creates an in-memory representation of the set of files for an Operator package bundle.
-    The output format can be fed directly to the create_files function.
+    Create a bundle of files and metadata for an Operator package.
+
+    This function generates a bundle of files and metadata for an Operator package,
+    including annotations, a CSV (ClusterServiceVersion) file, and other additional files.
 
     Args:
         operator_name (str): The name of the Operator.

--- a/operator-pipeline-images/tests/operator_repo/checks/test_checks.py
+++ b/operator-pipeline-images/tests/operator_repo/checks/test_checks.py
@@ -1,0 +1,111 @@
+from unittest.mock import MagicMock, call, patch
+
+from operatorcert.operator_repo import Bundle
+from operatorcert.operator_repo.checks import (
+    Fail,
+    Warn,
+    get_checks,
+    run_check,
+    run_suite,
+)
+
+
+def test_check_result() -> None:
+    result1 = Warn("foo")
+    result2 = Fail("bar")
+    result3 = Warn("foo")
+    assert result1 != result2
+    assert result1 < result2
+    assert result1 == result3
+    assert "foo" in str(result1)
+    assert "bar" in str(result2)
+    assert "foo" in repr(result1)
+    assert "bar" in repr(result2)
+    assert "warning" in str(result1)
+    assert "failure" in str(result2)
+    assert {result1, result2, result3} == {result1, result2}
+
+
+@patch("importlib.import_module")
+def test_get_checks(mock_import_module: MagicMock) -> None:
+    def check_fake(_something):  # type: ignore
+        pass
+
+    fake_module = MagicMock()
+    fake_module.check_fake = check_fake
+    fake_module.non_check_bar = lambda x: None
+    mock_import_module.return_value = fake_module
+    assert get_checks("suite.name") == {
+        "operator": [check_fake],
+        "bundle": [check_fake],
+        "operator_catalogs": [check_fake],
+    }
+    mock_import_module.assert_has_calls(
+        [call("suite.name.operator"), call("suite.name.bundle")], any_order=True
+    )
+
+
+@patch("importlib.import_module")
+def test_get_checks_skip_check(mock_import_module: MagicMock) -> None:
+    def check_fake(_something):  # type: ignore
+        pass
+
+    fake_module = MagicMock()
+    fake_module.check_fake = check_fake
+    fake_module.check_ignore = lambda x: None
+    mock_import_module.return_value = fake_module
+    assert get_checks("suite.name", skip_tests=["check_ignore"]) == {
+        "operator": [check_fake],
+        "bundle": [check_fake],
+        "operator_catalogs": [check_fake],
+    }
+    mock_import_module.assert_has_calls(
+        [call("suite.name.operator"), call("suite.name.bundle")], any_order=True
+    )
+
+
+@patch("importlib.import_module")
+def test_get_checks_missing_modules(mock_import_module: MagicMock) -> None:
+    mock_import_module.side_effect = ModuleNotFoundError()
+    assert get_checks("suite.name") == {
+        "operator": [],
+        "bundle": [],
+        "operator_catalogs": [],
+    }
+    mock_import_module.assert_has_calls(
+        [call("suite.name.operator"), call("suite.name.bundle")], any_order=True
+    )
+
+
+def test_run_check(mock_bundle: Bundle) -> None:
+    def check_fake(_something):  # type: ignore
+        yield Warn("foo")
+
+    assert list(run_check(check_fake, mock_bundle)) == [
+        Warn("foo", "check_fake", mock_bundle)
+    ]
+
+    def check_with_exception(_something):  # type: ignore
+        raise Exception("bar")
+
+    results = list(run_check(check_with_exception, mock_bundle))
+    assert results == [
+        Fail(
+            # Copying the exception message
+            results[0].reason,
+            "check_with_exception",
+            mock_bundle,
+        )
+    ]
+    assert 'Exception("bar")' in results[0].reason
+
+
+@patch("operatorcert.operator_repo.checks.get_checks")
+def test_run_suite(mock_get_checks: MagicMock, mock_bundle: Bundle) -> None:
+    def check_fake(_something):  # type: ignore
+        yield Warn("foo")
+
+    mock_get_checks.return_value = {"bundle": [check_fake], "operator": []}
+    assert list(run_suite([mock_bundle], "fake.suite")) == [
+        Warn("foo", "check_fake", mock_bundle)
+    ]

--- a/operator-pipeline-images/tests/operator_repo/conftest.py
+++ b/operator-pipeline-images/tests/operator_repo/conftest.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+import pytest
+
+from operatorcert.operator_repo import Bundle, Repo
+from tests.utils import bundle_files, catalog_files, create_files
+
+
+@pytest.fixture
+def mock_bundle(tmp_path: Path) -> Bundle:
+    """
+    Create a dummy file structure for a bundle and return the corresponding
+    Bundle object
+    """
+    create_files(tmp_path, bundle_files("hello", "0.0.1"))
+    repo = Repo(tmp_path)
+    return repo.operator("hello").bundle("0.0.1")
+
+
+@pytest.fixture
+def mock_repo(tmp_path: Path) -> Repo:
+    """
+    Create a dummy file structure for an operator repo with two operators
+    and a total of four bundles and return the corresponding Repo object
+    """
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.1"),
+        bundle_files("hello", "0.0.2"),
+        bundle_files("world", "0.0.1"),
+        bundle_files(
+            "world",
+            "0.0.2",
+            {"operators.operatorframework.io.bundle.package.v1": "fake-incorect-name"},
+            other_files={"operators/world/ci.yaml": "invalid ci content"},
+        ),
+        catalog_files("v4.17", "hello"),
+        catalog_files("v4.18", "hello"),
+    )
+    repo = Repo(tmp_path)
+    return repo

--- a/operator-pipeline-images/tests/operator_repo/test_bundle.py
+++ b/operator-pipeline-images/tests/operator_repo/test_bundle.py
@@ -1,0 +1,144 @@
+from pathlib import Path
+
+import pytest
+from operatorcert.operator_repo import Bundle, Repo
+from operatorcert.operator_repo.exceptions import (
+    InvalidBundleException,
+    InvalidOperatorException,
+)
+from tests.utils import bundle_files, create_files
+
+
+def test_bundle(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.1"),
+    )
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    bundle = operator.bundle("0.0.1")
+    assert bundle.root == operator.root / "0.0.1"
+    assert bundle.csv_operator_name == "hello"
+    assert bundle.csv_operator_version == "0.0.1"
+    assert (
+        bundle.annotations["operators.operatorframework.io.bundle.package.v1"]
+        == "hello"
+    )
+    assert bundle.dependencies == []
+    assert bundle.release_config == None
+
+
+def test_bundle_with_release_config(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.1"),
+        {"operators/hello/0.0.1/release-config.yaml": {"catalogs": []}},
+    )
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    bundle = operator.bundle("0.0.1")
+
+    assert bundle.release_config == {"catalogs": []}
+
+
+def test_bundle_compare(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.1"),
+        bundle_files("hello", "0.0.2"),
+        bundle_files("world", "0.1.0"),
+    )
+    repo = Repo(tmp_path)
+    operator_hello = repo.operator("hello")
+    operator_world = repo.operator("world")
+    assert operator_hello == repo.operator("hello")
+    assert operator_hello != operator_world
+    assert operator_hello < operator_world
+    hello_bundle_1 = operator_hello.bundle("0.0.1")
+    hello_bundle_2 = operator_hello.bundle("0.0.2")
+    world_bundle_1 = operator_world.bundle("0.1.0")
+    assert hello_bundle_1 != hello_bundle_2
+    assert hello_bundle_1 < hello_bundle_2
+    assert hello_bundle_1 != world_bundle_1
+    assert hello_bundle_1 < world_bundle_1
+    assert operator_hello.bundle("0.0.1") != operator_hello
+    with pytest.raises(TypeError):
+        _ = operator_hello.bundle("0.0.1") < operator_hello
+
+
+def test_bundle_non_semver(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.99.0"),
+        bundle_files("hello", "0.0.100.0"),
+    )
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    bundle_99 = operator.bundle("0.0.99.0")
+    bundle_100 = operator.bundle("0.0.100.0")
+    assert bundle_99 > bundle_100
+    assert operator.channels == {"beta"}
+    assert operator.default_channel == "beta"
+
+
+def test_bundle_invalid(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files(
+            "invalid_csv_name", "0.0.1", csv={"metadata": {"name": "rubbish"}}
+        ),
+        {
+            "operators/missing_manifests/0.0.1/metadata/annotations.yaml": {
+                "annotations": {}
+            }
+        },
+        bundle_files("invalid_csv_contents", "0.0.1"),
+        {
+            "operators/invalid_csv_contents/0.0.1/manifests/invalid_csv_contents.clusterserviceversion.yaml": [],
+        },
+        bundle_files("invalid_metadata_contents", "0.0.1"),
+        {
+            "operators/invalid_metadata_contents/0.0.1/metadata/annotations.yaml": [],
+        },
+        bundle_files("empty_metadata", "0.0.1"),
+        {
+            "operators/empty_metadata/0.0.1/metadata/annotations.yaml": "",
+        },
+        {
+            "operators/missing_csv/0.0.1/metadata/annotations.yaml": {
+                "annotations": {}
+            },
+            "operators/missing_csv/0.0.1/manifests": None,
+        },
+        bundle_files("one_empty_bundle", "0.0.1"),
+        {
+            "operators/one_empty_bundle/0.0.2": None,
+        },
+    )
+    repo = Repo(tmp_path)
+    with pytest.raises(InvalidBundleException, match="has invalid .metadata.name"):
+        _ = repo.operator("invalid_csv_name").bundle("0.0.1").csv_operator_name
+    assert not repo.has("missing_manifests")
+    with pytest.raises(InvalidBundleException, match="Not a valid bundle"):
+        _ = Bundle(repo.root / "operators" / "missing_manifests" / "0.0.1")
+    with pytest.raises(InvalidOperatorException, match="Not a valid operator"):
+        _ = repo.operator("missing_manifests")
+    assert repo.has("invalid_csv_contents")
+    with pytest.raises(InvalidBundleException, match="Invalid CSV contents"):
+        _ = repo.operator("invalid_csv_contents").bundle("0.0.1").csv_operator_version
+    with pytest.raises(InvalidBundleException, match="Invalid .* contents"):
+        _ = repo.operator("invalid_metadata_contents").bundle("0.0.1").annotations
+    assert repo.operator("empty_metadata").bundle("0.0.1").annotations == {}
+    assert repo.operator("empty_metadata").channels == set()
+    assert repo.operator("empty_metadata").default_channel is None
+    assert repo.has("missing_csv")
+    with pytest.raises(InvalidBundleException, match="CSV file for .* not found"):
+        _ = repo.operator("missing_csv").bundle("0.0.1").csv_operator_name
+    assert list(repo.operator("one_empty_bundle")) == [
+        repo.operator("one_empty_bundle").bundle("0.0.1")
+    ]
+
+
+def test_bundle_caching(mock_bundle: Bundle) -> None:
+    assert Bundle(mock_bundle.root).operator == mock_bundle.operator
+    assert Bundle(mock_bundle.root).operator is not mock_bundle.operator

--- a/operator-pipeline-images/tests/operator_repo/test_catalog.py
+++ b/operator-pipeline-images/tests/operator_repo/test_catalog.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+import pytest
+from operatorcert.operator_repo import Catalog, Repo
+from operatorcert.operator_repo.exceptions import InvalidCatalogException
+from tests.utils import bundle_files, catalog_files, create_files
+
+
+def test_no_catalog(tmp_path: Path) -> None:
+    create_files(tmp_path, bundle_files("fake-operator", "0.0.1"))
+    repo = Repo(tmp_path)
+    assert list(repo.all_catalogs()) == []
+
+
+def test_invalid_catalog(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator"),
+        bundle_files("fake-operator", "0.0.1"),
+    )
+    repo = Repo(tmp_path)
+    with pytest.raises(InvalidCatalogException):
+        Catalog(repo.root / "catalogs" / "not-found")
+
+
+def test_catalog_empty(tmp_path: Path) -> None:
+    create_files(
+        tmp_path, {"catalogs/readme.txt": "hello", "operators/readme.txt": "hello"}
+    )
+    repo = Repo(tmp_path)
+    assert not repo.has_catalog("hello")
+
+
+def test_catalog_one_operator(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator"),
+        bundle_files("fake-operator", "0.0.1"),
+        {"catalogs/readme.txt": "hello"},
+    )
+    repo = Repo(tmp_path)
+    assert list(repo.all_catalogs()) == [repo.catalog("v4.14")]
+    catalog = repo.catalog("v4.14")
+    assert repr(catalog) == "Catalog(v4.14)"
+    assert catalog.repo == repo
+    assert Catalog(catalog.root).repo == repo
+    operator = catalog.operator_catalog("fake-operator")
+    assert len(list(catalog)) == 1
+    assert set(catalog) == {operator}
+    assert not catalog.has("not-found")
+    assert catalog.has("fake-operator")
+
+
+def test_catalog_compare(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator"),
+        catalog_files("v4.14", "fake-operator-2"),
+        catalog_files("v4.15", "fake-operator-2"),
+        bundle_files("fake-operator", "0.0.1"),
+    )
+    repo = Repo(tmp_path)
+
+    assert repo.catalog("v4.14") == repo.catalog("v4.14")
+    assert repo.catalog("v4.14") != repo.catalog("v4.15")
+    assert repo.catalog("v4.14") < repo.catalog("v4.15")
+    assert repo.catalog("v4.14") != {"foo": "bar"}
+    with pytest.raises(TypeError):
+        repo.catalog("v4.14") < {"foo": "bar"}

--- a/operator-pipeline-images/tests/operator_repo/test_cli.py
+++ b/operator-pipeline-images/tests/operator_repo/test_cli.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+from typing import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from _pytest.capture import CaptureFixture
+from operatorcert.operator_repo import Bundle, Operator, Repo
+from operatorcert.operator_repo.checks import CheckResult
+from operatorcert.operator_repo.cli import _get_repo, main, parse_target
+
+
+def test_cli_parse_target(mock_repo: Repo) -> None:
+    assert parse_target(mock_repo, "hello") == mock_repo.operator("hello")
+    assert parse_target(mock_repo, "world/0.0.1") == mock_repo.operator("world").bundle(
+        "0.0.1"
+    )
+
+
+def test_cli_list(mock_repo: Repo, capsys: CaptureFixture[str]) -> None:
+    with patch("sys.argv", ["optool", "-r", str(mock_repo.root), "list", "hello"]):
+        main()
+    captured = capsys.readouterr()
+    assert "hello/0.0.1" in captured.out
+    assert "hello/0.0.2" in captured.out
+    assert "v4.17/hello" in captured.out
+    assert "v4.18/hello" in captured.out
+
+
+def test_cli_list_repo(mock_repo: Repo, capsys: CaptureFixture[str]) -> None:
+    with patch("sys.argv", ["optool", "-r", str(mock_repo.root), "list"]):
+        main()
+    captured = capsys.readouterr()
+    assert "hello" in captured.out
+    assert "world" in captured.out
+
+
+def test_cli_list_bundle(mock_repo: Repo, capsys: CaptureFixture[str]) -> None:
+    with patch(
+        "sys.argv", ["optool", "-r", str(mock_repo.root), "list", "hello/0.0.1"]
+    ):
+        main()
+    captured = capsys.readouterr()
+    assert "hello/0.0.1" in captured.out
+    assert "hello/0.0.2" not in captured.out
+
+
+def test_cli_list_recursive(mock_repo: Repo, capsys: CaptureFixture[str]) -> None:
+    with patch("sys.argv", ["optool", "-r", str(mock_repo.root), "list", "-R"]):
+        main()
+    captured = capsys.readouterr()
+    assert "hello/0.0.1" in captured.out
+    assert "hello/0.0.2" in captured.out
+    assert "world/0.0.1" in captured.out
+    assert "world/0.0.2" in captured.out
+
+
+def test_cli_check(mock_repo: Repo, capsys: CaptureFixture[str]) -> None:
+    with patch("sys.argv", ["optool", "-r", str(mock_repo.root), "check", "world"]):
+        main()
+    captured = capsys.readouterr()
+    assert (
+        "Operator's 'ci.yaml' contains invalid data which does not comply"
+        in captured.out
+    )
+
+
+def test_cli_check_recursive(mock_repo: Repo, capsys: CaptureFixture[str]) -> None:
+    with patch("sys.argv", ["optool", "-r", str(mock_repo.root), "check", "-R"]):
+        main()
+    captured = capsys.readouterr()
+    assert "check_operator_name(Bundle(world/0.0.2)): Operator name from "
+    "annotations.yaml (fake-incorect-name) does not match" in captured.out
+
+
+def test_cli_check_operator_recursive(
+    mock_repo: Repo, capsys: CaptureFixture[str]
+) -> None:
+    with patch(
+        "sys.argv", ["optool", "-r", str(mock_repo.root), "check", "-R", "world"]
+    ):
+        main()
+    captured = capsys.readouterr()
+    assert (
+        "check_operator_name(Bundle(world/0.0.2)): Operator name from "
+        "annotations.yaml (fake-incorect-name) does not match" in captured.out
+    )
+
+
+@patch("operatorcert.operator_repo.cli.get_checks")
+def test_cli_check_list(mock_checks: MagicMock, capsys: CaptureFixture[str]) -> None:
+    def check_foo(_: Operator) -> Iterator[CheckResult]:
+        """This is the check_foo description"""
+        raise StopIteration
+
+    def check_bar(_: Bundle) -> Iterator[CheckResult]:
+        """This is the check_bar description"""
+        raise StopIteration
+
+    mock_checks.return_value = {"operator": [check_foo], "bundle": [check_bar]}
+    with patch("sys.argv", ["optool", "check", "--list"]):
+        main()
+    captured = capsys.readouterr()
+    assert "This is the check_foo description" in captured.out
+    assert "This is the check_bar description" in captured.out
+
+
+@patch("operatorcert.operator_repo.cli.Path.cwd")
+def test_cli_get_repo(mock_cwd: MagicMock, mock_repo: Repo) -> None:
+    mock_cwd.return_value = mock_repo.root
+    assert _get_repo() == mock_repo
+
+
+@patch("operatorcert.operator_repo.cli.Path.cwd")
+def test_cli_get_repo_invalid(
+    mock_cwd: MagicMock, tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
+    mock_cwd.return_value = tmp_path
+    with pytest.raises(SystemExit):
+        _ = _get_repo()
+    captured = capsys.readouterr()
+    assert "is not a valid operator repository" in captured.out
+
+
+def test_cli_help(capsys: CaptureFixture[str]) -> None:
+    with patch("sys.argv", ["optool"]):
+        main()
+    captured = capsys.readouterr()
+    assert "usage: optool" in captured.out

--- a/operator-pipeline-images/tests/operator_repo/test_operator.py
+++ b/operator-pipeline-images/tests/operator_repo/test_operator.py
@@ -1,0 +1,221 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from operatorcert.operator_repo import Operator, Repo
+from tests.utils import bundle_files, create_files
+
+
+def test_operator_empty(tmp_path: Path) -> None:
+    create_files(tmp_path, {"operators/hello/readme.txt": "hello"})
+    repo = Repo(tmp_path)
+    assert not repo.has("hello")
+
+
+def test_operator_no_bundles(tmp_path: Path) -> None:
+    create_files(tmp_path, {"operators/hello/ci.yaml": "hello"})
+    repo = Repo(tmp_path)
+    assert repo.has("hello")
+
+    assert repo.operator("hello").head("beta") is None
+
+
+def test_operator_one_bundle(tmp_path: Path) -> None:
+    create_files(tmp_path, bundle_files("hello", "0.0.1"))
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    assert operator.repo == repo
+    assert Operator(operator.root).repo == repo
+    bundle = operator.bundle("0.0.1")
+    assert len(list(operator)) == 1
+    assert set(operator) == {bundle}
+    assert operator.has("0.0.1")
+    assert bundle.operator == operator
+    assert operator.config == {}
+    assert bundle.dependencies == []
+    assert operator.root == repo.root / "operators" / "hello"
+    assert "hello" in repr(operator)
+    assert operator != "foo"
+    with pytest.raises(TypeError):
+        _ = operator < "foo"
+
+
+def test_channels(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.1"),
+        bundle_files("hello", "0.0.2", csv={"spec": {"replaces": "hello.v0.0.1"}}),
+        bundle_files(
+            "hello",
+            "0.1.0",
+            csv={"spec": {"replaces": "hello.v0.0.2"}},
+            annotations={
+                "operators.operatorframework.io.bundle.channel.default.v1": "candidate",
+                "operators.operatorframework.io.bundle.channels.v1": "beta,candidate",
+            },
+        ),
+        bundle_files(
+            "hello",
+            "1.0.0",
+            csv={"spec": {"replaces": "hello.v0.1.0"}},
+            annotations={
+                "operators.operatorframework.io.bundle.channel.default.v1": "stable",
+                "operators.operatorframework.io.bundle.channels.v1": "beta,candidate,stable",
+            },
+        ),
+        bundle_files("hello", "1.0.1", csv={"spec": {"replaces": "hello.v1.0.0"}}),
+    )
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    bundle001 = operator.bundle("0.0.1")
+    bundle002 = operator.bundle("0.0.2")
+    bundle010 = operator.bundle("0.1.0")
+    bundle100 = operator.bundle("1.0.0")
+    bundle101 = operator.bundle("1.0.1")
+    assert operator.channels == {"beta", "candidate", "stable"}
+    assert operator.default_channel == "beta"
+    assert operator.channel_bundles("beta") == [
+        bundle001,
+        bundle002,
+        bundle010,
+        bundle100,
+        bundle101,
+    ]
+    assert operator.channel_bundles("candidate") == [bundle010, bundle100]
+    assert operator.channel_bundles("stable") == [bundle100]
+    assert operator.head("beta") == bundle101
+    assert operator.head("candidate") == bundle100
+    assert operator.head("stable") == bundle100
+
+
+def test_update_graph(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.1"),
+        bundle_files("hello", "0.0.2", csv={"spec": {"replaces": "hello.v0.0.1"}}),
+        bundle_files("hello", "0.0.3", csv={"spec": {"replaces": "hello.v0.0.2"}}),
+        bundle_files(
+            "hello",
+            "0.0.4",
+            csv={"spec": {"replaces": "hello.v0.0.2", "skips": ["hello.v0.0.3"]}},
+        ),
+        bundle_files(
+            "hello",
+            "0.0.5",
+            csv={
+                "spec": {"replaces": "hello.v0.0.2"},
+                "metadata": {"annotations": {"olm.skipRange": ">=0.0.3 <0.0.5"}},
+            },
+        ),
+    )
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    bundle1 = operator.bundle("0.0.1")
+    bundle2 = operator.bundle("0.0.2")
+    bundle3 = operator.bundle("0.0.3")
+    bundle4 = operator.bundle("0.0.4")
+    bundle5 = operator.bundle("0.0.5")
+    assert operator.head("beta") == bundle5
+    update = operator.update_graph("beta")
+    assert update[bundle1] == {bundle2}
+    assert update[bundle2] == {bundle3, bundle4, bundle5}
+    assert update[bundle3] == {bundle4, bundle5}
+    assert update[bundle4] == {bundle5}
+
+
+@patch("operatorcert.operator_repo.core.log")
+def test_update_graph_invalid_skip_range(mock_log: MagicMock, tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.1"),
+        bundle_files(
+            "hello",
+            "0.0.2",
+            # Range cannot contain the letter 'v', raises ValueError
+            csv={
+                "spec": {"replaces": "hello.v0.0.1"},
+                "metadata": {"annotations": {"olm.skipRange": "<v0.0.2"}},
+            },
+        ),
+    )
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    bundle1 = operator.bundle("0.0.1")
+    bundle2 = operator.bundle("0.0.2")
+    assert operator.head("beta") == bundle2
+    update = operator.update_graph("beta")
+    # Field 'replaces' works and the code does not fail, but a warning is logged
+    mock_log.warning.assert_called()
+    assert update[bundle1] == {bundle2}
+
+
+def test_update_graph_invalid_replaces(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.1"),
+        # To avoid erroring out on old bundles with inconsistent operator name
+        # we ignore the operator name when creating the update graph and assume
+        # all bundles within the same operator directory belong to the same operator
+        bundle_files("hello", "0.0.2", csv={"spec": {"replaces": "other.v0.0.1"}}),
+    )
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    update = operator.update_graph("beta")
+    bundle1 = operator.bundle("0.0.1")
+    bundle2 = operator.bundle("0.0.2")
+    assert update[bundle1] == {bundle2}
+
+
+def test_update_graph_replaces_missing_bundle(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.2", csv={"spec": {"replaces": "hello.v0.0.1"}}),
+    )
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    _ = operator.update_graph("beta")
+
+
+def test_update_graph_invalid_operator_name(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.1", csv={"metadata": {"name": "other.v0.0.1"}}),
+        # To avoid erroring out on old bundles with inconsistent operator name
+        # we ignore the operator name when creating the update graph and assume
+        # all bundles within the same operator directory belong to the same operator
+        bundle_files("hello", "0.0.2", csv={"spec": {"replaces": "hello.v0.0.1"}}),
+    )
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    update = operator.update_graph("beta")
+    bundle1 = operator.bundle("0.0.1")
+    bundle2 = operator.bundle("0.0.2")
+    assert update[bundle1] == {bundle2}
+
+
+def test_update_graph_semver(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.1"),
+        bundle_files("hello", "0.0.2"),
+        {"operators/hello/ci.yaml": {"updateGraph": "semver-mode"}},
+    )
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    bundle1 = operator.bundle("0.0.1")
+    bundle2 = operator.bundle("0.0.2")
+    update = operator.update_graph("beta")
+    assert update[bundle1] == {bundle2}
+
+
+def test_update_graph_unsupported(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        bundle_files("hello", "0.0.1"),
+        bundle_files("hello", "0.0.2"),
+        {"operators/hello/ci.yaml": {"updateGraph": "semver-skippatch"}},
+    )
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    with pytest.raises(NotImplementedError, match="unsupported updateGraph value"):
+        _ = operator.update_graph("beta")

--- a/operator-pipeline-images/tests/operator_repo/test_operator_catalog.py
+++ b/operator-pipeline-images/tests/operator_repo/test_operator_catalog.py
@@ -1,0 +1,130 @@
+from pathlib import Path
+
+import pytest
+from operatorcert.operator_repo import OperatorCatalog, OperatorCatalogList, Repo
+from operatorcert.operator_repo.exceptions import InvalidOperatorCatalogException
+from tests.utils import bundle_files, catalog_files, create_files
+
+
+def test_invalid_catalog(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator"),
+        bundle_files("fake-operator", "0.0.1"),
+    )
+    repo = Repo(tmp_path)
+    with pytest.raises(InvalidOperatorCatalogException):
+        OperatorCatalog(repo.root / "catalogs" / "4.14" / "not-found")
+
+
+def test_operator_catalog(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator", content=({"foo": "bar"},)),
+        catalog_files("v4.13", "fake-operator-2"),
+        bundle_files("fake-operator", "0.0.1"),
+    )
+    repo = Repo(tmp_path)
+    catalog = repo.catalog("v4.14")
+    assert len(list(catalog.all_operator_catalogs())) == 1
+    operator_catalog = catalog.operator_catalog("fake-operator")
+
+    assert repr(operator_catalog) == "OperatorCatalog(v4.14/fake-operator)"
+    assert operator_catalog == "v4.14/fake-operator"
+
+    # create operator catalog directly without Catalog
+    catalog_without_parent = OperatorCatalog(repo.catalog_path("v4.14/fake-operator"))
+    assert catalog_without_parent == operator_catalog
+    assert catalog_without_parent.operator_catalog_name == "v4.14/fake-operator"
+
+    assert operator_catalog.repo == repo
+    assert operator_catalog.catalog == catalog
+
+    assert (
+        operator_catalog.catalog_content_path == operator_catalog.root / "catalog.yaml"
+    )
+
+    assert operator_catalog.catalog_content == [{"foo": "bar"}]
+
+    assert operator_catalog == catalog.operator_catalog("fake-operator")
+
+    operator_catalog = OperatorCatalog(operator_catalog.root)
+    assert operator_catalog.catalog == catalog
+
+    assert operator_catalog.operator == repo.operator("fake-operator")
+
+    assert list(repo.operator("fake-operator").all_catalogs()) == [catalog]
+
+
+def test_catalog_operator_compare(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator"),
+        catalog_files("v4.15", "fake-operator"),
+        bundle_files("fake-operator", "0.0.1"),
+    )
+    repo = Repo(tmp_path)
+    catalog = repo.catalog("v4.14")
+    catalog2 = repo.catalog("v4.15")
+    operator_catalog1 = catalog.operator_catalog("fake-operator")
+    operator_catalog2 = catalog2.operator_catalog("fake-operator")
+
+    assert operator_catalog1 == operator_catalog1
+    assert operator_catalog1 != operator_catalog2
+    assert operator_catalog1 < operator_catalog2
+
+    assert len({operator_catalog1, operator_catalog1}) == 1
+    assert len({operator_catalog1, operator_catalog2}) == 2
+
+    assert operator_catalog1 == "v4.14/fake-operator"
+    assert "v4.14/fake-operator" == operator_catalog1
+
+    assert operator_catalog1 != "foo"
+    assert operator_catalog1 != 42
+    with pytest.raises(TypeError):
+        operator_catalog1 < "foo"
+
+
+def test_operator_catalog_list(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        catalog_files("v4.14", "fake-operator"),
+        catalog_files("v4.14", "fake-operator-2"),
+        catalog_files("v4.14", "fake-operator-3"),
+        catalog_files("v4.14", "fake-operator-4"),
+        bundle_files("fake-operator", "0.0.1"),
+    )
+    repo = Repo(tmp_path)
+    catalog = repo.catalog("v4.14")
+    operator_catalog = catalog.operator_catalog("fake-operator")
+    operator_catalog2 = catalog.operator_catalog("fake-operator-2")
+    operator_catalog3 = catalog.operator_catalog("fake-operator-3")
+    operator_catalog4 = catalog.operator_catalog("fake-operator-4")
+
+    empty_operator_catalog_list = OperatorCatalogList()
+    assert len(empty_operator_catalog_list) == 0
+    operator_catalog_list = OperatorCatalogList([operator_catalog, operator_catalog])
+    assert len(operator_catalog_list) == 1
+    assert repr(operator_catalog_list) == "[OperatorCatalog(v4.14/fake-operator)]"
+    operator_catalog_list.append(operator_catalog2)
+    operator_catalog_list.extend([operator_catalog3])
+    operator_catalog_list.insert(0, operator_catalog4)
+    assert len(operator_catalog_list) == 4
+
+    assert operator_catalog in operator_catalog_list
+    assert "v4.14/fake-operator-4" in operator_catalog_list
+
+    with pytest.raises(ValueError):
+        operator_catalog_list.append(operator_catalog)
+    with pytest.raises(ValueError):
+        operator_catalog_list.insert(0, operator_catalog)
+    with pytest.raises(ValueError):
+        operator_catalog_list.extend([operator_catalog])
+    with pytest.raises(TypeError):
+        OperatorCatalogList(["foo", 1])  # type: ignore
+    with pytest.raises(TypeError):
+        operator_catalog_list.append("foo")
+    with pytest.raises(TypeError):
+        operator_catalog_list.extend([1, 2, 3])
+    with pytest.raises(TypeError):
+        operator_catalog_list.insert(0, {"foo": "bar"})

--- a/operator-pipeline-images/tests/operator_repo/test_repo.py
+++ b/operator-pipeline-images/tests/operator_repo/test_repo.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import pytest
+from operatorcert.operator_repo import Repo
+from operatorcert.operator_repo.exceptions import InvalidRepoException
+from tests.utils import bundle_files, catalog_files, create_files
+
+
+def test_repo_non_existent() -> None:
+    with pytest.raises(InvalidRepoException, match="Not a valid operator repository"):
+        _ = Repo("/non_existent")
+
+
+def test_repo_empty(tmp_path: Path) -> None:
+    with pytest.raises(InvalidRepoException, match="Not a valid operator repository"):
+        _ = Repo(str(tmp_path))
+
+
+def test_repo_no_operators(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        {
+            "operators": None,
+            "config.yaml": {"hello": "world"},
+        },
+    )
+    repo = Repo(tmp_path)
+    assert len(list(repo)) == 0
+    assert repo.config == {"hello": "world"}
+    assert repo.root == tmp_path.resolve()
+    assert str(tmp_path) in repr(repo)
+
+
+def test_repo_one_bundle(tmp_path: Path) -> None:
+    create_files(
+        tmp_path, bundle_files("hello", "0.0.1"), catalog_files("v4.14", "hello")
+    )
+    repo = Repo(tmp_path)
+    assert repo.config == {}
+    assert len(list(repo)) == 1
+    assert set(repo) == {repo.operator("hello")}
+    assert repo.has("hello")
+    assert repo != "foo"
+    assert repo.has_catalog("v4.14")

--- a/operator-pipeline-images/tests/operator_repo/test_utils.py
+++ b/operator-pipeline-images/tests/operator_repo/test_utils.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import pytest
+from operatorcert.operator_repo.exceptions import OperatorRepoException
+from operatorcert.operator_repo.utils import load_multidoc_yaml, load_yaml, lookup_dict
+from tests.operator_repo import create_files
+
+
+def test_load_yaml(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        {"data/en.yml": {"hello": "world"}},
+        {"data/it.yaml": {"ciao": "mondo"}},
+        {"data/something.txt": {"foo": "bar"}},
+    )
+    assert load_yaml(tmp_path / "data/en.yaml") == {"hello": "world"}
+    assert load_yaml(tmp_path / "data/en.yml") == {"hello": "world"}
+    assert load_yaml(tmp_path / "data/it.yaml") == {"ciao": "mondo"}
+    assert load_yaml(tmp_path / "data/it.yml") == {"ciao": "mondo"}
+    assert load_yaml(tmp_path / "data/something.txt") == {"foo": "bar"}
+    with pytest.raises(FileNotFoundError):
+        _ = load_yaml(tmp_path / "data/something.yaml")
+    with pytest.raises(FileNotFoundError):
+        _ = load_yaml(tmp_path / "data/something.yml")
+
+
+def test_load_yaml_invalid(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        {"data/multi-doc.yml": "---\nhello: world\n---\nfoo: bar\n"},
+        {"data/invalid.yaml": "{This is not a valid\nyaml document]\n"},
+    )
+    with pytest.raises(OperatorRepoException, match="contains multiple yaml documents"):
+        _ = load_yaml(tmp_path / "data/multi-doc.yml")
+    with pytest.raises(OperatorRepoException, match="is not a valid yaml document"):
+        _ = load_yaml(tmp_path / "data/invalid.yml")
+
+
+def test_load_multidoc_yaml(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        {"data/all.yml": ({"hello": "world"}, {"ciao": "mondo"})},
+    )
+    assert load_multidoc_yaml(tmp_path / "data/all.yaml") == [
+        {"hello": "world"},
+        {"ciao": "mondo"},
+    ]
+    with pytest.raises(FileNotFoundError):
+        _ = load_multidoc_yaml(tmp_path / "data/something.yaml")
+
+
+def test_load_multidoc_yaml_invalid(tmp_path: Path) -> None:
+    create_files(
+        tmp_path,
+        {"data/invalid.yaml": "{This is not a valid\nyaml document]\n"},
+    )
+    with pytest.raises(OperatorRepoException, match="is not a valid yaml document"):
+        _ = load_multidoc_yaml(tmp_path / "data/invalid.yml")
+
+
+def test_lookup_dict() -> None:
+    data = {"hello": "world", "sub1": {"sub3": "value1"}}
+    assert lookup_dict(data, "hello") == "world"
+    assert lookup_dict(data, "sub1.sub3") == "value1"
+    assert lookup_dict(data, "sub1/sub3", separator="/") == "value1"
+    assert lookup_dict(data, "sub2") is None
+    assert lookup_dict(data, "sub2", default="") == ""

--- a/operator-pipeline-images/tests/static_tests/common/test_bundle.py
+++ b/operator-pipeline-images/tests/static_tests/common/test_bundle.py
@@ -1,16 +1,15 @@
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from typing import Any
+
 import pytest
-from operator_repo import Repo
-from operator_repo.checks import Fail, Warn
+from operatorcert.operator_repo import Repo
+from operatorcert.operator_repo.checks import Fail, Warn
 from operatorcert.static_tests.common.bundle import (
-    check_operator_name,
     check_bundle_release_config,
+    check_operator_name,
     check_validate_schema_bundle_release_config,
 )
 from tests.utils import bundle_files, create_files
-
-from typing import Any
 
 
 @pytest.mark.parametrize(

--- a/operator-pipeline-images/tests/static_tests/common/test_operator.py
+++ b/operator-pipeline-images/tests/static_tests/common/test_operator.py
@@ -1,14 +1,14 @@
 from pathlib import Path
+from typing import Any
+
 import pytest
-from operator_repo import Repo
-from operator_repo.checks import Fail
+from operatorcert.operator_repo import Repo
+from operatorcert.operator_repo.checks import Fail
 from operatorcert.static_tests.common.operator import (
     check_catalog_usage_ci_config,
     check_schema_operator_ci_config,
 )
 from tests.utils import bundle_files, create_files
-
-from typing import Any
 
 
 @pytest.mark.parametrize(
@@ -173,7 +173,7 @@ from typing import Any
 def test_check_schema_operator_ci_config(
     tmp_path: Path,
     files: list[dict[str, Any]],
-    operator_to_check: tuple[str, str],
+    operator_to_check: str,
     expected_results: set[tuple[type, str]],
 ) -> None:
     create_files(tmp_path, *files)
@@ -265,7 +265,7 @@ def test_check_schema_operator_ci_config(
 def test_check_catalog_usage_ci_config(
     tmp_path: Path,
     files: list[dict[str, Any]],
-    operator_to_check: tuple[str, str],
+    operator_to_check: str,
     expected_results: set[tuple[type, str]],
 ) -> None:
     create_files(tmp_path, *files)

--- a/operator-pipeline-images/tests/static_tests/common/test_operator_catalogs.py
+++ b/operator-pipeline-images/tests/static_tests/common/test_operator_catalogs.py
@@ -2,8 +2,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-
-from operator_repo import OperatorCatalogList, Repo
+from operatorcert.operator_repo import OperatorCatalogList, Repo
 from operatorcert.static_tests.common.operator_catalogs import (
     check_bundle_images_in_fbc,
 )

--- a/operator-pipeline-images/tests/static_tests/community/test_bundle.py
+++ b/operator-pipeline-images/tests/static_tests/community/test_bundle.py
@@ -1,21 +1,21 @@
 import re
 from pathlib import Path
 from typing import Any, Dict, Optional, Set
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
-from operator_repo import Repo
-from operator_repo.checks import CheckResult, Fail, Warn
+from operatorcert.operator_repo import Repo
+from operatorcert.operator_repo.checks import CheckResult, Fail, Warn
 from operatorcert.static_tests.community.bundle import (
+    check_api_version_constraints,
     check_dangling_bundles,
     check_osdk_bundle_validate_operator_framework,
     check_osdk_bundle_validate_operatorhub,
-    check_required_fields,
-    run_operator_sdk_bundle_validate,
-    check_api_version_constraints,
     check_replaces_availability,
+    check_required_fields,
     check_using_fbc,
     ocp_to_k8s_ver,
+    run_operator_sdk_bundle_validate,
 )
 from semver import Version
 from tests.utils import bundle_files, create_files, merge

--- a/operator-pipeline-images/tests/static_tests/community/test_operator.py
+++ b/operator-pipeline-images/tests/static_tests/community/test_operator.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 from typing import Any
+from unittest.mock import PropertyMock, patch
 
 import pytest
-from unittest.mock import patch, PropertyMock
-from operator_repo import Repo
-from operator_repo.checks import Fail, Warn
+from operatorcert.operator_repo import Repo
+from operatorcert.operator_repo.checks import Fail, Warn
 from operatorcert.static_tests.community.operator import (
     check_ci_upgrade_graph,
     check_operator_name_unique,

--- a/operator-pipeline-images/tests/static_tests/isv/test_bundle.py
+++ b/operator-pipeline-images/tests/static_tests/isv/test_bundle.py
@@ -2,8 +2,8 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 import pytest
-from operator_repo import Repo
-from operator_repo.checks import Fail, Warn
+from operatorcert.operator_repo import Repo
+from operatorcert.operator_repo.checks import Fail, Warn
 from operatorcert.static_tests.isv.bundle import (
     PRUNED_GRAPH_ERROR,
     check_marketplace_annotation,

--- a/operator-pipeline-images/tests/static_tests/test_helpers.py
+++ b/operator-pipeline-images/tests/static_tests/test_helpers.py
@@ -1,8 +1,8 @@
-from typing import Any, Iterator
+from typing import Iterator
+from unittest.mock import MagicMock, call, patch
 
+from operatorcert.operator_repo import Bundle, Operator
 from operatorcert.static_tests.helpers import skip_fbc
-from operator_repo import Operator, Bundle
-from unittest.mock import call, MagicMock, patch
 
 
 @patch("operatorcert.static_tests.helpers.LOGGER")

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "operatorcert-dev", "tox"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:d32b7a87f705a713d9c90ccec15848511c83155e55d0fb2d7b63e832fe3f69f3"
+content_hash = "sha256:d03c616ff24e16ab8cee2d66e8b8c436adb692a406ca0a38695e7ebb4be0bfb9"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -1217,20 +1217,6 @@ dependencies = [
 files = [
     {file = "openshift_client-2.0.5-py3-none-any.whl", hash = "sha256:d90e42dc63ba1e4a871d8ee3c5367e6ba1001028f1c8b594d8b727fdfb26af7d"},
     {file = "openshift_client-2.0.5.tar.gz", hash = "sha256:7fc386e68ff673a7a94a26d70972200bb5e37370d7f2f651d02ac1aa65144415"},
-]
-
-[[package]]
-name = "operator-repo"
-version = "0.4.12"
-requires_python = ">=3.9"
-git = "https://github.com/mporrato/operator-repo.git"
-ref = "v0.4.12"
-revision = "b0d2185b2c356a6fd0dc50b716e30d385479ce74"
-summary = "Library and utilities to handle repositories of kubernetes operators"
-groups = ["default"]
-dependencies = [
-    "pyyaml>=6.0.1",
-    "semantic-version>=2.10.0",
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,3 @@
-[tool.black]
-target_version = ['py312']
 
 [tool.pdm.build]
 package-dir = "./operator-pipeline-images"
@@ -31,11 +29,11 @@ dependencies = [
     "PyGithub<2.0,>=1.59.0",
     "GitPython>=3.1.37",
     "semver>=3.0.1",
-    "operator-repo @ git+https://github.com/mporrato/operator-repo.git@v0.4.12",
     "urllib3>=2.2.2",
     "openshift-client>=2.0.4",
     "pydantic>=2.10.0",
     "ruamel-yaml>=0.18.10",
+    "semantic-version>=2.10.0",
 ]
 
 [project.scripts]
@@ -65,6 +63,7 @@ invalidate-preflight-versions = "operatorcert.entrypoints.invalidate_preflight_v
 link-pull-request = "operatorcert.entrypoints.link_pull_request:main"
 ocp-version-info = "operatorcert.entrypoints.ocp_version_info:main"
 open-pull-request = "operatorcert.entrypoints.github_pr:main"
+optool = "operatorcert.operator_repo.cli:main"
 pipelinerun-summary = "operatorcert.entrypoints.pipelinerun_summary:main"
 preflight-result-filter = "operatorcert.entrypoints.preflight_result_filter:main"
 publish-pyxis-image = "operatorcert.entrypoints.publish_pyxis_image:main"

--- a/scripts/promote-catalog.py
+++ b/scripts/promote-catalog.py
@@ -5,14 +5,13 @@ import logging
 import os
 import re
 import shutil
-
 from datetime import datetime
-from git import Repo as GitRepo
 from pathlib import Path
 from typing import Any, Optional
 
+from git import Repo as GitRepo
 from operatorcert import github, ocp_version_info
-from operator_repo import Repo as OperatorRepo
+from operatorcert.operator_repo import Repo as OperatorRepo
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
The library is used only in single place and having it in a separate repository caused a difficulties in a development. This commit merges the library under the operatorcert module.

To merge the library here a couple of changes had to be done:
 - comply with mypy and pylint
 - remove sample test checks - replaced by the reals suites
 - update unit tests
 - fix couple of bugs that have been discovered during the merge process

JIRA: ISV-5650

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes