### PR TITLE
[ISV-5925] bot commits are signed off

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-fbc.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-fbc.yml
@@ -143,7 +143,7 @@ spec:
         FBC_UPDATE_BRANCH="add-$(params.operator_name)-$(params.operator_version)-to-fbc-$RANDOM"
 
         git checkout -b $FBC_UPDATE_BRANCH
-        git commit -m "Add $(params.operator_name) $(params.operator_version) to FBC"
+        git commit --signoff -m "Add $(params.operator_name) $(params.operator_version) to FBC"
         git push origin "$FBC_UPDATE_BRANCH"
 
         cat > pr_comment.md << EOL


### PR DESCRIPTION
Commits created by the bot are now signed off. Tested by separate pipeline resulting in [this signed commit](https://github.com/redhat-openshift-ecosystem/community-operators-pipeline-preprod/pull/334/commits).

Closes ISV-5925

### Merge Request Checklists

- [x] Development is done in feature branches
- [x] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [x] Code passes all automated code tests:
    - [x] Linting
    - [x] Code formatter - Black
    - [x] Security scanners
    - [x] Unit tests
    - [x] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [x] Pull request is tagged with "risk/good-to-go" label for minor changes