### PR TITLE
fix(ISV-7433): registry secret resolution after OPM bump

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-fbc.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-fbc.yml
@@ -65,13 +65,19 @@ spec:
     - name: add-bundle-to-fbc
       image: "$(params.pipeline_image)"
       workingDir: $(workspaces.source.path)
-      env:
-        # The registry auth file for opm render catalog command
-        - name: REGISTRY_AUTH_FILE
-          value: "$(workspaces.registry-credentials.path)/.dockerconfigjson"
       script: |
         #! /usr/bin/env bash
         set -xe
+
+        # OPM 1.53+ (containers/image) expects a Docker-style auth layout:
+        # DOCKER_CONFIG/config.json and/or REGISTRY_AUTH_FILE pointing at that file.
+        # K8s dockerconfigjson secrets mount as .dockerconfigjson; reshape for OPM.
+        if [[ "$(workspaces.registry-credentials.bound)" == "true" ]]; then
+          export DOCKER_CONFIG="$(mktemp -d)"
+          cp "$(workspaces.registry-credentials.path)/.dockerconfigjson" \
+            "$DOCKER_CONFIG/config.json"
+          export REGISTRY_AUTH_FILE="$DOCKER_CONFIG/config.json"
+        fi
 
         RELEASE_CONFIG_PATH="operators/$(params.operator_name)/$(params.operator_version)/release-config.yaml"
 

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/build-fbc-scratch-catalog.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/build-fbc-scratch-catalog.yml
@@ -63,11 +63,15 @@ spec:
         EXTRA_ARGS=""
         if [[ "$(workspaces.credentials.bound)" == "true" ]]; then
           DOCKERCONFIGJSON="$(workspaces.credentials.path)/.dockerconfigjson"
+          # buildah accepts the K8s-mounted .dockerconfigjson path directly
           EXTRA_ARGS+=" --authfile $DOCKERCONFIGJSON"
 
-          # OPM reads the config location from env var and cannot be provided as a parameter
-          # this will expose the config path to the OPM tool
-          export REGISTRY_AUTH_FILE=$DOCKERCONFIGJSON
+          # OPM 1.53+ (containers/image) expects a Docker-style auth layout:
+          # DOCKER_CONFIG/config.json and/or REGISTRY_AUTH_FILE pointing at that file.
+          # K8s dockerconfigjson secrets mount as .dockerconfigjson; reshape for OPM.
+          export DOCKER_CONFIG="$(mktemp -d)"
+          cp "$DOCKERCONFIGJSON" "$DOCKER_CONFIG/config.json"
+          export REGISTRY_AUTH_FILE="$DOCKER_CONFIG/config.json"
         fi
 
         # The registry pull-spec is in following format:


### PR DESCRIPTION
After OPM bump in https://github.com/redhat-openshift-ecosystem/operator-pipelines/pull/990 there are errors in stage environment like this https://github.com/redhat-openshift-ecosystem/certified-operators-preprod/pull/7473#issuecomment-4998878082
The previous version of OPM was 1.46.0 and the new is 1.71.0 - in 1.53.0 new secret resolution was introduced https://github.com/operator-framework/operator-registry/releases/tag/v1.53.0 as a possible breaking change. OPM now expects `config.json` and our defined `.dockerconfigjson` is picked up only if the first does not exist. If the file exist but it is empty, then it is silently passed as the secret.
This PR copies the `.dockerconfigjson` to the right location. Verified in this PR https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/3773 against the current code as our integration test do not cover this workflow.

Assisted-by: Cursor

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes