### PR TITLE
[ISV-7252] fix: Strip newline characters from build timestamp result

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-build-timestamp.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/generate-build-timestamp.yml
@@ -17,4 +17,4 @@ spec:
       image: "$(params.pipeline_image)"
       script: |
         #!/usr/bin/env bash
-        date +%s | tee "$(results.timestamp.path)"
+        date +%s | tr -d '\n\r' | tee "$(results.timestamp.path)"


### PR DESCRIPTION
Use `tr -d '\n\r'` to remove trailing newline/carriage-return characters from the timestamp written to the Tekton task result, preventing downstream tasks from receiving a malformed value.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes