### PR TITLE
add sparse checkout to hosted and release pipelines to reduce clone size

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -239,10 +239,27 @@ spec:
         - name: access_type
           value: "internal"
 
+    # Resolve sparse checkout directories from PR changed files
+    - name: resolve-sparse-dirs
+      runAfter:
+        - set-env
+      taskRef:
+        name: resolve-sparse-checkout-dirs
+        kind: Task
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: git_pr_url
+          value: "$(params.git_pr_url)"
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
+
     # Git clone
     - name: clone-repository
       runAfter:
-        - set-env
+        - resolve-sparse-dirs
       taskRef:
         name: git-clone
         kind: Task
@@ -251,6 +268,8 @@ spec:
           value: $(params.git_fork_url)
         - name: revision
           value: $(params.git_commit)
+        - name: sparseCheckoutDirectories
+          value: "$(tasks.resolve-sparse-dirs.results.sparse_dirs)"
         - name: gitInitImage
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
       workspaces:
@@ -266,12 +285,14 @@ spec:
         name: git-clone
         kind: Task
       runAfter:
-        - set-env
+        - resolve-sparse-dirs
       params:
         - name: url
           value: "$(params.git_repo_url)"
         - name: revision
           value: "$(params.git_commit_base)"
+        - name: sparseCheckoutDirectories
+          value: "$(tasks.resolve-sparse-dirs.results.sparse_dirs)"
         - name: gitInitImage
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
       workspaces:

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -151,10 +151,27 @@ spec:
         - name: access_type
           value: "internal"
 
+    # Resolve sparse checkout directories from PR changed files
+    - name: resolve-sparse-dirs
+      runAfter:
+        - set-env
+      taskRef:
+        name: resolve-sparse-checkout-dirs
+        kind: Task
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: git_pr_url
+          value: "$(params.git_pr_url)"
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
+
     # Git clone
     - name: clone-repository
       runAfter:
-        - set-env
+        - resolve-sparse-dirs
       taskRef:
         name: git-clone
         kind: Task
@@ -163,6 +180,8 @@ spec:
           value: $(params.git_repo_url)
         - name: revision
           value: $(params.git_commit)
+        - name: sparseCheckoutDirectories
+          value: "$(tasks.resolve-sparse-dirs.results.sparse_dirs)"
         - name: gitInitImage
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
       workspaces:
@@ -178,12 +197,14 @@ spec:
         name: git-clone
         kind: Task
       runAfter:
-        - set-env
+        - resolve-sparse-dirs
       params:
         - name: url
           value: "$(params.git_repo_url)"
         - name: revision
           value: "$(params.git_commit_base)"
+        - name: sparseCheckoutDirectories
+          value: "$(tasks.resolve-sparse-dirs.results.sparse_dirs)"
         - name: gitInitImage
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
       workspaces:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/resolve-sparse-checkout-dirs.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/resolve-sparse-checkout-dirs.yml
@@ -1,0 +1,93 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: resolve-sparse-checkout-dirs
+spec:
+  description: >-
+    Queries the GitHub API for a pull request's changed files and computes
+    the minimal set of directories needed for a sparse checkout. This
+    allows the pipeline to clone only the affected operator directories
+    plus shared resources (config.yaml, catalogs) instead of the entire
+    repository.
+  params:
+    - name: pipeline_image
+
+    - name: git_pr_url
+      description: URL of the GitHub pull request
+      type: string
+
+    - name: github_token_secret_name
+      description: The name of the Kubernetes Secret that contains the GitHub token.
+      default: github-bot-token
+
+    - name: github_token_secret_key
+      description: The key within the Kubernetes Secret that contains the GitHub token.
+      default: github_bot_token
+
+  results:
+    - name: sparse_dirs
+      description: >-
+        Comma-separated list of directories for sparse checkout.
+        Always includes config.yaml and catalogs; dynamically adds
+        operators/<name> for each affected operator.
+
+  steps:
+    - name: resolve-dirs
+      image: "$(params.pipeline_image)"
+      env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.github_token_secret_name)
+              key: $(params.github_token_secret_key)
+      script: |
+        #! /usr/bin/env bash
+        set -xe
+
+        PR_URL="$(params.git_pr_url)"
+
+        REPO_PATH=$(echo "$PR_URL" | sed -n 's|.*github\.com/\([^/]*/[^/]*\)/pull/.*|\1|p')
+        PR_NUM=$(echo "$PR_URL" | sed -n 's|.*github\.com/[^/]*/[^/]*/pull/\([0-9]*\).*|\1|p')
+
+        if [[ -z "$REPO_PATH" || -z "$PR_NUM" ]]; then
+          echo "ERROR: Could not parse repo and PR number from URL: $PR_URL"
+          exit 1
+        fi
+
+        echo "Fetching changed files for $REPO_PATH PR #$PR_NUM"
+
+        ALL_FILES=""
+        PAGE=1
+        while true; do
+          RESPONSE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${REPO_PATH}/pulls/${PR_NUM}/files?per_page=100&page=${PAGE}")
+
+          FILES=$(echo "$RESPONSE" | jq -r '.[].filename // empty')
+          if [ -z "$FILES" ]; then
+            break
+          fi
+          ALL_FILES="${ALL_FILES}
+        ${FILES}"
+          PAGE=$((PAGE + 1))
+        done
+
+        # Always include config.yaml (get-organization, pipelinerun-summary)
+        # and catalogs (add-bundle-to-fbc validation, build-fragment-images)
+        declare -A DIRS
+        DIRS["config.yaml"]=1
+        DIRS["catalogs"]=1
+
+        for filepath in $ALL_FILES; do
+          if [[ "$filepath" == operators/* ]]; then
+            # Extract operators/<name> (the operator root directory)
+            dir=$(echo "$filepath" | cut -d'/' -f1,2)
+            DIRS["$dir"]=1
+          fi
+        done
+
+        RESULT=$(printf '%s\n' "${!DIRS[@]}" | sort | paste -sd ',' -)
+
+        echo "Sparse checkout directories: $RESULT"
+        echo -n "$RESULT" > "$(results.sparse_dirs.path)"


### PR DESCRIPTION
The community operator repo is ~4.2GB and requires 8GB+ PVCs for the two clones in the hosted/release pipelines. This adds a resolve-sparse-checkout-dirs task that queries the GitHub API for PR changed files and computes the minimal sparse checkout directories (affected operators + catalogs + config.yaml), reducing clone size to ~300MB-1GB per clone.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes