### PR TITLE
Enable Operator CI pipeline to run from repos with nested operators directory

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -228,6 +228,8 @@ spec:
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
+        - name: operators_path
+          value: "$(tasks.bundle-path-validation.results.operators_path)"
         - name: affected_operators
           value: "$(tasks.bundle-path-validation.results.package_name)"
       workspaces:
@@ -306,6 +308,8 @@ spec:
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
+        - name: catalog_repository
+          value: "$(tasks.bundle-path-validation.results.catalog_repo_path)"
         - name: bundle_pullspec
           value: *bundleImage
         - name: ocp_version

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/bundle-path-validation.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/bundle-path-validation.yml
@@ -15,6 +15,10 @@ spec:
       description: Path to the operator package
     - name: bundle_version
       description: Operator bundle version
+    - name: operators_path
+      description: Path to the operators directory
+    - name: catalog_repo_path
+      description: Path to the catalog repository containing the operators directory
   workspaces:
     - name: source
   steps:
@@ -30,3 +34,10 @@ spec:
         echo -n "$BUNDLE_PATH" | rev | cut -d '/' -f 2 | tr -d $'\n' | rev | tee "$(results.package_name.path)"
         echo -n "$BUNDLE_PATH" | rev | cut -d '/' -f 1 | tr -d $'\n' | rev | tee "$(results.bundle_version.path)"
         dirname "$BUNDLE_PATH" | tr -d $'\n' | tee "$(results.package_path.path)"
+
+        # Extract operators path by removing the last 2 directory entries (operator_name/version)
+        OPERATORS_PATH=$(echo -n "$BUNDLE_PATH" | rev | cut -d '/' -f 3- | rev | tr -d $'\n')
+        echo -n "$OPERATORS_PATH" | tee "$(results.operators_path.path)"
+
+        # Extract catalog repo path as parent of operators path
+        dirname "$OPERATORS_PATH" | tr -d $'\n' | tee "$(results.catalog_repo_path.path)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/cert-project-check.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/cert-project-check.yml
@@ -6,6 +6,9 @@ metadata:
 spec:
   params:
     - name: pipeline_image
+    - name: operators_path
+      description: Path to the operators directory
+      default: "operators"
     - name: affected_operators
       description: Comma separated list of affected operators
       default: ""
@@ -64,7 +67,7 @@ spec:
 
 
         for operator_name in "${!ALL_AFFECTED_OPERATORS[@]}"; do
-          file_path="operators/$operator_name/ci.yaml"
+          file_path="$(params.operators_path)/$operator_name/ci.yaml"
 
           if [ ! -f "$file_path" ]; then
             echo "File '$file_path' not found."


### PR DESCRIPTION
We integrated in the past the `OpenShift Operator CI Pipeline` into our automated workflows in our private repo to test our Operator bundles before attempting bundle certification at https://github.com/redhat-openshift-ecosystem/certified-operators.

This was working fine with a fixed version of the Operator Tekton Pipeline resources from last year (around May or June, do not recall exactly). However, when we tried to sync the latest version, now FBC approach is used and the pipeline resources expect to run the tasks in repo https://github.com/redhat-openshift-ecosystem/certified-operators.

The minor changes here will allow us to keep executing this `OpenShift Operator CI Pipeline` in our repo where we have this folder structure and will also allow others to do the same.

This is our current folder structure in our private repository:

```
certified-operators
    └── operators <------ NOTICE THIS IS NOT AT THE ROOT OF OUR REPO
          ├── minio-object-store-operator
          └── minio-minkms-operator
```

The changes are minor and to not impact running this `OpenShift Operator CI Pipeline` at https://github.com/redhat-openshift-ecosystem/certified-operators and also the OpenShift Hosted Operator Pipeline is also not impacted.

Please take a look and let me know your thoughts.

Thank you

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes