### PR TITLE
fix: Add libkrb5-dev to hadolint CI job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -103,6 +103,10 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Install non-python dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y libkrb5-dev
+
       - name: Install tox
         run: pip install tox
 


### PR DESCRIPTION
The hadolint job was missing the kerberos development library, causing `krb5-config --libs gssapi` to fail with exit status 127 (command not found) when installing Python dependencies.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes