### PR TITLE
fix(ISV-7101): Make add-bundle-to-fbc run as last task before finally block

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -401,48 +401,6 @@ spec:
         - name: registry-credentials
           workspace: registry-serve-credentials
 
-    # Automatically add bundle to FBC based on operators release config file
-    - name: add-bundle-to-fbc
-      runAfter:
-        - publish-pyxis-data
-      taskRef:
-        kind: Task
-        name: add-bundle-to-fbc
-      when:
-        - input: "$(tasks.detect-changes.results.added_bundle)"
-          operator: notin
-          values: [""]
-      params:
-        - name: pipeline_image
-          value: "$(params.pipeline_image)"
-        - name: bundle_pullspec
-          value: "$(tasks.copy-bundle-image-to-released-registry.results.image_pullspec)"
-        - name: operator_name
-          value: "$(tasks.detect-changes.results.added_operator)"
-        - name: operator_version
-          value: "$(tasks.detect-changes.results.added_bundle)"
-        - name: git_base_branch
-          value: "$(params.git_base_branch)"
-        - name: github_origin_pr_url
-          value: "$(params.git_pr_url)"
-        - name: github_token_secret_name
-          value: "$(params.github_token_secret_name)"
-        - name: github_token_secret_key
-          value: "$(params.github_token_secret_key)"
-        - name: create_pull_request
-          value: "true"
-      workspaces:
-        - name: source
-          workspace: repository
-          subPath: src
-        - name: output
-          workspace: results
-          subPath: summary
-        - name: ssh-directory
-          workspace: ssh-dir
-        - name: registry-credentials
-          workspace: registry-pull-credentials
-
     # Get the bundle versions to build index
     - name: get-supported-versions
       runAfter:
@@ -649,6 +607,48 @@ spec:
       workspaces:
         - name: results
           workspace: results
+
+    # Automatically add bundle to FBC based on operators release config file
+    - name: add-bundle-to-fbc
+      runAfter:
+        - publish-to-index
+      taskRef:
+        kind: Task
+        name: add-bundle-to-fbc
+      when:
+        - input: "$(tasks.detect-changes.results.added_bundle)"
+          operator: notin
+          values: [""]
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: bundle_pullspec
+          value: "$(tasks.copy-bundle-image-to-released-registry.results.image_pullspec)"
+        - name: operator_name
+          value: "$(tasks.detect-changes.results.added_operator)"
+        - name: operator_version
+          value: "$(tasks.detect-changes.results.added_bundle)"
+        - name: git_base_branch
+          value: "$(params.git_base_branch)"
+        - name: github_origin_pr_url
+          value: "$(params.git_pr_url)"
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
+        - name: create_pull_request
+          value: "true"
+      workspaces:
+        - name: source
+          workspace: repository
+          subPath: src
+        - name: output
+          workspace: results
+          subPath: summary
+        - name: ssh-directory
+          workspace: ssh-dir
+        - name: registry-credentials
+          workspace: registry-pull-credentials
 
   finally:
 


### PR DESCRIPTION
Made add-bundle-to-fbc not run in parallel with a group of tasks, but rather as last task in the group before finally block. This is to ensure that duplicate PRs are not created when a task from the parallel group fails -> need to retry the pipeline -> running add-bundle-to-fbc multiple times -> multiple duplicate PRs.

Before:
1. publish-pyxis-data
2. add-bundle-to-fbc 
2. get-supported-versions -> build-fragment-images -> acquire-lease -> add-bundle-to-index / build-fbc-index-images -> sign-index-image -> publish-to-index
3. finally block

After:
1. publish-pyxis-data
2. get-supported-versions -> build-fragment-images -> acquire-lease -> add-bundle-to-index / build-fbc-index-images -> sign-index-image -> publish-to-index -> add-bundle-to-fbc 
3. finally block

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes