### PR TITLE
adding log message for projects that chose undistributed, so it's cle…

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -882,6 +882,8 @@ spec:
           value: "$(context.pipeline.name)"
         - name: pipeline_status
           value: "$(tasks.status)"
+        - name: operator_distribution
+          value: "$(tasks.get-pyxis-certification-data.results.operator_distribution)"
       workspaces:
         - name: base
           workspace: repository

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/github-pipelinerun-summary.yml
@@ -53,6 +53,14 @@ spec:
         A flag that determines whether pipeline logs should be uploaded to Github gists
       type: string
 
+    - name: operator_distribution
+      description: |
+        Only applies to certified/marketplace operators.
+        Valid values: connect, marketplace, undistributed.
+        Defaults to empty string for all other operator types.
+      type: string
+      default: ""
+
   steps:
     - name: gather-info
       workingDir: $(workspaces.output.path)
@@ -152,6 +160,11 @@ spec:
             if [[ -f "$RELEASE_INFO_DIR_PATH/updated_indices.txt" ]]; then
               echo -e "\n*Updated indices:* \n" >> "$PR_NAME/comment.md"
               cat "$RELEASE_INFO_DIR_PATH/updated_indices.txt" >> "$PR_NAME/comment.md"
+            fi
+            if [[ "$(params.operator_distribution)" == "undistributed" ]]; then
+              echo -e "\n*Operator Distribution:* \n" >> "$PR_NAME/comment.md"
+              echo "Operator distribution value: $(params.operator_distribution)" >> "$PR_NAME/comment.md"
+              echo "Operator will **not** be released to any indexes/catalogs" >> "$PR_NAME/comment.md"
             fi
           else
             echo -e "\nNothing was released.\n" >> "$PR_NAME/comment.md"


### PR DESCRIPTION
…arer when their operator isn't released to catalogs

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes

## Motivation
PR's like the below, there are no logs explaining why `acquire-lease` is skipped and only a bundle is released. This adds a finally block so this is always logged for clarity, and does not affect any of the workflow revolving around the lease itself.

- Relates: redhat-openshift-ecosystem/certified-operators#8761