### PR TITLE
Add queued label to PR for events in queue

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/webhook_dispatcher/webhook-dispatcher-deployment.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/webhook_dispatcher/webhook-dispatcher-deployment.yml
@@ -65,6 +65,11 @@ spec:
                 secretKeyRef:
                   name: github-webhook-secret
                   key: webhook-secret
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: github-bot-token
+                  key: github_bot_token
           volumeMounts:
             - name: "webhook-dispatcher-config"
               mountPath: "/home/user/dispatcher-config.yml"


### PR DESCRIPTION
A webhook dispatcher sets a PR label once there is not enough capacity on a cluster and event gets in a queue.

The queue label matches a current label pattern for each pipeline. The example for hosted pipeline is "operator-hosted-pipeline/queued". This format makes sure the label is removed once the pipeline starts processing the PR.

The label is set only once when the event gets in a queue. The event corresponding DB entry is also changed to indicate queued status.

JIRA: ISV-6265

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes