### PR TITLE
fix(ISV-7421): add 90 minute timeout to tasks, so task is not clawed …

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-index.yml
@@ -68,6 +68,7 @@ spec:
   steps:
     - name: add-bundle-to-index
       image: "$(params.pipeline_image)"
+      timeout: "1h30m0s"
       workingDir: $(workspaces.output.path)
       env:
         - name: KRB_KEYTAB_FILE

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/build-fbc-index-images.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/build-fbc-index-images.yml
@@ -67,6 +67,7 @@ spec:
   steps:
     - name: add-fbc-fragments-to-index
       image: "$(params.pipeline_image)"
+      timeout: "1h30m0s"
       workingDir: $(workspaces.output.path)
       env:
         - name: KRB_KEYTAB_FILE
@@ -140,6 +141,7 @@ spec:
 
     - name: rm-operator-from-index
       image: "$(params.pipeline_image)"
+      timeout: "1h30m0s"
       workingDir: $(workspaces.output.path)
       env:
         - name: KRB_KEYTAB_FILE


### PR DESCRIPTION
…back by pipeline at default 60min mark. Continuation of PR 982.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [x] Pull request is tagged with "risk/good-to-go" label for minor changes

## Motivation
The below PR made the default possible for 90mins, but did not update the default for tasks, so timeouts still happen at 60mins.
- Implementation: #982 
- Still affected: redhat-openshift-ecosystem/community-operators-prod#10312