### PR TITLE
[ISV-6167] Slack notification contain PR url if present

### DIFF
--- a/ansible/roles/config_ocp_cluster/files/tasks/chat-pipelinerun-summary.yml
+++ b/ansible/roles/config_ocp_cluster/files/tasks/chat-pipelinerun-summary.yml
@@ -22,6 +22,8 @@ spec:
       description: The namespace of the PipelineRun.
     - name: pipelinerun
       description: The name of the PipelineRun to summarize.
+    - name: git_pr_url
+      description: The url of the related pull request.
     - name: jq_image
       description: Container image with jq installed
       default: "quay.io/redhat-isv/operator-pipelines-images:released"
@@ -46,8 +48,12 @@ spec:
 
         ns="$(params.namespace)"
         pr="$(params.pipelinerun)"
+        pr_url="$(params.git_pr_url)"
         echo "PipelineRun: $pr" >> pipelinerun.txt
         echo "Namespace: $ns" >> pipelinerun.txt
+        if [ -n "$pr_url" ]; then
+          echo "PR URL: $pr_url" >> pipelinerun.txt
+        fi
 
         echo "Getting PipelineRun info"
         status=$(oc get pipelinerun $pr -n $ns -o 'jsonpath={.status.conditions[-1].reason}')

--- a/ansible/roles/config_ocp_cluster/tasks/chat-trigger.yml
+++ b/ansible/roles/config_ocp_cluster/tasks/chat-trigger.yml
@@ -46,8 +46,8 @@
                 value: $(body.pipelineRun.metadata.namespace)
               - name: pipelinerun
                 value: $(body.pipelineRun.metadata.name)
-              - name: thread_key
-                value: "$(body.pipelineRun.metadata.namespace)-$(header['Ce-Type'])"
+              - name: git_pr_url
+                value: $(body.pipelineRun.spec.params[?(@.name=='git_pr_url')].value)
 
     - name: Create Chat TriggerTemplate
       kubernetes.core.k8s:
@@ -64,7 +64,8 @@
             params:
               - name: namespace
               - name: pipelinerun
-              - name: thread_key
+              - name: git_pr_url
+                default: ""
             resourcetemplates:
               - apiVersion: tekton.dev/v1
                 kind: TaskRun
@@ -79,8 +80,8 @@
                       value: $(tt.params.namespace)
                     - name: pipelinerun
                       value: $(tt.params.pipelinerun)
-                    - name: thread_key
-                      value: $(tt.params.thread_key)
+                    - name: git_pr_url
+                      value: $(tt.params.git_pr_url)
                   taskRef:
                     name: chat-pipelinerun-summary
 


### PR DESCRIPTION
Tested in stage, both [index verify](https://redhat-internal.slack.com/archives/C06LTFLUQMQ/p1754485279123999) and [operator pipelines](https://redhat-internal.slack.com/archives/C06LTFLUQMQ/p1754486272452519) work, the later one containing the PR URL.
Removed the unused thread_key from old G-chat notifications.

closes: ISV-6167

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes