### PR TITLE
[ISV-5825] trigger hosted pipeline when PR is marked as ready

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/community-pipeline-event-listener.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-pipeline-event-listener.yml
@@ -38,7 +38,7 @@
                         value: >-
                           (
                             header.match("X-GitHub-Event", "pull_request")
-                            && body.action in ["opened", "reopened", "synchronize"]
+                            && body.action in ["opened", "reopened", "synchronize", "ready_for_review"]
                             && body.pull_request.base.ref == "{{ branch }}"
                           )
                 bindings:

--- a/ansible/roles/operator-pipeline/tasks/operator-pipeline-event-listener.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-pipeline-event-listener.yml
@@ -38,7 +38,7 @@
                         value: >-
                           (
                             header.match("X-GitHub-Event", "pull_request")
-                            && body.action in ["opened", "reopened", "synchronize"]
+                            && body.action in ["opened", "reopened", "synchronize", "ready_for_review"]
                             && body.pull_request.base.ref == "{{ branch }}"
                           )
                 bindings:


### PR DESCRIPTION
Hosted pipeline is triggered now also for a change from `draft` to `ready_for_review`
[Example run](https://github.com/redhat-openshift-ecosystem/community-operators-pipeline-preprod/pull/321#event-17301813086) 

### Merge Request Checklists

- [x] Development is done in feature branches
- [x] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [x] Code passes all automated code tests:
    - [x] Linting
    - [x] Code formatter - Black
    - [x] Security scanners
    - [x] Unit tests
    - [x] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [x] Pull request is tagged with "risk/good-to-go" label for minor changes