### PR TITLE
Add option to specify basic-auth workspace for checkout task in operator ci pipeline

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -73,6 +73,8 @@ spec:
     - name: pipeline
     - name: ssh-dir
       optional: true
+    - name: basic-auth
+      optional: true
     - name: registry-credentials
       optional: true
     - name: registry-cacert
@@ -107,6 +109,8 @@ spec:
           subPath: src
         - name: ssh-directory
           workspace: ssh-dir
+        - name: basic-auth
+          workspace: basic-auth
 
     # Verify the bundle path exists
     - name: bundle-path-validation

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -73,8 +73,11 @@ spec:
     - name: pipeline
     - name: ssh-dir
       optional: true
-    - name: basic-auth
+    - name: git_repo_basic_auth
       optional: true
+      description: |
+        Credentials for basic authentication to access a private GitHub repository.
+        A workspace containing a .gitconfig and .git-credentials files.
     - name: registry-credentials
       optional: true
     - name: registry-cacert
@@ -110,7 +113,7 @@ spec:
         - name: ssh-directory
           workspace: ssh-dir
         - name: basic-auth
-          workspace: basic-auth
+          workspace: git_repo_basic_auth
 
     # Verify the bundle path exists
     - name: bundle-path-validation


### PR DESCRIPTION
Even when it is recommended the git authentication using ssh, basic authentication should be fully supported. It was missing to propagate the `basic-auth` workspace from the pipeline to the task.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes