### PR TITLE
Add static check for NetworkPolicy presence

### DIFF
--- a/docs/users/static_checks.md
+++ b/docs/users/static_checks.md
@@ -173,6 +173,19 @@ To prevent the test from failing download the latest [Makefile](https://raw.gith
 and re-render the catalog again with `make catalogs` command. The Makefile uses
 extra arguments `--migrate-level bundle-object-to-csv-metadata` for opm when rendering
 catalogs for `>=4.17` version.
+
+#### check_network_policy_presence
+
+The test checks if there is a NetworkPolicy object defined in the bundle manifests.
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+...
+```
+Network policies are not a supported resource that Operator Lifecycle Manager(OLM)
+can install and manage. Static checks will raise an error if such resource is
+found in the bundle manifests.
+
 ## Running tests locally
 
 ```bash


### PR DESCRIPTION
A new static check for all incoming bundles that rejects any bundle that contains a NetworkPolicy.

Based on the decision from OLM team this resource is temporarily not allowed globally for all OCP versions until OLM releases a backport.

JIRA: ISV-6226

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes