### PR TITLE
Add static test for catalog olm.bundle.object presence

### DIFF
--- a/docs/users/static_checks.md
+++ b/docs/users/static_checks.md
@@ -160,6 +160,19 @@ fbc:
       catalog_names: ["v4.13", "v4.14"] # The 4.14 is already used in the basic.yaml template
       type: olm.semver
 ```
+
+#### check_olm_bundle_object_in_fbc
+The test verifies a presence of `olm.bundle.object` in the catalog's bundle properties.
+For catalogs `>=v4.17` the `olm.bundle.object` is not allowed as it has negative
+impact on performance of the OpenShift olm.
+
+The test will fail if the `olm.bundle.object` is present in the catalog within
+the `/catalogs/{ocp_version}/{operator_name}/catalog.yaml` file.
+
+To prevent the test from failing download the latest [Makefile](https://raw.githubusercontent.com/redhat-openshift-ecosystem/operator-pipelines/main/fbc/Makefile)
+and re-render the catalog again with `make catalogs` command. The Makefile uses
+extra arguments `--migrate-level bundle-object-to-csv-metadata` for opm when rendering
+catalogs for `>=4.17` version.
 ## Running tests locally
 
 ```bash

--- a/fbc/Makefile
+++ b/fbc/Makefile
@@ -58,7 +58,7 @@ fbc-onboarding: clean
 #     - template_name: semver.yaml
 #       catalog_names: ["v4.13", "v4.17"]
 #       type: olm.semver
-catalogs: ${BINDIR}/render_catalogs.sh ${BINDIR}/opm ${BINDIR}/yq clean
+catalogs: render_catalogs.sh ${BINDIR}/opm ${BINDIR}/yq clean
 	@echo "Rendering catalogs from templates"
 	@${BINDIR}/render_catalogs.sh
 
@@ -94,7 +94,8 @@ ${BINDIR}/yq:
 	if [ ! -d ${BINDIR} ]; then mkdir -p ${BINDIR}; fi
 	curl -sLO https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(OS)_$(ARCH) && mv yq_$(OS)_$(ARCH) ${BINDIR}/yq && chmod +x ${BINDIR}/yq
 
-${BINDIR}/render_catalogs.sh:
+@PHONY: render_catalogs.sh
+render_catalogs.sh:
 	if [ ! -d ${BINDIR} ]; then mkdir -p ${BINDIR}; fi
 	curl -sLO https://raw.githubusercontent.com/redhat-openshift-ecosystem/operator-pipelines/main/fbc/render_catalogs.sh
 	mv render_catalogs.sh ${BINDIR}/render_catalogs.sh

--- a/operator-pipeline-images/operatorcert/entrypoints/add_bundle_to_fbc.py
+++ b/operator-pipeline-images/operatorcert/entrypoints/add_bundle_to_fbc.py
@@ -232,15 +232,9 @@ class CatalogTemplate(ABC):
         Returns:
             list[str]: command line arguments for the migration.
         """
-        if not catalog.startswith("v"):
+        if not utils.is_catalog_v4_17_plus(catalog):
             return []
-
-        major, minor = catalog[1:].split(".")
-        if int(major) >= 4 and int(minor) >= 17:
-            # Catalogs with version >= 4.17 needs an extra argument
-            # to migrate catalog content
-            return ["--migrate-level", "bundle-object-to-csv-metadata"]
-        return []
+        return ["--migrate-level", "bundle-object-to-csv-metadata"]
 
 
 class BasicTemplate(CatalogTemplate):

--- a/operator-pipeline-images/operatorcert/operator_repo/core.py
+++ b/operator-pipeline-images/operatorcert/operator_repo/core.py
@@ -640,6 +640,20 @@ class OperatorCatalog:
         """
         return load_multidoc_yaml(self.catalog_content_path)
 
+    def get_catalog_bundles(self) -> list[Any]:
+        """
+        Get all object with schema olm.bundle from the catalog content
+
+        Returns:
+            list[Any]: List of all bundles in the catalog
+        """
+        content = self.catalog_content
+        bundles = []
+        for item in content:
+            if item.get("schema") == "olm.bundle":
+                bundles.append(item)
+        return bundles
+
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, str):
             return self.operator_catalog_name == other

--- a/operator-pipeline-images/operatorcert/utils.py
+++ b/operator-pipeline-images/operatorcert/utils.py
@@ -5,15 +5,16 @@ import json
 import logging
 import os
 import pathlib
+import re
 import subprocess
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 import yaml
+from packaging.version import Version
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
-from packaging.version import Version
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -243,3 +244,25 @@ def sort_versions(version_list: list[Any]) -> list[Any]:
         list[Any]: A sorted list of version strings.
     """
     return sorted(version_list, key=lambda x: Version(x[1:]))
+
+
+def is_catalog_v4_17_plus(catalog: str) -> bool:
+    """
+    Check if the catalog is v4.17 or higher.
+
+    Args:
+        catalog (str): A name of the catalog.
+
+    Returns:
+        bool: True if the catalog is v4.17 or higher, False otherwise.
+    """
+    # We expect the catalog name to be in the format "vX.Y" where X and Y are integers
+    # Example: "v4.17", "v5.0"
+    version_regex = r"^v\d+\.\d+$"
+    if not re.match(version_regex, catalog):
+        return False
+
+    major, minor = catalog[1:].split(".")
+    if int(major) > 4 or (int(major) >= 4 and int(minor) >= 17):
+        return True
+    return False

--- a/operator-pipeline-images/tests/entrypoints/test_add_bundle_to_fbc.py
+++ b/operator-pipeline-images/tests/entrypoints/test_add_bundle_to_fbc.py
@@ -305,11 +305,12 @@ def test_BasicCatalogTemplate__render_template_extra_args(
     assert result == ["--foo", "bar"]
 
 
+@patch("operatorcert.entrypoints.add_bundle_to_fbc.utils.is_catalog_v4_17_plus")
 def test_BasicCatalogTemplate__bundle_object_to_csv_metada(
+    mock_is_catalog_v4_17_plus: MagicMock,
     basic_catalog_template: add_bundle_to_fbc.BasicTemplate,
 ) -> None:
-    result = basic_catalog_template._bundle_object_to_csv_metada("unknown")
-    assert result == []
+    mock_is_catalog_v4_17_plus.side_effect = [False, True, False]
 
     result = basic_catalog_template._bundle_object_to_csv_metada("v4.12")
     assert result == []

--- a/operator-pipeline-images/tests/operator_repo/test_operator_catalog.py
+++ b/operator-pipeline-images/tests/operator_repo/test_operator_catalog.py
@@ -20,7 +20,9 @@ def test_invalid_catalog(tmp_path: Path) -> None:
 def test_operator_catalog(tmp_path: Path) -> None:
     create_files(
         tmp_path,
-        catalog_files("v4.14", "fake-operator", content=({"foo": "bar"},)),
+        catalog_files(
+            "v4.14", "fake-operator", content=({"schema": "olm.bundle"}, {"foo": "bar"})
+        ),
         catalog_files("v4.13", "fake-operator-2"),
         bundle_files("fake-operator", "0.0.1"),
     )
@@ -44,7 +46,11 @@ def test_operator_catalog(tmp_path: Path) -> None:
         operator_catalog.catalog_content_path == operator_catalog.root / "catalog.yaml"
     )
 
-    assert operator_catalog.catalog_content == [{"foo": "bar"}]
+    assert operator_catalog.catalog_content == [
+        {"schema": "olm.bundle"},
+        {"foo": "bar"},
+    ]
+    assert operator_catalog.get_catalog_bundles() == [{"schema": "olm.bundle"}]
 
     assert operator_catalog == catalog.operator_catalog("fake-operator")
 

--- a/operator-pipeline-images/tests/static_tests/common/test_operator_catalogs.py
+++ b/operator-pipeline-images/tests/static_tests/common/test_operator_catalogs.py
@@ -5,6 +5,7 @@ import pytest
 from operatorcert.operator_repo import OperatorCatalogList, Repo
 from operatorcert.static_tests.common.operator_catalogs import (
     check_bundle_images_in_fbc,
+    check_olm_bundle_object_in_fbc,
 )
 from tests.utils import bundle_files, catalog_files, create_files
 
@@ -12,17 +13,19 @@ from tests.utils import bundle_files, catalog_files, create_files
 @pytest.mark.parametrize(
     ["config", "expected_results"],
     [
-        (
+        pytest.param(
             {},
             set(),
+            id="Config not set",
         ),
-        (
+        pytest.param(
             {
                 "allowed_bundle_registries": ["quay.io/org-foo/", "quay.io/org-bar/"],
             },
             set(),
+            id="All registries allowed",
         ),
-        (
+        pytest.param(
             {
                 "allowed_bundle_registries": ["quay.io/org-foo/"],
             },
@@ -32,12 +35,8 @@ from tests.utils import bundle_files, catalog_files, create_files
                 "Only these registries are allowed for bundle images: "
                 "quay.io/org-foo/.",
             },
+            id="Registry not allowed",
         ),
-    ],
-    ids=[
-        "Config not set",
-        "All registries allowed",
-        "Registry not allowed",
     ],
 )
 def test_check_bundle_images_in_fbc(
@@ -66,3 +65,71 @@ def test_check_bundle_images_in_fbc(
     operator_catalog = catalog.operator_catalog("fake-operator")
     catalogs = OperatorCatalogList([operator_catalog])
     assert {x.reason for x in check_bundle_images_in_fbc(catalogs)} == expected_results
+
+
+@pytest.mark.parametrize(
+    ["catalog_name", "catalog_content", "expected_results"],
+    [
+        pytest.param(
+            "unknown-catalog",
+            {
+                "schema": "olm.bundle",
+                "properties": [{"type": "olm.bundle.object"}],
+            },
+            set(),
+            id="Uknown version of catalog",
+        ),
+        pytest.param(
+            "v4.16",
+            {
+                "schema": "olm.bundle",
+                "properties": [{"type": "olm.bundle.object"}],
+            },
+            set(),
+            id="4.16 valid catalog",
+        ),
+        pytest.param(
+            "v4.17",
+            {
+                "schema": "olm.bundle",
+                "properties": [{"type": "olm.bundle.object"}],
+            },
+            {
+                "Bundle object found in OperatorCatalog(v4.17/fake-operator) catalog uses "
+                "'olm.bundle.object'. This is not allowed for catalogs with version `>= "
+                "4.17`. Render catalog again with latest "
+                "[Makefile](https://redhat-openshift-ecosystem.github.io/operator-pipelines/users/fbc_workflow/#generate-catalogs-using-templates) "
+                "using `make catalogs`. Bundle object is not supported in FBC.",
+            },
+            id="4.17 invalid catalog",
+        ),
+        pytest.param(
+            "v4.17",
+            {
+                "schema": "olm.bundle",
+                "properties": [{"type": "olm.csv.metadata"}],
+            },
+            set(),
+            id="4.17 valid catalog",
+        ),
+    ],
+)
+def test_check_olm_bundle_object_in_fbc(
+    tmp_path: Path,
+    catalog_name: str,
+    catalog_content: Any,
+    expected_results: set[str],
+) -> None:
+
+    create_files(
+        tmp_path,
+        catalog_files(catalog_name, "fake-operator", content=catalog_content),
+        bundle_files("fake-operator", "0.0.1"),
+    )
+    repo = Repo(tmp_path)
+    catalog = repo.catalog(catalog_name)
+    operator_catalog = catalog.operator_catalog("fake-operator")
+    catalogs = OperatorCatalogList([operator_catalog])
+    assert {
+        x.reason for x in check_olm_bundle_object_in_fbc(catalogs)
+    } == expected_results

--- a/operator-pipeline-images/tests/test_utils.py
+++ b/operator-pipeline-images/tests/test_utils.py
@@ -171,3 +171,14 @@ def test_copy_images_to_destination(mock_subprocess: MagicMock) -> None:
         stderr=mock_subprocess.PIPE,
         check=True,
     )
+
+
+def test_is_catalog_v4_17_plus() -> None:
+    assert utils.is_catalog_v4_17_plus("v4.17")
+    assert utils.is_catalog_v4_17_plus("v4.18")
+    assert utils.is_catalog_v4_17_plus("v4.19")
+    assert utils.is_catalog_v4_17_plus("v5.1")
+    assert not utils.is_catalog_v4_17_plus("v3.19")
+    assert not utils.is_catalog_v4_17_plus("v4.15")
+    assert not utils.is_catalog_v4_17_plus("v4.16")
+    assert not utils.is_catalog_v4_17_plus("unknown")


### PR DESCRIPTION
The test verifies if a "olm.bundle.object" is present in the catalog with v4.17 or higher. This property type is not allowed and test will fail if it finds it.

JIRA: ISV-5917

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes