### PR TITLE
publish_pyxis_image: check if status_message key exists before use

### DIFF
--- a/operatorcert/entrypoints/publish_pyxis_image.py
+++ b/operatorcert/entrypoints/publish_pyxis_image.py
@@ -54,7 +54,7 @@ def submit_image_request(args: Any) -> Any:
         LOGGER.error(
             "Image request failed: %s - %s",
             image_request["status"],
-            image_request["status_message"],
+            image_request.get("status_message", "N/A"),
         )
         sys.exit(1)
     return image_request

--- a/operatorcert/pyxis.py
+++ b/operatorcert/pyxis.py
@@ -378,7 +378,7 @@ def wait_for_image_request(
                 "Image request %s finished with status %s - %s",
                 image_request_id,
                 status,
-                image_request["status_message"],
+                image_request.get("status_message", "N/A"),
             )
             return image_request
         if now() - start_time > timedelta(seconds=timeout):

--- a/tests/entrypoints/test_publish_pyxis_image.py
+++ b/tests/entrypoints/test_publish_pyxis_image.py
@@ -63,6 +63,27 @@ def test_submit_image_request_error(
         publish_pyxis_image.submit_image_request(args)
 
 
+@patch("operatorcert.entrypoints.publish_pyxis_image.pyxis.wait_for_image_request")
+@patch("operatorcert.entrypoints.publish_pyxis_image.pyxis.post_image_request")
+def test_submit_image_request_error_no_status_message(
+    mock_post_image_request: MagicMock, mock_wait_for_image_request: MagicMock
+) -> None:
+    """Test that a timeout response without status_message does not raise KeyError."""
+    args = MagicMock()
+    args.pyxis_url = "https://catalog.redhat.com/api/containers/"
+    args.cert_project_id = "project_id"
+    args.image_identifier = "image_id"
+
+    mock_post_image_request.return_value = {"_id": "123"}
+    mock_wait_for_image_request.return_value = {
+        "status": "pending",
+        "_id": "123",
+    }
+
+    with pytest.raises(SystemExit):
+        publish_pyxis_image.submit_image_request(args)
+
+
 @patch("operatorcert.entrypoints.publish_pyxis_image.submit_image_request")
 @patch("operatorcert.entrypoints.publish_pyxis_image.setup_logger")
 @patch("operatorcert.entrypoints.publish_pyxis_image.setup_argparser")


### PR DESCRIPTION
In Pyxis, the image_request object may not always contain a `status_message` key (for example, if the request is still in state `pending`). Check for the existence of the key and use a fallback value `N/A` for the status message in logs, to avoid crashing while attempting to log and provide a neater error message.

---

Example pipeline run where the error was encountered: https://gist.github.com/rh-operator-bundle-bot/6c9441e0c4bcd790910d89ab64129b8e#file-operator-release-pipeline-run8f2b6-log-L469-L479

```
[publish-pyxis-data : publish-pyxis-image] Traceback (most recent call last):
[publish-pyxis-data : publish-pyxis-image]   File "/home/user/.venv/bin/publish-pyxis-image", line 6, in <module>
[publish-pyxis-data : publish-pyxis-image]     sys.exit(main())
[publish-pyxis-data : publish-pyxis-image]              ~~~~^^
[publish-pyxis-data : publish-pyxis-image]   File "/home/user/operatorcert/entrypoints/publish_pyxis_image.py", line 75, in main
[publish-pyxis-data : publish-pyxis-image]     submit_image_request(args)
[publish-pyxis-data : publish-pyxis-image]     ~~~~~~~~~~~~~~~~~~~~^^^^^^
[publish-pyxis-data : publish-pyxis-image]   File "/home/user/operatorcert/entrypoints/publish_pyxis_image.py", line 57, in submit_image_request
[publish-pyxis-data : publish-pyxis-image]     image_request["status_message"],
[publish-pyxis-data : publish-pyxis-image]     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
[publish-pyxis-data : publish-pyxis-image] KeyError: 'status_message'
```

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes