### PR TITLE
feat(ISV-7107): Check bundle version against channel head for all indexes

### DIFF
--- a/operatorcert/static_tests/common/bundle.py
+++ b/operatorcert/static_tests/common/bundle.py
@@ -354,10 +354,9 @@ def check_bundle_higher_than_channel_head(bundle: Bundle) -> Iterator[CheckResul
                 continue
 
             channel_head = max(bundles_in_ocp)
-            if bundle <= channel_head:
-                yield Fail(
-                    f"Cannot add bundle {bundle} to channel '{channel}' for index version "
-                    f"{target_ocp_version}. The head of the channel is {channel_head}. It is not "
-                    f"possible to add new versions lower than or equal to the head of the channel. "
-                    f"Consider increasing the new bundle version above {channel_head}."
-                )
+            yield Fail(
+                f"Cannot add bundle {bundle} to channel '{channel}' for index version "
+                f"{target_ocp_version}. The head of the channel is {channel_head}. It is not "
+                f"possible to add new versions lower than or equal to the head of the channel. "
+                f"Consider increasing the new bundle version above {channel_head}."
+            )

--- a/operatorcert/static_tests/common/bundle.py
+++ b/operatorcert/static_tests/common/bundle.py
@@ -294,3 +294,70 @@ def check_replaces_availability(bundle: Bundle) -> Iterator[CheckResult]:
         f"`{replaces_bundle}` - `{replaces_ocp_version_str}`"
     )
     yield from []
+
+
+def _build_ocp_version_to_bundles_map(
+    bundles: set[Bundle], organization: str
+) -> dict[str, list[Bundle]]:
+    """
+    Helper function to build a mapping of OCP versions to bundles that support them.
+    """
+    ocp_version_to_bundles: dict[str, list[Bundle]] = {}
+    for bundle in bundles:
+        ocp_versions_str = bundle.annotations.get("com.redhat.openshift.versions")
+        supported_ocp_versions = utils.get_ocp_supported_versions(
+            organization, ocp_versions_str
+        )
+        for ocp_version in supported_ocp_versions:
+            ocp_version_to_bundles.setdefault(ocp_version, []).append(bundle)
+
+    return ocp_version_to_bundles
+
+
+@skip_fbc
+def check_bundle_higher_than_channel_head(bundle: Bundle) -> Iterator[CheckResult]:
+    """
+    Check if the current bundle version is higher than existing channel heads
+    in all target OCP index versions.
+
+    Args:
+        bundle (Bundle): Operator bundle
+
+    Yields:
+        Iterator[CheckResult]: Failure if a higher or equal version exists in any target index
+    """
+    organization = bundle.operator.repo.config.get("organization")
+    ocp_versions_str = bundle.annotations.get("com.redhat.openshift.versions")
+    target_ocp_versions = utils.get_ocp_supported_versions(
+        organization, ocp_versions_str
+    )
+
+    all_channels: set[str] = set(bundle.channels)
+    if bundle.default_channel is not None:
+        all_channels.add(bundle.default_channel)
+
+    operator = bundle.operator
+    for channel in all_channels:
+        other_bundles = set(operator.channel_bundles(channel)) - {bundle}
+        higher_or_equal_bundles = {b for b in other_bundles if b >= bundle}
+
+        if not higher_or_equal_bundles:
+            continue
+
+        ocp_version_to_bundles = _build_ocp_version_to_bundles_map(
+            higher_or_equal_bundles, organization
+        )
+
+        for target_ocp_version in target_ocp_versions:
+            bundles_in_ocp = ocp_version_to_bundles.get(target_ocp_version, [])
+            if not bundles_in_ocp:
+                continue
+
+            channel_head = max(bundles_in_ocp)
+            if bundle <= channel_head:
+                yield Fail(
+                    f"Cannot add bundle {bundle} to channel '{channel}' for index version "
+                    f"{target_ocp_version}. The head of the channel is {channel_head}. It is not "
+                    f"possible to add new versions lower than or equal to the head of the channel. "
+                    f"Consider increasing the new bundle version above {channel_head}."
+                )

--- a/tests/static_tests/common/test_bundle.py
+++ b/tests/static_tests/common/test_bundle.py
@@ -12,6 +12,7 @@ from operatorcert.static_tests.common.bundle import (
     check_network_policy_presence,
     check_operator_version_directory_name,
     check_replaces_availability,
+    check_bundle_higher_than_channel_head,
 )
 from tests.utils import bundle_files, create_files
 
@@ -853,5 +854,140 @@ def test_check_replaces_availability(
     operator = repo.operator("hello")
     bundle = operator.bundle("0.0.2")
     errors = list(check_replaces_availability(bundle))
+
+    assert set(errors) == expected
+
+
+@pytest.mark.parametrize(
+    "bundles_data,bundle_to_check,ocp_versions_mock,expected",
+    [
+        pytest.param(
+            [
+                ("0.0.1", "v4.14-v4.16", "beta"),
+                ("0.0.3", "v4.14-v4.18", "beta"),
+            ],
+            "0.0.3",
+            [
+                ["v4.14", "v4.15", "v4.16", "v4.17", "v4.18"],
+            ],
+            set(),
+            id="pass: new bundle is higher than existing",
+        ),
+        pytest.param(
+            [
+                ("0.0.1", "v4.14", "beta"),
+                ("0.0.2", "v4.15", "beta"),
+            ],
+            "0.0.2",
+            [["v4.15"]],
+            set(),
+            id="pass: different OCP versions, no overlap",
+        ),
+        pytest.param(
+            [
+                ("0.0.5", "v4.14-v4.16", "beta"),
+                ("0.0.3", "v4.14-v4.18", "beta"),
+            ],
+            "0.0.3",
+            [
+                ["v4.14", "v4.15", "v4.16", "v4.17", "v4.18"],
+                ["v4.14", "v4.15", "v4.16"],
+            ],
+            {
+                Fail(
+                    "Cannot add bundle Bundle(hello/0.0.3) to channel 'beta' for index version "
+                    "v4.14. The head of the channel is Bundle(hello/0.0.5). It is not "
+                    "possible to add new versions lower than or equal to the head of the channel. "
+                    "Consider increasing the new bundle version above Bundle(hello/0.0.5)."
+                ),
+                Fail(
+                    "Cannot add bundle Bundle(hello/0.0.3) to channel 'beta' for index version "
+                    "v4.15. The head of the channel is Bundle(hello/0.0.5). It is not "
+                    "possible to add new versions lower than or equal to the head of the channel. "
+                    "Consider increasing the new bundle version above Bundle(hello/0.0.5)."
+                ),
+                Fail(
+                    "Cannot add bundle Bundle(hello/0.0.3) to channel 'beta' for index version "
+                    "v4.16. The head of the channel is Bundle(hello/0.0.5). It is not "
+                    "possible to add new versions lower than or equal to the head of the channel. "
+                    "Consider increasing the new bundle version above Bundle(hello/0.0.5)."
+                ),
+            },
+            id="fail: new bundle is lower than existing",
+        ),
+        pytest.param(
+            [
+                ("0.0.1", "v4.14", "beta"),
+                ("0.0.9", "v4.14-v4.16", "beta"),
+                ("0.0.5", "v4.17-v4.18", "beta"),
+            ],
+            "0.0.5",
+            [
+                ["v4.17", "v4.18"],
+                ["v4.14", "v4.15", "v4.16"],
+            ],
+            set(),
+            id="pass: higher bundle exists but for different OCP version",
+        ),
+        pytest.param(
+            [("0.0.1", "v4.14", "beta")],
+            "0.0.1",
+            [["v4.14"]],
+            set(),
+            id="pass: first bundle in channel",
+        ),
+        pytest.param(
+            [
+                ("0.0.1", "v4.14", "stable"),
+                ("0.0.9", "v4.14", "beta"),
+                ("0.0.5", "v4.14", "beta,stable"),
+            ],
+            "0.0.5",
+            [
+                ["v4.14"],
+                ["v4.14"],
+            ],
+            {
+                Fail(
+                    "Cannot add bundle Bundle(hello/0.0.5) to channel 'beta' for index version "
+                    "v4.14. The head of the channel is Bundle(hello/0.0.9). It is not "
+                    "possible to add new versions lower than or equal to the head of the channel. "
+                    "Consider increasing the new bundle version above Bundle(hello/0.0.9)."
+                ),
+            },
+            id="fail: multiple channels, fails for one channel only",
+        ),
+    ],
+)
+@patch("operatorcert.static_tests.common.bundle.utils.get_ocp_supported_versions")
+def test_check_bundle_higher_than_channel_head(
+    mock_get_ocp_supported_versions: MagicMock,
+    bundles_data: list[tuple[str, str, str]],
+    bundle_to_check: str,
+    ocp_versions_mock: list[list[str]],
+    expected: set[Fail],
+    tmp_path: Path,
+) -> None:
+    create_files(
+        tmp_path,
+        {"config.yaml": {"organization": "certified-operators"}},
+    )
+
+    for version, ocp_annotation, channel in bundles_data:
+        annotations = {
+            "operators.operatorframework.io.bundle.channels.v1": channel,
+            "com.redhat.openshift.versions": ocp_annotation,
+        }
+        create_files(
+            tmp_path,
+            bundle_files("hello", version, annotations=annotations),
+        )
+
+    mock_get_ocp_supported_versions.side_effect = ocp_versions_mock
+
+    repo = Repo(tmp_path)
+    operator = repo.operator("hello")
+    bundle = operator.bundle(bundle_to_check)
+    errors = list(check_bundle_higher_than_channel_head(bundle))
 
     assert set(errors) == expected


### PR DESCRIPTION
Added static test "check_bundle_higher_than_channel_head" that checks if there's an existing bundle version higher than the bundle version being added, that for all index versions. Specifically, checking the bundles in the channels the new bundle is being added to.

I've tested the new check in PRs created in my fork (more details there):
- [failing test check PR](https://github.com/JakubDurkac/certified-operators-preprod/pull/2)
- [passing test check PR](https://github.com/JakubDurkac/certified-operators-preprod/pull/3)

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes