### PR TITLE
add-bundle-to-fbc: Create template dir if not exist

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-fbc.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-fbc.yml
@@ -79,9 +79,6 @@ spec:
           --operator-name "$(params.operator_name)" \
           --operator-version "$(params.operator_version)"
 
-        cat operators/$(params.operator_name)/catalog-templates/basic.yaml
-        cat operators/$(params.operator_name)/catalog-templates/semver.yaml
-
         # Loop over all catalogs in /catalogs and run opm validate to ensure the catalogs are valid
         for catalog in ./catalogs/*; do
           opm validate $catalog

--- a/operator-pipeline-images/operatorcert/entrypoints/add_bundle_to_fbc.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/add_bundle_to_fbc.py
@@ -7,6 +7,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from typing import Any
+from pathlib import Path
 
 from operatorcert import utils
 from operatorcert.logger import setup_logger
@@ -68,9 +69,22 @@ class CatalogTemplate(ABC):
         self.catalog_names = catalog_names
 
         self._template: dict[str, Any] = {}
-        self.template_path = (
-            self.operator.root / "catalog-templates" / self.template_name
-        )
+        self.template_path = self.template_dir / self.template_name
+
+    @property
+    def template_dir(self) -> Path:
+        """
+        Get a directory of the template and create it if it doesn't exist.
+
+        Returns:
+            Path: A path to the directory of the template.
+        """
+        path = self.operator.root / "catalog-templates"
+
+        # Create the directory if it doesn't exist
+        os.makedirs(path, exist_ok=True)
+
+        return path
 
     def exists(self) -> bool:
         """


### PR DESCRIPTION
In case of first release of the operator the directory for template might be missing. This commit creates the directory if missing.

JIRA: ISV-5740

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes