### PR TITLE
feat(ISV-6998): publish-to-index uses repository from config

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -640,10 +640,10 @@ spec:
       params:
         - name: pipeline_image
           value: "$(params.pipeline_image)"
-        - name: environment
-          value: "$(params.env)"
-        - name: organization
-          value: "$(tasks.get-organization.results.organization)"
+        - name: destination_repository
+          value: "$(tasks.get-supported-versions.results.repository)"
+        - name: public_repository_mirror
+          value: "$(tasks.get-supported-versions.results.public_repository_mirror)"
         - name: quay_push_final_index_secret
           value: "$(params.quay_push_final_index_secret)"
       workspaces:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/copy-image.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/copy-image.yml
@@ -46,11 +46,13 @@ spec:
         RELEASE_INFO_DIR_PATH="$(workspaces.output.path)/release_info"
         mkdir -p "$RELEASE_INFO_DIR_PATH"
 
+        SUFFIX=`date +%s`
+
         if [[ "$(params.repository_namespace)" == "" ]]; then
           echo "Image pullspec for community bundle is the source image itself."
           echo -n > "$(results.container_digest.path)"
           echo -n "$(params.src_image)" > "$(results.image_pullspec.path)"
-          echo "- $(params.src_image)" | tee "$RELEASE_INFO_DIR_PATH/released_bundle.txt"
+          echo "- \`$(params.src_image)\`" | tee "$RELEASE_INFO_DIR_PATH/released_bundle.txt"
           exit 0
         fi
 
@@ -65,6 +67,12 @@ spec:
           docker://$(params.src_image) \
           docker://"$(params.dest_image_registry_namespace_certproject):$(params.dest_image_tag)"
 
+        retry 5 skopeo copy \
+          --retry-times 5 \
+          --src-authfile $SRC_AUTHFILE \
+          --dest-authfile $DEST_AUTHFILE \
+          docker://$(params.src_image) \
+          docker://"$(params.dest_image_registry_namespace_certproject):$(params.dest_image_tag)-${SUFFIX}"
 
         retry 5 skopeo copy \
           --retry-times 5 \
@@ -75,5 +83,5 @@ spec:
 
         DIGEST=$(retry 5 skopeo inspect --retry-times 5 --authfile $DEST_AUTHFILE docker://$(params.dest_image_registry_namespace_certproject):$(params.dest_image_tag) | jq -r .Digest)
         echo -n $DIGEST | tee $(results.container_digest.path)
-        echo "- $CONNECT_REPO_PATH:$(params.dest_image_tag)" | tee "$RELEASE_INFO_DIR_PATH/released_bundle.txt"
+        echo "- \`$CONNECT_REPO_PATH:$(params.dest_image_tag)\` (stable tag: \`$(params.dest_image_tag)-${SUFFIX}\`)" | tee "$RELEASE_INFO_DIR_PATH/released_bundle.txt"
         echo -n "$CONNECT_REPO_PATH@${DIGEST}" > $(results.image_pullspec.path)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-index.yml
@@ -6,11 +6,15 @@ metadata:
 spec:
   params:
     - name: pipeline_image
-    - name: environment
+      description: A container image of operator-pipeline-images for the steps to run in.
+    - name: destination_repository
       description: |
-        Which environment the pipeline is running in. Can be one of [dev, qa, stage, prod]
-    - name: organization
-      description: Operator organization. Can be one of [certified-operators, redhat-marketplace, community-operators]
+        The destination repository where the index image will be published.
+        Example: quay.io/redhat/redhat----community-operator-index
+    - name: public_repository_mirror
+      description: |
+        The public repository mirror where the index image becomes available.
+        Example: registry.redhat.io/redhat/community-operator-index
     - name: quay_push_final_index_secret
       description: |
         Name of the Quay credentials secret:
@@ -35,63 +39,11 @@ spec:
             secretKeyRef:
               name: "$(params.quay_push_final_index_secret)"
               key: password
-        - name: ORGANIZATION
-          value: "$(params.organization)"
       script: |
         #! /usr/bin/env bash
         # DO NOT USE `set -x`, to avoid revealing the quay token in logs!
         set -e
 
-        # select the correct index
-        case "$(params.environment)" in
-            prod)
-                case $ORGANIZATION in
-                    certified-operators)
-                      FROM_INDEX="quay.io/redhat/redhat----certified-operator-index"
-                    ;;
-                    redhat-marketplace)
-                      FROM_INDEX="quay.io/redhat/redhat----redhat-marketplace-index"
-                    ;;
-                    community-operators)
-                      FROM_INDEX="quay.io/redhat/redhat----community-operator-index"
-                    ;;
-                    *)
-                      echo "Unknown value for organization: $ORGANIZATION"
-                      exit 1
-                    ;;
-                esac
-            ;;
-            stage | integration-tests)
-                case $ORGANIZATION in
-                    certified-operators)
-                      FROM_INDEX="quay.io/redhat-pending/redhat----certified-operator-index"
-                    ;;
-                    redhat-marketplace)
-                      FROM_INDEX="quay.io/redhat-pending/redhat----redhat-marketplace-index"
-                    ;;
-                    community-operators)
-                      FROM_INDEX="quay.io/redhat-pending/redhat----community-operator-index"
-                    ;;
-                    *)
-                      echo "Unknown value for organization: $ORGANIZATION"
-                      exit 1
-                    ;;
-                esac
-            ;;
-            *)
-                echo "Publishing bundle to an index is a NOOP for dev and qa environments at this time."
-                exit 0
-            ;;
-        esac
-
-        echo "FROM_INDEX: $FROM_INDEX"
-        # Replace internal registry with external address
-        INDEX_NAME="${FROM_INDEX#*----}"
-        if [[ "$(params.environment)" == "prod" ]]; then
-          FROM_INDEX_PROXY="registry.redhat.io/redhat/${INDEX_NAME}"
-        else
-          FROM_INDEX_PROXY="registry.stage.redhat.io/redhat/${INDEX_NAME}"
-        fi
         # Create folder for release info if it's non-existent
         RELEASE_INFO_DIR_PATH="$(workspaces.results.path)/summary/release_info"
         mkdir -p "$RELEASE_INFO_DIR_PATH"
@@ -108,12 +60,13 @@ spec:
           SRC_IMAGE=$(echo $i | awk -F '+' '{print $2}')
           echo "Source image: $SRC_IMAGE"
           VERSION=$(echo $i | awk -F '+' '{print $1}' | awk -F ':' '{print $2}')
-          DEST_IMAGE_VERSION_TAG="${FROM_INDEX}:${VERSION}"
-          DEST_IMAGE_PERMANENT_TAG="${DEST_IMAGE_VERSION_TAG}-${SUFFIX}"
+
+          DEST_REPO_WITH_VERSION_TAG="$(params.destination_repository):${VERSION}"
+          DEST_REPO_WITH_PERMANENT_TAG="${DEST_REPO_WITH_VERSION_TAG}-${SUFFIX}"
 
           echo "Dest images:"
-          echo " - $DEST_IMAGE_VERSION_TAG"
-          echo " - $DEST_IMAGE_PERMANENT_TAG"
+          echo " - $DEST_REPO_WITH_VERSION_TAG"
+          echo " - $DEST_REPO_WITH_PERMANENT_TAG"
 
           # Add version tag to an index
           retry 5 skopeo \
@@ -123,7 +76,7 @@ spec:
             --src-no-creds \
             --dest-creds $QUAY_USER:$QUAY_TOKEN \
             docker://$SRC_IMAGE \
-            docker://$DEST_IMAGE_VERSION_TAG
+            docker://$DEST_REPO_WITH_VERSION_TAG
 
           # Add permanent tag to an index
           retry 5 skopeo \
@@ -133,10 +86,10 @@ spec:
             --src-no-creds \
             --dest-creds $QUAY_USER:$QUAY_TOKEN \
             docker://$SRC_IMAGE \
-            docker://$DEST_IMAGE_PERMANENT_TAG
+            docker://$DEST_REPO_WITH_PERMANENT_TAG
 
           # Save data about updated indices to volume
-          echo "- ${FROM_INDEX_PROXY}:${VERSION}" | tee -a "$RELEASE_INFO_DIR_PATH/updated_indices.txt"
+          echo "- \`$(params.public_repository_mirror):${VERSION}\` (stable tag: \`${VERSION}-${SUFFIX}\`)" | tee -a "$RELEASE_INFO_DIR_PATH/updated_indices.txt"
         done
 
         sort -o "$RELEASE_INFO_DIR_PATH/updated_indices.txt" "$RELEASE_INFO_DIR_PATH/updated_indices.txt"


### PR DESCRIPTION
The previous solution used hardcoded values as a destination for the index images. This change removes the hardcoded logic and replace it with a results from get-supported-versions that extract the info from repository config.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes