### PR TITLE
fix: Set a socket timeout for stomp connection

### DIFF
--- a/operator-pipeline-images/operatorcert/umb.py
+++ b/operator-pipeline-images/operatorcert/umb.py
@@ -36,6 +36,7 @@ class UmbClient:
             keepalive=True,
             host_and_ports=self.hostnames,
             reconnect_attempts_max=5,
+            timeout=10,
             heartbeats=(8000, 0),
         )
         self.connection.set_ssl(


### PR DESCRIPTION
With a new version of python there seems to be a race condition when a connection is not establish properly. After couple of debugging iteration it seems the connection is to fast and is never establish. Adding a timeout to a connection helped locally.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes