### PR TITLE
[ISV-5998] Give OPM access to registry

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/build-fbc-scratch-catalog.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/build-fbc-scratch-catalog.yml
@@ -65,12 +65,9 @@ spec:
           DOCKERCONFIGJSON="$(workspaces.credentials.path)/.dockerconfigjson"
           EXTRA_ARGS+=" --authfile $DOCKERCONFIGJSON"
 
-          # provide config.json using the default env variable
-          # so OPM has access to registry
-          TEMP_CONFIG="/tmp/temp_config"
-          mkdir "$TEMP_CONFIG"
-          cp "$DOCKERCONFIGJSON" "${TEMP_CONFIG}/config.json"
-          export DOCKER_CONFIG="$TEMP_CONFIG"
+          # OPM reads the config location from env var and cannot be provided as a parameter
+          # this will expose the config path to the OPM tool
+          export REGISTRY_AUTH_FILE=$DOCKERCONFIGJSON
         fi
 
         # The registry pull-spec is in following format:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/build-fbc-scratch-catalog.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/build-fbc-scratch-catalog.yml
@@ -62,7 +62,15 @@ spec:
 
         EXTRA_ARGS=""
         if [[ "$(workspaces.credentials.bound)" == "true" ]]; then
-          EXTRA_ARGS+=" --authfile $(workspaces.credentials.path)/.dockerconfigjson"
+          DOCKERCONFIGJSON="$(workspaces.credentials.path)/.dockerconfigjson"
+          EXTRA_ARGS+=" --authfile $DOCKERCONFIGJSON"
+
+          # provide config.json using the default env variable
+          # so OPM has access to registry
+          TEMP_CONFIG="/tmp/temp_config"
+          mkdir "$TEMP_CONFIG"
+          cp "$DOCKERCONFIGJSON" "${TEMP_CONFIG}/config.json"
+          export DOCKER_CONFIG="$TEMP_CONFIG"
         fi
 
         # The registry pull-spec is in following format:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/buildah.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/buildah.yml
@@ -64,9 +64,7 @@ spec:
       optional: true
     - name: dockerconfig
       description: >-
-        An optional workspace that allows providing a .docker/config.json file
-        for Buildah to access the container registry.
-        The file should be placed at the root of the Workspace with name config.json.
+        An optional workspace that provides a .dockerconfigjson file
       optional: true
   results:
     - name: IMAGE_DIGEST


### PR DESCRIPTION
OPM reads registry config from env vars [in given order](https://github.com/operator-framework/operator-registry/issues/1591#issuecomment-2825903241) - this PR exposes the `.dockerconfigjson` also as an env var to fix access to private registries in CI pipeline.

Closes: ISV-5998

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes