### PR TITLE
[ISV-6713] fix error propagation in pipelines

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml
@@ -83,7 +83,7 @@ spec:
         # the start of the pipeline run
         MERGE_STDERR=$(gh pr merge "$(params.git_pr_url)" --squash --admin --match-head-commit "$(params.git_head_commit)" 2>&1 >/dev/null)
         MERGE_RESULT=$?
-        MERGE_ERROR=$(echo "$MERGE_STDERR" | grep -oP '(?<=GraphQL: ).*')
+        MERGE_ERROR=$(echo "$MERGE_STDERR" | grep -oP '(?<=GraphQL: ).*|(?<=^X ).*')
 
         if [[ $MERGE_RESULT -eq 0 ]] ; then
             echo "PR has been merged!"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2512,24 +2512,25 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyjwt"
-version = "2.10.1"
+version = "2.12.1"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb"},
-    {file = "pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953"},
+    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
+    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
 ]
 
 [package.dependencies]
 cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+typing_extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
-dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
 docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
+tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
 name = "pylint"


### PR DESCRIPTION
After investigating the issue mentioned in the ticket ISV-6713 and going through the failed pipeline logs in certified and community repo, I found out that some of the errors are coming as GraphQL errors and some are coming from CLI; this caused the some of the errors to be silenced.
I also went through the failed logs and PRs, and searched for other different forms of error messages so we can catch everything but there are only 2 formats, one with graphql message and one for CLI beginning with X. 
Coincidentally, we are getting non-graphql errors predominantly  from FBC workflow when 2 or more catalogs are being updated. 

pip-audit failed so this also targets pyjwt dependency update.

Closes: https://redhat.atlassian.net/browse/ISV-6713

### Merge Request Checklists

- [x] Development is done in feature branches
- [x] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes