### PR TITLE
fix: escape username and password db inputs

### DIFF
--- a/operator-pipeline-images/operatorcert/webhook_dispatcher/config.py
+++ b/operator-pipeline-images/operatorcert/webhook_dispatcher/config.py
@@ -2,6 +2,7 @@
 
 import os
 from typing import List, Optional
+from urllib.parse import quote_plus
 
 import yaml
 from pydantic import BaseModel, Field
@@ -33,7 +34,7 @@ class DatabaseConfig(BaseModel):
         """
         # A user can set the DATABASE_URL or provide the individual parameters
         default_url = (
-            f"postgresql://{self.db_user}:{self.db_password}@"
+            f"postgresql://{quote_plus(self.db_user)}:{quote_plus(self.db_password)}@"
             f"{self.db_host}:{self.db_port}/{self.db_name}"
         )
         env_url = os.getenv("DATABASE_URL", default_url)

--- a/operator-pipeline-images/tests/webhook_dispatcher/test_database.py
+++ b/operator-pipeline-images/tests/webhook_dispatcher/test_database.py
@@ -14,8 +14,8 @@ from sqlalchemy.exc import SQLAlchemyError
 @pytest.fixture
 def database_manager() -> DatabaseManager:
     config = DatabaseConfig(
-        db_user="user",
-        db_password="password",
+        db_user="user_with_special_chars!@#",
+        db_password="password_with_special_chars!@#",
         db_host="localhost",
         db_port="5432",
         db_name="test",
@@ -35,7 +35,7 @@ def test_database_manager_engine(
     assert mock_create_engine.call_count == 1
     assert (
         mock_create_engine.call_args[0][0]
-        == "postgresql://user:password@localhost:5432/test"
+        == "postgresql://user_with_special_chars%21%40%23:password_with_special_chars%21%40%23@localhost:5432/test"
     )
     assert mock_create_engine.call_args[1]["echo"] is False
     assert mock_create_engine.call_args[1]["pool_size"] == 5


### PR DESCRIPTION
In case a username or password contains special character the URL become invalid and sqlalchemy can't connect to it. This commit escapes both username and password and assemble valid URL.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes