### PR TITLE
changing fbc onboarding to lookup package name instead of using folde…

### DIFF
--- a/operatorcert/entrypoints/fbc_onboarding.py
+++ b/operatorcert/entrypoints/fbc_onboarding.py
@@ -9,6 +9,7 @@ import requests
 import yaml
 from operatorcert.logger import setup_logger
 from operatorcert.operator_repo import Operator, Repo
+from operatorcert.operator_repo.exceptions import InvalidBundleException
 from operatorcert.utils import run_command
 
 LOGGER = logging.getLogger("operator-cert")
@@ -34,7 +35,7 @@ def setup_argparser() -> Any:
     )
     parser.add_argument(
         "--operator-name",
-        help="Name of the operator",
+        help="Name of the operator folder (package name will be auto-detected from bundles)",
         required=True,
     )
     parser.add_argument(
@@ -231,6 +232,52 @@ def update_operator_config(
         yaml.safe_dump(config, f, explicit_start=True)
 
 
+def get_package_name_from_operator(operator: Operator) -> str:
+    """
+    Get the package name from the operator's bundles.
+    The package name may differ from the operator folder name.
+
+    Args:
+        operator (Operator): Operator object
+
+    Returns:
+        str: The package name as defined in the operator's bundle metadata
+    """
+    # Get any bundle from the operator to extract the package name
+    bundles = list(operator.all_bundles())
+    if not bundles:
+        # If no bundles exist, fall back to the folder name
+        LOGGER.warning(
+            "No bundles found for operator '%s', using folder name as package name",
+            operator.operator_name,
+        )
+        return operator.operator_name
+
+    # Use the metadata_operator_name from the first bundle
+    # (all bundles should have the same package name)
+    package_name = bundles[0].metadata_operator_name
+    if not package_name:
+        # Fallback to CSV operator name if metadata is missing
+        try:
+            package_name = bundles[0].csv_operator_name
+            LOGGER.warning(
+                "Package name not found in bundle metadata for '%s', using CSV name: %s",
+                operator.operator_name,
+                package_name,
+            )
+        except InvalidBundleException as exc:
+            # If CSV is also invalid, fall back to folder name
+            LOGGER.warning(
+                "Could not extract package name from bundle metadata or CSV for '%s' (%s). "
+                "Using folder name as package name.",
+                operator.operator_name,
+                exc,
+            )
+            package_name = operator.operator_name
+
+    return package_name
+
+
 def render_fbc_from_template(operator: Operator, version: str) -> None:
     """
     Render catalog from templates
@@ -276,7 +323,7 @@ def onboard_operator_to_fbc(
     Onboard operator to FBC and generates templates, catalogs and config
 
     Args:
-        operator_name (str): Name of the operator that will be onboarded
+        operator_name (str): Name of the operator folder that will be onboarded
         repository (Repo): A repository object with operators
         cache_dir (str): A directory where the catalog cache will be stored
     """
@@ -292,6 +339,12 @@ def onboard_operator_to_fbc(
     operator = repository.operator(operator_name)
     template_dir = create_catalog_template_dir_if_not_exists(operator)
 
+    # Get the package name from the operator's bundles (may differ from folder name)
+    package_name = get_package_name_from_operator(operator)
+    LOGGER.info(
+        "Using package name '%s' for operator folder '%s'", package_name, operator_name
+    )
+
     catalog_mapping = []
 
     for catalog in supported_catalogs:
@@ -301,7 +354,7 @@ def onboard_operator_to_fbc(
 
         build_cache(version, image, cache_dir)
         template = generate_and_save_base_templates(
-            version, operator_name, cache_dir, template_dir
+            version, package_name, cache_dir, template_dir
         )
         if template:
             # Render a catalog only if basic template was generated

--- a/tests/entrypoints/test_fbc_onboarding.py
+++ b/tests/entrypoints/test_fbc_onboarding.py
@@ -1,9 +1,10 @@
 import os
 from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from operatorcert.entrypoints import fbc_onboarding
+from operatorcert.operator_repo.exceptions import InvalidBundleException
 
 
 def test_setup_argparser() -> None:
@@ -160,6 +161,62 @@ def test_generate_and_save_base_templates_no_content(
         mock_yaml_dump.assert_not_called()
 
 
+def test_get_package_name_from_operator() -> None:
+    # Test normal case: bundle with metadata_operator_name
+    operator = MagicMock()
+    bundle = MagicMock()
+    bundle.metadata_operator_name = "my-package-name"
+    bundle.csv_operator_name = "different-csv-name"
+    operator.all_bundles.return_value = [bundle]
+    operator.operator_name = "my-folder-name"
+
+    result = fbc_onboarding.get_package_name_from_operator(operator)
+    assert result == "my-package-name"
+
+
+def test_get_package_name_from_operator_csv_fallback() -> None:
+    # Test fallback case: bundle with only CSV operator name (no metadata)
+    operator = MagicMock()
+    bundle = MagicMock()
+    bundle.metadata_operator_name = ""  # Empty metadata
+    bundle.csv_operator_name = "csv-package-name"
+    operator.all_bundles.return_value = [bundle]
+    operator.operator_name = "my-folder-name"
+
+    result = fbc_onboarding.get_package_name_from_operator(operator)
+    assert result == "csv-package-name"
+
+
+def test_get_package_name_from_operator_no_bundles() -> None:
+    # Test case: no bundles exist, should return folder name
+    operator = MagicMock()
+    operator.all_bundles.return_value = []
+    operator.operator_name = "my-folder-name"
+
+    result = fbc_onboarding.get_package_name_from_operator(operator)
+    assert result == "my-folder-name"
+
+
+def test_get_package_name_from_operator_csv_raises_exception() -> None:
+    # Test case: metadata is empty and CSV parsing raises InvalidBundleException
+    # Should gracefully fall back to folder name instead of crashing
+    operator = MagicMock()
+    bundle = MagicMock()
+    bundle.metadata_operator_name = ""  # Empty metadata, so will try CSV fallback
+
+    # Simulate csv_operator_name property raising InvalidBundleException (e.g., invalid CSV)
+    type(bundle).csv_operator_name = PropertyMock(
+        side_effect=InvalidBundleException("CSV for bundle has invalid .metadata.name")
+    )
+
+    operator.all_bundles.return_value = [bundle]
+    operator.operator_name = "my-folder-name"
+
+    # Should fall back to folder name instead of raising an exception
+    result = fbc_onboarding.get_package_name_from_operator(operator)
+    assert result == "my-folder-name"
+
+
 @patch("operatorcert.entrypoints.fbc_onboarding.yaml.safe_dump")
 def test_update_operator_config(mock_yaml_dump: MagicMock) -> None:
     operator = MagicMock()
@@ -239,9 +296,11 @@ def test_render_fbc_from_template(
 @patch(
     "operatorcert.entrypoints.fbc_onboarding.create_catalog_template_dir_if_not_exists"
 )
+@patch("operatorcert.entrypoints.fbc_onboarding.get_package_name_from_operator")
 @patch("operatorcert.entrypoints.fbc_onboarding.get_supported_catalogs")
 def test_onboard_operator_to_fbc(
     mock_catalogs: MagicMock,
+    mock_get_package_name: MagicMock,
     mock_template_dir: MagicMock,
     mock_cache: MagicMock,
     mock_base_template: MagicMock,
@@ -256,12 +315,36 @@ def test_onboard_operator_to_fbc(
         {"ocp_version": "1", "path": "registry.com/foo"},
         {"ocp_version": "2", "path": "registry.com/foo"},
     ]
+    # Mock the package name extraction - simulating folder name != package name
+    mock_get_package_name.return_value = "my-package-name"
+
     fbc_onboarding.onboard_operator_to_fbc("op1", repo, "/tmp", False)
+
     mock_catalogs.assert_called_once_with("org", False)
+    repo.operator.assert_called_once_with("op1")
+    mock_get_package_name.assert_called_once_with(operator)
     mock_template_dir.assert_called_once_with(operator)
 
     assert mock_cache.call_count == 2
     assert mock_base_template.call_count == 2
+
+    # Verify that package_name (not operator folder name) is passed to generate_and_save_base_templates
+    # Check the actual arguments passed to the function
+    assert len(mock_base_template.call_args_list) == 2
+    # First call should be for version "1" with package name
+    assert mock_base_template.call_args_list[0][0] == (
+        "1",
+        "my-package-name",
+        "/tmp",
+        mock.ANY,
+    )
+    # Second call should be for version "2" with package name
+    assert mock_base_template.call_args_list[1][0] == (
+        "2",
+        "my-package-name",
+        "/tmp",
+        mock.ANY,
+    )
 
     mock_render.assert_has_calls([mock.call(operator, "1"), mock.call(operator, "2")])
 


### PR DESCRIPTION
## Problem

The FBC onboarding tool assumed the operator folder name matched the package name used in catalogs. However, these can differ - for example:
- Folder: `operators/eda-openshift-operator/`
- Package in catalog: `eda-k8s-operator`

This caused catalog lookups to fail when the names didn't match.

## Solution

- Added `get_package_name_from_operator()` to extract the actual package name from existing bundle metadata
- Updated `--operator-name` to accept the folder name, with package name auto-detected
- Modified catalog lookups to use the extracted package name instead of the folder name
- Added comprehensive unit tests for the new functionality

## Testing

- All unit tests pass (15/15 in test_fbc_onboarding.py)
- Tested in `certified-operators` with:
  ```
  OPERATOR_PIPELINE_IMAGE=quay.io/acornett/operator-pipelines-test-image:1780413878 make fbc-onboarding
  ```

### Merge Request Checklists

- [x] Development is done in feature branches
- [x] Code changes are submitted as pull request into a primary branch
- [x] Code changes are covered with unit and integration tests.
- [x] Code passes all automated code tests:
    - [x] Linting
    - [x] Code formatter - Black
    - [x] Security scanners
    - [x] Unit tests
    - [x] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes