### PR TITLE
Wait for db and dispatcher to be operational

### DIFF
--- a/ansible/inventory/group_vars/operator-pipeline.yml
+++ b/ansible/inventory/group_vars/operator-pipeline.yml
@@ -43,7 +43,8 @@ operator_pipeline_gpg_passphrase_path: ../../vaults/{{ env }}/operator-pipeline-
 # SSH key for the operator pipeline bot to access git repositories
 operator_pipeline_bot_ssh_key_path: ../../vaults/common/github-bot-ssh
 
-operator_pipeline_webhook_dispatcher_url: "https://webhook-dispatcher-{{ oc_namespace }}.{{ operator_pipeline_base_url }}/api/v1/webhooks/github-pipeline"
+operator_pipeline_webhook_dispatcher_base_url: "https://webhook-dispatcher-{{ oc_namespace }}.{{ operator_pipeline_base_url }}"
+operator_pipeline_webhook_dispatcher_url: "{{ operator_pipeline_webhook_dispatcher_base_url }}/api/v1/webhooks/github-pipeline"
 operator_pipeline_webhook_secret: ../../vaults/common/github-webhook-secret-preprod.txt
 
 kerberos_keytab_isv: ../../vaults/common/nonprod-operatorpipelines.keytab
@@ -74,8 +75,8 @@ operator_pipeline_dispatcher_release_pipeline_events:
   - labeled
   - closed
 
-operator_pipeline_dispatcher_hosted_capacity: 3
-operator_pipeline_dispatcher_release_capacity: 3
+operator_pipeline_dispatcher_hosted_capacity: 5
+operator_pipeline_dispatcher_release_capacity: 5
 
 operator_pipeline_callback_url: "https://operator-pipeline-{{ oc_namespace }}.{{ operator_pipeline_base_url}}"
 operator_pipeline_community_pipeline_callback_url: "https://community-operator-pipeline-{{ oc_namespace }}.{{ operator_pipeline_base_url }}"

--- a/ansible/roles/operator-pipeline/tasks/webhook-dispatcher.yml
+++ b/ansible/roles/operator-pipeline/tasks/webhook-dispatcher.yml
@@ -31,6 +31,18 @@
     - ../templates/openshift/webhook_dispatcher/postgres-db-stateful-set.yml
     - ../templates/openshift/webhook_dispatcher/postgres-db-service.yml
 
+- name: Wait for postgres database to be ready
+  kubernetes.core.k8s_info:
+    kind: StatefulSet
+    namespace: "{{ oc_namespace }}"
+    name: "{{ operator_pipeline_webhook_dispatcher_name }}-postgres-db"
+  register: postgres_db_info
+  until: >
+    postgres_db_info.resources[0].status.readyReplicas is defined and
+    postgres_db_info.resources[0].status.readyReplicas > 0
+  retries: 20
+  delay: 3
+
 - name: Create a webhook dispatcher service account
   ansible.builtin.import_tasks: tasks/webhook-dispatcher-sa.yml
 
@@ -61,3 +73,13 @@
     - "../templates/openshift/webhook_dispatcher/webhook-dispatcher-deployment.yml"
     - "../templates/openshift/webhook_dispatcher/webhook-dispatcher-service.yml"
     - "../templates/openshift/webhook_dispatcher/webhook-dispatcher-route.yml"
+
+- name: Wait for webhook dispatcher route to be available
+  ansible.builtin.uri:
+    url: "{{ operator_pipeline_webhook_dispatcher_base_url }}/api/v1/status/db"
+    method: GET
+    status_code: 200
+  register: webhook_dispatcher_status
+  until: webhook_dispatcher_status.status == 200
+  retries: 20
+  delay: 3

--- a/docs/local-dev-environment.md
+++ b/docs/local-dev-environment.md
@@ -1,0 +1,45 @@
+# Local development environment
+
+This document provides instructiion on how to set up an environment for "local"
+development of the Operator Pipelines project.
+
+The word "local" in this context means that developer will use existing stage
+operator pipelines cluster and use a custom namespace for development.
+
+## Setup & Deployment
+
+A operator pipelines interact with Github repositories (certified, marketplace and
+community). It is highly recomended to `fork` the upstream repository and only work
+on your fork.
+
+1. Fork the upstream repository:
+   1. [Certified Operators](https://github.com/redhat-openshift-ecosystem/certified-operators-preprod/)
+   2. [Community Operators](https://github.com/redhat-openshift-ecosystem/community-operators-pipeline-preprod)
+2. Set environment variables referencing your fork:
+   1. Create `.env` file in the root of the repository.
+   2. Add the following variables to the `.env` file:
+      1. `GITHUB_USER` - your GitHub username
+3. Sign in to the OpenShift cluster using `oc` CLI:
+   ```bash
+   oc login --web --server=https://api.pipelines-stage.0ce8.p1.openshiftapps.com:6443
+   ```
+4. Use a `Makefile` to build and deploy your namespace:
+   1. `make deploy-playground`
+   2. This will create a new namespace `$(USER)-playground` and deploy the operator pipelines
+      to it.
+5. Add a Github webhook to your forked repositories:
+   1. Go to your forked repository settings.
+   2. Add a new webhook with the following settings:
+      - **Payload URL**: `https://webhook-dispatcher-$(USER)-playground.operator-pipeline-stage.apps.pipelines-stage.0ce8.p1.openshiftapps.com/api/v1/webhooks/github-pipeline`
+      - **Content type**: `application/json`
+      - **Secret**: Use the value from `ansible/vaults/common/github-webhook-secret-preprod.txt`.
+      - **Which events would you like to trigger this webhook?**: Select "Let me select individual events" and check "Pull requests and Labels".
+      - **Active**: Ensure the webhook is active.
+
+## Trigger a pipeline event
+Once the environment is set up, you can submit a new pull request to your forked repository.
+When opening your PR you need to target the branch `$USER` (the same as your local user).
+This will trigger the webhook and start the operator pipelines and process the pull request.
+
+After a moment you should see the pipeline running in the OpenShift console and also see
+firts interaction in the PR comments and labels being added to the PR.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
       - "Admin guide": "pipeline-admin-guide.md"
       - "Catalog image browser": "catalog_image_browser.md"
       - "FBC catalog promotion": "fbc-catalog-promotion.md"
+      - "Local development environment": "local-dev-environment.md"
 theme:
   name: material
   features:


### PR DESCRIPTION
In the integration test we can see that dispatcher and underlying db is not ready at the time when tests are executed. This commit adds a wait steps to wait for db and dispatcher.

It also adds an local dev environment guide with how to setup a environment using dispatcher.

The commit also increase a default capacity to 5 PRs instead of 3.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes