### PR TITLE
fix(ISV-7421): bump IIB request timeout from 60 to 90 minutes

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/community-hosted-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-hosted-pipeline-trigger.yml
@@ -96,8 +96,8 @@
                     git_pull_request_url: $(tt.params.git_pr_url)
                 spec:
                   timeouts:
-                    pipeline: "2h"
-                    tasks: "1h50m"
+                    pipeline: "2h30m"
+                    tasks: "2h20m"
                   pipelineRef:
                     name: operator-hosted-pipeline
                   params:

--- a/ansible/roles/operator-pipeline/tasks/operator-hosted-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-hosted-pipeline-trigger.yml
@@ -93,8 +93,8 @@
                     git_pull_request_url: $(tt.params.git_pr_url)
                 spec:
                   timeouts:
-                    pipeline: "2h"
-                    tasks: "1h50m"
+                    pipeline: "2h30m"
+                    tasks: "2h20m"
                   pipelineRef:
                     name: operator-hosted-pipeline
                   params:

--- a/operatorcert/entrypoints/add_fbc_fragments_to_index.py
+++ b/operatorcert/entrypoints/add_fbc_fragments_to_index.py
@@ -72,7 +72,7 @@ def setup_argparser() -> argparse.ArgumentParser:
 
 
 def wait_for_results(
-    iib_url: str, request_ids: List[int], timeout: float = 60 * 60, delay: float = 20
+    iib_url: str, request_ids: List[int], timeout: float = 90 * 60, delay: float = 20
 ) -> Any:
     """
     Wait for IIB build till it finishes
@@ -80,7 +80,7 @@ def wait_for_results(
     Args:
         iib_url (Any): CLI arguments
         request_ids (List[int]): IIB identifiers
-        timeout ([type], optional): Maximum wait time. Defaults to 60*60 (3600 seconds/1 hour)
+        timeout ([type], optional): Maximum wait time. Defaults to 90*60 (5400 seconds/90 minutes)
         delay (int, optional): Delay between build pollin. Defaults to 20.
 
     Returns:

--- a/operatorcert/iib.py
+++ b/operatorcert/iib.py
@@ -161,7 +161,7 @@ def get_build(base_url: str, request_id: int) -> Any:
 
 
 def wait_for_batch_results(
-    iib_url: str, batch_id: int, timeout: float = 60 * 60, delay: float = 20
+    iib_url: str, batch_id: int, timeout: float = 90 * 60, delay: float = 20
 ) -> Any:
     """
     Wait for IIB build till it finishes
@@ -169,7 +169,7 @@ def wait_for_batch_results(
     Args:
         iib_url (Any): CLI arguments
         batch_id (int): IIB batch identifier
-        timeout ([type], optional): Maximum wait time. Defaults to 60*60 (3600 seconds/1 hour)
+        timeout ([type], optional): Maximum wait time. Defaults to 90*60 (5400 seconds/90 minutes)
         delay (int, optional): Delay between build pollin. Defaults to 20.
 
     Returns:


### PR DESCRIPTION
Increase the IIB wait timeout from 60 to 90 minutes to avoid premature
timeouts on slow builds. Aligns the hosted pipeline PipelineRun
`pipeline`/`tasks` timeouts by the same 30 minutes.

### Changes

- `operatorcert/iib.py` — `wait_for_batch_results` default timeout: 60 min → 90 min
- `operatorcert/entrypoints/add_fbc_fragments_to_index.py` — `wait_for_results` default timeout: 60 min → 90 min
- `operator-hosted-pipeline-trigger` — `pipeline`: 2h → 2h30m, `tasks`: 1h50m → 2h20m
- `community-hosted-pipeline-trigger` — `pipeline`: 2h → 2h30m, `tasks`: 1h50m → 2h20m

### Merge Request Checklists

- [x] Development is done in feature branches
- [x] Code changes are submitted as pull request into a primary branch
- [x] Code changes are covered with unit and integration tests.
- [x] Code passes all automated code tests:
    - [x] Linting
    - [x] Code formatter - Black
    - [x] Security scanners
    - [x] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes