### PR TITLE
updating output to use printf to avoid tekton backtick escaping issue

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/publish-to-index.yml
@@ -92,7 +92,8 @@ spec:
             docker://$DEST_REPO_WITH_PERMANENT_TAG
 
           # Save data about updated indices to volume
-          echo "- \`$(params.public_repository_mirror):${VERSION}\` (stable tag: \`${VERSION}-${SUFFIX}\`)" | tee -a "$RELEASE_INFO_DIR_PATH/updated_indices.txt"
+          # Use printf with single quotes to avoid backtick escaping issues in YAML/Tekton context, which differs from normal shell.
+          printf -- '- `%s:%s` (stable tag: `%s-%s`)\n' "$(params.public_repository_mirror)" "${VERSION}" "${VERSION}" "${SUFFIX}" | tee -a "$RELEASE_INFO_DIR_PATH/updated_indices.txt"
         done
 
         sort -o "$RELEASE_INFO_DIR_PATH/updated_indices.txt" "$RELEASE_INFO_DIR_PATH/updated_indices.txt"


### PR DESCRIPTION
### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [x] Pull request is tagged with "risk/good-to-go" label for minor changes

## Issue
The latest change switched the output was formatted, but that does not work with how tekton's shell intperetes the escaped backtick. Leading to all `)` being after the last line entered, instead of being on each line.See the example below
https://github.com/redhat-openshift-ecosystem/certified-operators/pull/8348#issuecomment-4355630506

## Fix
Switch to `printf` to do the formatting, which is in the release image.
```
❯ podman run -it --rm --entrypoint /bin/bash quay.io/redhat-isv/operator-pipelines-images:released
[user@b982d8434249 ~]$ printf
printf: usage: printf [-v var] format [arguments]
```