### PR TITLE
update set quay visibility to capture success/failure and exit properly

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/set-quay-repo-visibility.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/set-quay-repo-visibility.yml
@@ -28,10 +28,22 @@ spec:
         # DO NOT use `set -x` to avoid exposing the OAuth token
         set -e
 
-        curl -X POST \
+        response=$(curl -s -w "\n%{http_code}" -X POST \
           -H "Authorization: Bearer $QUAY_OAUTH_TOKEN" \
           -H "Content-Type:application/json" \
           -d "{\"visibility\": \"$(params.visibility)\"}" \
-          "https://quay.io/api/v1/repository/$(params.repository)/changevisibility"
+          "https://quay.io/api/v1/repository/$(params.repository)/changevisibility")
 
-        echo "Repository visibility set to '$(params.visibility)'."
+        http_code=$(echo "$response" | tail -n1)
+        response_body=$(echo "$response" | head -n -1)
+
+        echo "Response body: $response_body"
+        echo "HTTP status code: $http_code"
+
+        # Account for 200 and 201, since quay's docs mention 201, but in testing 200 is returned
+        if [ "$http_code" != "200" || "$http_code" != "201"]; then
+          echo "Error: Expected HTTP 2xx but got $http_code"
+          exit 1
+        fi
+
+        echo "Repository visibility successfully changed."


### PR DESCRIPTION
## Motivation
- [PR](https://github.com/redhat-openshift-ecosystem/certified-operators/pull/6379) kept failing with an IIB access issue, but when looking further (at the logs) it was determined that the quay call was failing, but not stoping/exiting the task.
```
[make-bundle-repo-public : change-visibility]   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
[make-bundle-repo-public : change-visibility]                                  Dload  Upload   Total   Spent    Left  Speed
[make-bundle-repo-public : change-visibility] 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   225  100   201  100    24    501     59 --:--:-- --:--:-- --:--:--   559
100   225  100   201  100    24    500     59 --:--:-- --:--:-- --:--:--   559
[make-bundle-repo-public : change-visibility] {"detail": "Unauthorized", "error_message": "Unauthorized", "error_type": "insufficient_scope", "title": "insufficient_scope", "type": "https://quay.io/api/v1/error/insufficient_scope", "status": 403}
[make-bundle-repo-public : change-visibility] Repository visibility set to 'public'.
```
- The log here with the word `public` is misleading, since this is hard coded from the `input` and not from the `response`.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [x] Pull request is tagged with "risk/good-to-go" label for minor changes


