### PR TITLE
chore(ISV-7433): update OPM version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ COPY config/krb5.conf /etc/krb5.conf
 COPY hacks/retry-command.sh /usr/local/bin/retry
 
 # Install oc, opm and operator-sdk CLI
-RUN curl -LO https://github.com/operator-framework/operator-registry/releases/download/v1.46.0/linux-${ARCH}-opm && \
+RUN curl -LO https://github.com/operator-framework/operator-registry/releases/download/v1.71.0/linux-${ARCH}-opm && \
   chmod +x linux-${ARCH}-opm && \
   mv linux-${ARCH}-opm /usr/local/bin/opm && \
   curl -LO https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/stable-4.20/openshift-client-linux.tar.gz && \

--- a/ansible/roles/integration_tests/tasks/tools.yml
+++ b/ansible/roles/integration_tests/tasks/tools.yml
@@ -18,7 +18,7 @@
 
     - name: Download and extract the opm binary
       ansible.builtin.unarchive:
-        src: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.20/opm-linux.tar.gz
+        src: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.20/opm-linux-rhel9.tar.gz
         dest: "{{ integration_tests_temp_tools_dir.path }}"
         remote_src: true
         include:

--- a/ansible/roles/integration_tests/tasks/tools.yml
+++ b/ansible/roles/integration_tests/tasks/tools.yml
@@ -18,19 +18,19 @@
 
     - name: Download and extract the opm binary
       ansible.builtin.unarchive:
-        src: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.18/opm-linux.tar.gz
+        src: https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.20/opm-linux.tar.gz
         dest: "{{ integration_tests_temp_tools_dir.path }}"
         remote_src: true
         include:
-          - opm-rhel8
+          - opm-rhel9
 
     - name: Rename the opm binary
       ansible.builtin.copy:
-        src: "{{ integration_tests_temp_tools_dir.path }}/opm-rhel8"
+        src: "{{ integration_tests_temp_tools_dir.path }}/opm-rhel9"
         dest: "{{ integration_tests_temp_tools_dir.path }}/opm"
         mode: '0755'
 
     - name: Delete the original file
       ansible.builtin.file:
-        path: "{{ integration_tests_temp_tools_dir.path }}/opm-rhel8"
+        path: "{{ integration_tests_temp_tools_dir.path }}/opm-rhel9"
         state: absent

--- a/fbc/Makefile
+++ b/fbc/Makefile
@@ -84,7 +84,7 @@ OS=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(shell uname -m | sed 's/x86_64/amd64/')
 
 # Automatically download the binaries and scripts and place them in the bin directory
-OPM_VERSION ?= v1.46.0
+OPM_VERSION ?= v1.71.0
 ${BINDIR}/opm:
 	if [ ! -d ${BINDIR} ]; then mkdir -p ${BINDIR}; fi
 	curl -sLO https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$(OS)-$(ARCH)-opm && chmod +x $(OS)-$(ARCH)-opm && mv $(OS)-$(ARCH)-opm ${BINDIR}/opm


### PR DESCRIPTION
Update the OPM version used in the pipeline image and FBC Makefile.
I also updated the OPM version used in `Deploy tools to the host` to match the OCP and RHEL version.

Assisted-by: Cursor

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes