### PR TITLE
Sort parsed output for consistent data representation

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-index.yml
@@ -138,3 +138,5 @@ spec:
           # Save data about updated indices to volume
           echo "- ${FROM_INDEX_PROXY}:${VERSION}" | tee -a "$RELEASE_INFO_DIR_PATH/updated_indices.txt"
         done
+
+        sort -o "$RELEASE_INFO_DIR_PATH/updated_indices.txt" "$RELEASE_INFO_DIR_PATH/updated_indices.txt"

--- a/operator-pipeline-images/operatorcert/parsed_file.py
+++ b/operator-pipeline-images/operatorcert/parsed_file.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
 import yaml
+from operatorcert import utils
 from operatorcert.operator_repo import OperatorCatalog
 from operatorcert.operator_repo import Repo as OperatorRepo
 
@@ -42,13 +43,13 @@ class AffectedBundleCollection:
             Dict[str, Any]: A dictionary with the detected changes results
         """
         return {
-            "affected_bundles": [f"{x}/{y}" for x, y in self.union],
-            "added_bundles": [f"{x}/{y}" for x, y in self.added],
-            "modified_bundles": [f"{x}/{y}" for x, y in self.modified],
-            "deleted_bundles": [f"{x}/{y}" for x, y in self.deleted],
-            "added_or_modified_bundles": [
-                f"{x}/{y}" for x, y in self.added | self.modified
-            ],
+            "affected_bundles": sorted([f"{x}/{y}" for x, y in self.union]),
+            "added_bundles": sorted([f"{x}/{y}" for x, y in self.added]),
+            "modified_bundles": sorted([f"{x}/{y}" for x, y in self.modified]),
+            "deleted_bundles": sorted([f"{x}/{y}" for x, y in self.deleted]),
+            "added_or_modified_bundles": sorted(
+                [f"{x}/{y}" for x, y in self.added | self.modified]
+            ),
         }
 
 
@@ -73,11 +74,11 @@ class AffectedOperatorCollection:
             Dict[str, Any]: A dictionary with the detected changes results
         """
         return {
-            "affected_operators": list(self.union),
-            "added_operators": list(self.added),
-            "modified_operators": list(self.modified),
-            "deleted_operators": list(self.deleted),
-            "added_or_modified_operators": list(self.added | self.modified),
+            "affected_operators": sorted(list(self.union)),
+            "added_operators": sorted(list(self.added)),
+            "modified_operators": sorted(list(self.modified)),
+            "deleted_operators": sorted(list(self.deleted)),
+            "added_or_modified_operators": sorted(list(self.added | self.modified)),
         }
 
 
@@ -107,12 +108,14 @@ class AffectedCatalogOperatorCollection:
             Dict[str, Any]: A dictionary with the detected changes results
         """
         return {
-            "affected_catalog_operators": [f"{x}/{y}" for x, y in self.union],
-            "added_catalog_operators": [f"{x}/{y}" for x, y in self.added],
-            "modified_catalog_operators": [f"{x}/{y}" for x, y in self.modified],
-            "deleted_catalog_operators": [f"{x}/{y}" for x, y in self.deleted],
-            "catalogs_with_added_or_modified_operators": list(
-                self.catalogs_with_added_or_modified_operators
+            "affected_catalog_operators": sorted([f"{x}/{y}" for x, y in self.union]),
+            "added_catalog_operators": sorted([f"{x}/{y}" for x, y in self.added]),
+            "modified_catalog_operators": sorted(
+                [f"{x}/{y}" for x, y in self.modified]
+            ),
+            "deleted_catalog_operators": sorted([f"{x}/{y}" for x, y in self.deleted]),
+            "catalogs_with_added_or_modified_operators": utils.sort_versions(
+                list(self.catalogs_with_added_or_modified_operators)
             ),
         }
 
@@ -138,11 +141,13 @@ class AffectedCatalogCollection:
             Dict[str, Any]: A dictionary with the detected changes results
         """
         return {
-            "affected_catalogs": list(self.union),
-            "added_catalogs": list(self.added),
-            "modified_catalogs": list(self.modified),
-            "deleted_catalogs": list(self.deleted),
-            "added_or_modified_catalogs": list(self.added | self.modified),
+            "affected_catalogs": utils.sort_versions(list(self.union)),
+            "added_catalogs": utils.sort_versions(list(self.added)),
+            "modified_catalogs": utils.sort_versions(list(self.modified)),
+            "deleted_catalogs": utils.sort_versions(list(self.deleted)),
+            "added_or_modified_catalogs": utils.sort_versions(
+                list(self.added | self.modified)
+            ),
         }
 
 

--- a/operator-pipeline-images/operatorcert/utils.py
+++ b/operator-pipeline-images/operatorcert/utils.py
@@ -13,6 +13,7 @@ import yaml
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
+from packaging.version import Version
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -226,3 +227,19 @@ def copy_images_to_destination(
 
         LOGGER.info("Copying image to destination: %s", cmd)
         subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+
+
+def sort_versions(version_list: list[Any]) -> list[Any]:
+    """
+    Returns a sorted list of version strings in ascending order.
+    Example of the input: ["v4.12", "v4.11", "v4.9"]
+
+    The sorting is done by version number, not by string comparison.
+
+    Args:
+        version_list (list[Any]): A list of version strings to be sorted.
+
+    Returns:
+        list[Any]: A sorted list of version strings.
+    """
+    return sorted(version_list, key=lambda x: Version(x[1:]))

--- a/operator-pipeline-images/tests/test_parsed_file.py
+++ b/operator-pipeline-images/tests/test_parsed_file.py
@@ -1,0 +1,107 @@
+from operatorcert import parsed_file
+
+
+def test_AffectedBundleCollection() -> None:
+
+    bundles = parsed_file.AffectedBundleCollection(
+        added={("test_bundle", "1.0.0"), ("bundle-x", "2.9.0")},
+        deleted={("bundle-y", "1.0.0"), ("bundle-x", "2.9.0")},
+        modified={("bundle-z", "1.0.0"), ("bundle-x", "2.9.0")},
+    )
+
+    dict_result = bundles.to_dict()
+    assert dict_result == {
+        "added_bundles": ["bundle-x/2.9.0", "test_bundle/1.0.0"],
+        "deleted_bundles": ["bundle-x/2.9.0", "bundle-y/1.0.0"],
+        "modified_bundles": ["bundle-x/2.9.0", "bundle-z/1.0.0"],
+        "added_or_modified_bundles": [
+            "bundle-x/2.9.0",
+            "bundle-z/1.0.0",
+            "test_bundle/1.0.0",
+        ],
+        "affected_bundles": [
+            "bundle-x/2.9.0",
+            "bundle-y/1.0.0",
+            "bundle-z/1.0.0",
+            "test_bundle/1.0.0",
+        ],
+    }
+
+
+def test_AffectedOperatorCollection() -> None:
+    operator = parsed_file.AffectedOperatorCollection(
+        added={"test_operator", "operator-x"},
+        deleted={"operator-y", "operator-x"},
+        modified={"operator-z", "operator-x"},
+    )
+    dict_result = operator.to_dict()
+    assert dict_result == {
+        "added_operators": ["operator-x", "test_operator"],
+        "deleted_operators": ["operator-x", "operator-y"],
+        "modified_operators": ["operator-x", "operator-z"],
+        "added_or_modified_operators": [
+            "operator-x",
+            "operator-z",
+            "test_operator",
+        ],
+        "affected_operators": [
+            "operator-x",
+            "operator-y",
+            "operator-z",
+            "test_operator",
+        ],
+    }
+
+
+def test_AffectedCatalogOperatorCollection() -> None:
+    catalog_operators = parsed_file.AffectedCatalogOperatorCollection(
+        added={
+            ("v4.11", "test_catalog_operator"),
+            ("v4.12", "test_catalog_operator"),
+            ("v4.12", "catalog_operator-x"),
+        },
+        deleted={("v4.12", "catalog_operator-y"), ("v4.12", "catalog_operator-x")},
+        modified={("v4.12", "catalog_operator-z"), ("v4.12", "catalog_operator-x")},
+    )
+
+    dict_result = catalog_operators.to_dict()
+    assert dict_result == {
+        "added_catalog_operators": [
+            "v4.11/test_catalog_operator",
+            "v4.12/catalog_operator-x",
+            "v4.12/test_catalog_operator",
+        ],
+        "deleted_catalog_operators": [
+            "v4.12/catalog_operator-x",
+            "v4.12/catalog_operator-y",
+        ],
+        "modified_catalog_operators": [
+            "v4.12/catalog_operator-x",
+            "v4.12/catalog_operator-z",
+        ],
+        "affected_catalog_operators": [
+            "v4.11/test_catalog_operator",
+            "v4.12/catalog_operator-x",
+            "v4.12/catalog_operator-y",
+            "v4.12/catalog_operator-z",
+            "v4.12/test_catalog_operator",
+        ],
+        "catalogs_with_added_or_modified_operators": ["v4.11", "v4.12"],
+    }
+
+
+def test_AffectedCatalogCollection() -> None:
+    catalogs = parsed_file.AffectedCatalogCollection(
+        added={"v4.11", "v4.12", "v4.9"},
+        deleted={"v4.12", "v4.22"},
+        modified={"v4.12", "v4.1", "v4.33"},
+    )
+
+    dict_result = catalogs.to_dict()
+    assert dict_result == {
+        "added_catalogs": ["v4.9", "v4.11", "v4.12"],
+        "deleted_catalogs": ["v4.12", "v4.22"],
+        "modified_catalogs": ["v4.1", "v4.12", "v4.33"],
+        "affected_catalogs": ["v4.1", "v4.9", "v4.11", "v4.12", "v4.22", "v4.33"],
+        "added_or_modified_catalogs": ["v4.1", "v4.9", "v4.11", "v4.12", "v4.33"],
+    }


### PR DESCRIPTION
The output from parsed_file script is used across a whole pipeline solution. So far it has been using set() that doesn't guarantee the order of elements. We noticed some negative behaviour - PR title has been changing randomly.

This commit sorts the output with a specific logic to recognize the version of catalogs.

This commit also sorts the re-build index image list to stay always consistent.

JIRA: ISV-5686

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes