### PR TITLE
fix: Merge task fails with automerge

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
@@ -80,7 +80,7 @@ spec:
 
         # Squash and merge only if the head commit sha has not changed since
         # the start of the pipeline run
-        MERGE_STDERR=$(gh pr merge "$(params.git_pr_url)" --squash --auto --match-head-commit "$(params.git_head_commit)" 2>&1 >/dev/null)
+        MERGE_STDERR=$(gh pr merge "$(params.git_pr_url)" --squash --admin --match-head-commit "$(params.git_head_commit)" 2>&1 >/dev/null)
         MERGE_RESULT=$?
         MERGE_ERROR=$(echo "$MERGE_STDERR" | grep -oP '(?<=GraphQL: ).*')
 


### PR DESCRIPTION
Due to what seems to be like a bug in github CLI or directly in Github the --auto is now replaced with --admin.

The auto flag sometimes raised a Graphql error from which it was hard to tell what's wrong. The issue was pretty non-deterministic and pretty much failed randomly. A local testing didn't prove the issue on our site. This issue was most likely introduced by start using the Github CLI utility. Previously the merge was done using direct API calls to REST. The current CLI tool uses GraphQL.

At the point when pipelines wants to merge the PR we already know whether a test passed or failed so it is safe to use --admin and merge the PR immediately.

JIRA: ISV-6111

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes