### PR TITLE
ISV-7466 Separate queue for ISV and community

### DIFF
--- a/ansible/inventory/group_vars/operator-pipeline-integration-tests-community.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-integration-tests-community.yml
@@ -17,6 +17,8 @@ operator_pipeline_dispatcher_config:
       pipeline_name: "operator-hosted-pipeline"
       max_capacity: "{{ operator_pipeline_dispatcher_hosted_capacity }}"
       namespace: "{{ oc_namespace }}"
+      annotation_selector:
+        operator-pipelines.redhat.com/repository: "{{ integration_tests_git_upstream_repo }}"
     callback_url: "{{ operator_pipeline_community_pipeline_callback_url }}"
     filter:
       cel_expression: "{{ operator_pipeline_hosted_pipeline_cel_filter | replace('\n', '') }}"
@@ -29,6 +31,8 @@ operator_pipeline_dispatcher_config:
       pipeline_name: "operator-release-pipeline"
       max_capacity: "{{ operator_pipeline_dispatcher_release_capacity }}"
       namespace: "{{ oc_namespace }}"
+      annotation_selector:
+        operator-pipelines.redhat.com/repository: "{{ integration_tests_git_upstream_repo }}"
     callback_url: "{{ operator_pipeline_community_pipeline_callback_url }}"
     filter:
       cel_expression: "{{ operator_pipeline_release_pipeline_cel_filter | replace('\n', '') }}"

--- a/ansible/inventory/group_vars/operator-pipeline-integration-tests.yml
+++ b/ansible/inventory/group_vars/operator-pipeline-integration-tests.yml
@@ -48,6 +48,8 @@ operator_pipeline_dispatcher_config:
       pipeline_name: "operator-hosted-pipeline"
       max_capacity: "{{ operator_pipeline_dispatcher_hosted_capacity }}"
       namespace: "{{ oc_namespace }}"
+      annotation_selector:
+        operator-pipelines.redhat.com/repository: "{{ integration_tests_git_upstream_repo }}"
     callback_url: "{{ operator_pipeline_callback_url }}"
     filter:
       cel_expression: "{{ operator_pipeline_hosted_pipeline_cel_filter | replace('\n', '') }}"
@@ -60,6 +62,8 @@ operator_pipeline_dispatcher_config:
       pipeline_name: "operator-release-pipeline"
       max_capacity: "{{ operator_pipeline_dispatcher_release_capacity }}"
       namespace: "{{ oc_namespace }}"
+      annotation_selector:
+        operator-pipelines.redhat.com/repository: "{{ integration_tests_git_upstream_repo }}"
     callback_url: "{{ operator_pipeline_callback_url }}"
     filter:
       cel_expression: "{{ operator_pipeline_release_pipeline_cel_filter | replace('\n', '') }}"

--- a/ansible/inventory/group_vars/operator-pipeline.yml
+++ b/ansible/inventory/group_vars/operator-pipeline.yml
@@ -124,6 +124,8 @@ operator_pipeline_dispatcher_config:
       pipeline_name: "operator-hosted-pipeline"
       max_capacity: "{{ operator_pipeline_dispatcher_hosted_capacity }}"
       namespace: "{{ oc_namespace }}"
+      annotation_selector:
+        operator-pipelines.redhat.com/repository: "{{ operator_pipeline_certified_operators_repository_name }}"
     callback_url: "{{ operator_pipeline_callback_url }}"
     filter:
       cel_expression: "{{ operator_pipeline_hosted_pipeline_cel_filter | replace('\n', '') }}"
@@ -136,6 +138,8 @@ operator_pipeline_dispatcher_config:
       pipeline_name: "operator-release-pipeline"
       max_capacity: "{{ operator_pipeline_dispatcher_release_capacity }}"
       namespace: "{{ oc_namespace }}"
+      annotation_selector:
+        operator-pipelines.redhat.com/repository: "{{ operator_pipeline_certified_operators_repository_name }}"
     callback_url: "{{ operator_pipeline_callback_url }}"
     filter:
       cel_expression: "{{ operator_pipeline_release_pipeline_cel_filter | replace('\n', '') }}"
@@ -148,6 +152,8 @@ operator_pipeline_dispatcher_config:
       pipeline_name: "operator-hosted-pipeline"
       max_capacity: "{{ operator_pipeline_dispatcher_hosted_capacity }}"
       namespace: "{{ oc_namespace }}"
+      annotation_selector:
+        operator-pipelines.redhat.com/repository: "{{ operator_pipeline_marketplace_operators_repository_name }}"
     callback_url: "{{ operator_pipeline_callback_url }}"
     filter:
       cel_expression: "{{ operator_pipeline_hosted_pipeline_cel_filter | replace('\n', '') }}"
@@ -160,6 +166,8 @@ operator_pipeline_dispatcher_config:
       pipeline_name: "operator-release-pipeline"
       max_capacity: "{{ operator_pipeline_dispatcher_release_capacity }}"
       namespace: "{{ oc_namespace }}"
+      annotation_selector:
+        operator-pipelines.redhat.com/repository: "{{ operator_pipeline_marketplace_operators_repository_name }}"
     callback_url: "{{ operator_pipeline_callback_url }}"
     filter:
       cel_expression: "{{ operator_pipeline_release_pipeline_cel_filter | replace('\n', '') }}"
@@ -172,6 +180,8 @@ operator_pipeline_dispatcher_config:
       pipeline_name: "operator-hosted-pipeline"
       max_capacity: "{{ operator_pipeline_dispatcher_hosted_capacity }}"
       namespace: "{{ oc_namespace }}"
+      annotation_selector:
+        operator-pipelines.redhat.com/repository: "{{ operator_pipeline_community_operators_repository_name }}"
     callback_url: "{{ operator_pipeline_community_pipeline_callback_url }}"
     filter:
       cel_expression: "{{ operator_pipeline_hosted_pipeline_cel_filter | replace('\n', '') }}"
@@ -184,6 +194,8 @@ operator_pipeline_dispatcher_config:
       pipeline_name: "operator-release-pipeline"
       max_capacity: "{{ operator_pipeline_dispatcher_release_capacity }}"
       namespace: "{{ oc_namespace }}"
+      annotation_selector:
+        operator-pipelines.redhat.com/repository: "{{ operator_pipeline_community_operators_repository_name }}"
     callback_url: "{{ operator_pipeline_community_pipeline_callback_url }}"
     filter:
       cel_expression: "{{ operator_pipeline_release_pipeline_cel_filter | replace('\n', '') }}"

--- a/ansible/roles/operator-pipeline/tasks/community-hosted-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-hosted-pipeline-trigger.yml
@@ -50,6 +50,8 @@
                 value: operatorcert.static_tests.community,operatorcert.static_tests.common
               - name: cert_project_required
                 value: "false"
+              - name: git_repository_full_name
+                value: $(body.repository.full_name)
 
     - name: Create Community hosted pipeline Trigger template
       kubernetes.core.k8s:
@@ -82,6 +84,7 @@
               - name: hydra_sso_token_url
               - name: static_test_suites
               - name: cert_project_required
+              - name: git_repository_full_name
             resourcetemplates:
               - apiVersion: tekton.dev/v1
                 kind: PipelineRun
@@ -94,6 +97,7 @@
                     git_commit: $(tt.params.git_commit)
                   annotations:
                     git_pull_request_url: $(tt.params.git_pr_url)
+                    operator-pipelines.redhat.com/repository: $(tt.params.git_repository_full_name)
                 spec:
                   timeouts:
                     pipeline: "2h30m"

--- a/ansible/roles/operator-pipeline/tasks/community-release-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-release-pipeline-trigger.yml
@@ -46,6 +46,8 @@
                 value: krb5-community.keytab
               - name: quay_push_final_index_secret
                 value: community-push-final-index-quay-credentials
+              - name: git_repository_full_name
+                value: $(body.repository.full_name)
 
     - name: Create Community release pipeline Trigger Template
       kubernetes.core.k8s:
@@ -76,6 +78,7 @@
               - name: dest_image_namespace
               - name: kerberos_keytab_secret_key
               - name: quay_push_final_index_secret
+              - name: git_repository_full_name
             resourcetemplates:
               - apiVersion: tekton.dev/v1
                 kind: PipelineRun
@@ -88,6 +91,7 @@
                     git_commit: $(tt.params.git_commit)
                   annotations:
                     git_pull_request_url: $(tt.params.git_pr_url)
+                    operator-pipelines.redhat.com/repository: $(tt.params.git_repository_full_name)
                 spec:
                   timeouts:
                     pipeline: "4h15m0s"

--- a/ansible/roles/operator-pipeline/tasks/operator-hosted-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-hosted-pipeline-trigger.yml
@@ -50,6 +50,8 @@
                 value: "{{ operator_pipeline_hydra_sso_token_url }}"
               - name: static_test_suites
                 value: operatorcert.static_tests.isv,operatorcert.static_tests.common
+              - name: git_repository_full_name
+                value: $(body.repository.full_name)
 
     - name: Create Hosted pipeline Trigger Template
       kubernetes.core.k8s:
@@ -79,6 +81,7 @@
               - name: image_namespace
               - name: hydra_sso_token_url
               - name: static_test_suites
+              - name: git_repository_full_name
             resourcetemplates:
               - apiVersion: tekton.dev/v1
                 kind: PipelineRun
@@ -91,6 +94,7 @@
                     git_commit: $(tt.params.git_commit)
                   annotations:
                     git_pull_request_url: $(tt.params.git_pr_url)
+                    operator-pipelines.redhat.com/repository: $(tt.params.git_repository_full_name)
                 spec:
                   timeouts:
                     pipeline: "2h30m"

--- a/ansible/roles/operator-pipeline/tasks/operator-release-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-release-pipeline-trigger.yml
@@ -42,6 +42,8 @@
                 value: krb5-isv.keytab
               - name: quay_push_final_index_secret
                 value: iib-quay-credentials
+              - name: git_repository_full_name
+                value: $(body.repository.full_name)
     - name: Create Release pipeline Trigger Template
       kubernetes.core.k8s:
         state: present
@@ -68,6 +70,7 @@
               - name: dest_image_namespace
               - name: kerberos_keytab_secret_key
               - name: quay_push_final_index_secret
+              - name: git_repository_full_name
             resourcetemplates:
               - apiVersion: tekton.dev/v1
                 kind: PipelineRun
@@ -80,6 +83,7 @@
                     git_commit: $(tt.params.git_commit)
                   annotations:
                     git_pull_request_url: $(tt.params.git_pr_url)
+                    operator-pipelines.redhat.com/repository: $(tt.params.git_repository_full_name)
                 spec:
                   timeouts:
                     pipeline: "4h15m0s"

--- a/config/dispatcher_config.yaml
+++ b/config/dispatcher_config.yaml
@@ -15,6 +15,8 @@ dispatcher:
         pipeline_name: "operator-hosted-pipeline"
         max_capacity: 2
         namespace: "operator-pipeline-stage"
+        annotation_selector:
+          operator-pipelines.redhat.com/repository: "redhat-openshift-ecosystem/community-operators-preprod"
       callback_url: "https://example.com/foo" # Placeholder URL
 
 security:

--- a/operatorcert/webhook_dispatcher/capacity_manager.py
+++ b/operatorcert/webhook_dispatcher/capacity_manager.py
@@ -113,24 +113,20 @@ class OCPTektonCapacityManager(CapacityManager):
             int: A count of running pipelines
         """
         try:
-            # Use the Kubernetes custom objects API to query Tekton PipelineRuns
             custom_objects_api = client.CustomObjectsApi(self.k8s_client)
 
-            # Query PipelineRuns in the Tekton namespace
+            # Tekton automatically sets tekton.dev/pipeline on every PipelineRun
+            # created via pipelineRef, enabling server-side filtering by pipeline name.
             pipeline_runs = custom_objects_api.list_namespaced_custom_object(
                 group="tekton.dev",
                 version="v1beta1",
                 namespace=self.namespace,
                 plural="pipelineruns",
+                label_selector=f"tekton.dev/pipeline={self.pipeline_name}",
             )
 
-            # Count running pipelines
             running_count = 0
             for item in pipeline_runs.get("items", []):
-                pipeline_name = item.get("spec", {}).get("pipelineRef", {}).get("name")
-                if pipeline_name != self.pipeline_name:
-                    continue
-
                 if not self._matches_annotation_selector(item):
                     continue
 

--- a/operatorcert/webhook_dispatcher/capacity_manager.py
+++ b/operatorcert/webhook_dispatcher/capacity_manager.py
@@ -31,11 +31,17 @@ class OCPTektonCapacityManager(CapacityManager):
 
     """
 
-    def __init__(self, pipeline_name: str, max_capacity: int, namespace: str):
+    def __init__(
+        self,
+        pipeline_name: str,
+        max_capacity: int,
+        namespace: str,
+        annotation_selector: dict[str, str] | None = None,
+    ):
         self.pipeline_name = pipeline_name
         self.max_capacity = max_capacity
         self.namespace = namespace
-
+        self.annotation_selector = annotation_selector
         self._k8s_client = None
 
     @property
@@ -82,6 +88,22 @@ class OCPTektonCapacityManager(CapacityManager):
         )
         return is_free
 
+    def _matches_annotation_selector(self, item: dict) -> bool:  # type: ignore[type-arg]
+        """
+        Check whether a PipelineRun item matches the configured annotation selector.
+        If no annotation_selector is configured, all items match.
+
+        Args:
+            item (dict): A PipelineRun item from the Kubernetes API response.
+
+        Returns:
+            bool: True if the item matches the annotation selector, False otherwise.
+        """
+        if not self.annotation_selector:
+            return True
+        annotations = item.get("metadata", {}).get("annotations", {})
+        return all(annotations.get(k) == v for k, v in self.annotation_selector.items())
+
     async def _get_running_tekton_pipelines_count(self) -> int:
         """
         Get the count of currently running Tekton pipelines for the specified
@@ -107,6 +129,9 @@ class OCPTektonCapacityManager(CapacityManager):
             for item in pipeline_runs.get("items", []):
                 pipeline_name = item.get("spec", {}).get("pipelineRef", {}).get("name")
                 if pipeline_name != self.pipeline_name:
+                    continue
+
+                if not self._matches_annotation_selector(item):
                     continue
 
                 status = item.get("status", {})

--- a/operatorcert/webhook_dispatcher/config.py
+++ b/operatorcert/webhook_dispatcher/config.py
@@ -60,6 +60,7 @@ class CapacityConfig(BaseModel):
     pipeline_name: str
     max_capacity: int
     namespace: str
+    annotation_selector: Optional[dict[str, str]] = None
 
 
 class Filter(BaseModel):

--- a/operatorcert/webhook_dispatcher/pipeline_event.py
+++ b/operatorcert/webhook_dispatcher/pipeline_event.py
@@ -61,6 +61,7 @@ class PipelineEvent:
                 self.config_item.capacity.pipeline_name,
                 self.config_item.capacity.max_capacity,
                 self.config_item.capacity.namespace,
+                self.config_item.capacity.annotation_selector,
             )
         raise ValueError(f"Unsupported capacity type: {self.config_item.capacity.type}")
 

--- a/tests/webhook_dispatcher/test_capacity_manager.py
+++ b/tests/webhook_dispatcher/test_capacity_manager.py
@@ -71,12 +71,7 @@ async def test_ocptekton_capacity_manager__get_running_tekton_pipelines_count(
     mock_custom_objects_api.return_value.list_namespaced_custom_object.return_value = {
         "items": [
             {
-                "metadata": {"name": "unknown-pipeline"},
-                "spec": {"pipelineRef": {"name": "unknown-pipeline"}},
-            },
-            {
                 "metadata": {"name": "test-pipeline-1"},
-                "spec": {"pipelineRef": {"name": "test-pipeline"}},
                 "status": {
                     "conditions": [
                         {"type": "Succeeded", "status": "Unknown", "reason": "Running"}
@@ -85,7 +80,6 @@ async def test_ocptekton_capacity_manager__get_running_tekton_pipelines_count(
             },
             {
                 "metadata": {"name": "test-pipeline-2"},
-                "spec": {"pipelineRef": {"name": "test-pipeline"}},
                 "status": {
                     "conditions": [
                         {"type": "Succeeded", "status": "Unknown", "reason": "Running"}
@@ -94,12 +88,18 @@ async def test_ocptekton_capacity_manager__get_running_tekton_pipelines_count(
             },
             {
                 "metadata": {"name": "test-pipeline-3"},
-                "spec": {"pipelineRef": {"name": "test-pipeline"}},
                 "status": {"conditions": [{"type": "Succeeded", "status": "True"}]},
             },
         ],
     }
     assert await capacity_manager._get_running_tekton_pipelines_count() == 2
+    mock_custom_objects_api.return_value.list_namespaced_custom_object.assert_called_once_with(
+        group="tekton.dev",
+        version="v1beta1",
+        namespace="test-namespace",
+        plural="pipelineruns",
+        label_selector="tekton.dev/pipeline=test-pipeline",
+    )
 
 
 @pytest.mark.asyncio
@@ -183,3 +183,10 @@ async def test_ocptekton_capacity_manager__get_running_tekton_pipelines_count_wi
         ],
     }
     assert await capacity_manager._get_running_tekton_pipelines_count() == 1
+    mock_custom_objects_api.return_value.list_namespaced_custom_object.assert_called_once_with(
+        group="tekton.dev",
+        version="v1beta1",
+        namespace="test-namespace",
+        plural="pipelineruns",
+        label_selector="tekton.dev/pipeline=test-pipeline",
+    )

--- a/tests/webhook_dispatcher/test_capacity_manager.py
+++ b/tests/webhook_dispatcher/test_capacity_manager.py
@@ -121,3 +121,65 @@ async def test_ocptekton_capacity_manager__get_running_tekton_pipelines_count_er
     )
     with pytest.raises(Exception):  # pylint: disable=broad-exception-raised
         await capacity_manager._get_running_tekton_pipelines_count()
+
+
+@pytest.mark.asyncio
+@patch(
+    "operatorcert.webhook_dispatcher.capacity_manager.OCPTektonCapacityManager.k8s_client"
+)
+@patch("operatorcert.webhook_dispatcher.capacity_manager.client.CustomObjectsApi")
+async def test_ocptekton_capacity_manager__get_running_tekton_pipelines_count_with_annotation_selector(
+    mock_custom_objects_api: MagicMock,
+    mock_k8s_client: MagicMock,
+) -> None:
+    capacity_manager = OCPTektonCapacityManager(
+        pipeline_name="test-pipeline",
+        max_capacity=10,
+        namespace="test-namespace",
+        annotation_selector={"operator-pipelines.redhat.com/repository": "org/repo-a"},
+    )
+    mock_custom_objects_api.return_value.list_namespaced_custom_object.return_value = {
+        "items": [
+            {
+                # matches pipeline name AND annotation → counted
+                "metadata": {
+                    "name": "test-pipeline-1",
+                    "annotations": {
+                        "operator-pipelines.redhat.com/repository": "org/repo-a"
+                    },
+                },
+                "spec": {"pipelineRef": {"name": "test-pipeline"}},
+                "status": {
+                    "conditions": [
+                        {"type": "Succeeded", "status": "Unknown", "reason": "Running"}
+                    ]
+                },
+            },
+            {
+                # matches pipeline name but annotation value differs → not counted
+                "metadata": {
+                    "name": "test-pipeline-2",
+                    "annotations": {
+                        "operator-pipelines.redhat.com/repository": "org/repo-b"
+                    },
+                },
+                "spec": {"pipelineRef": {"name": "test-pipeline"}},
+                "status": {
+                    "conditions": [
+                        {"type": "Succeeded", "status": "Unknown", "reason": "Running"}
+                    ]
+                },
+            },
+            {
+                # matches pipeline name but annotation key absent → not counted
+                "metadata": {"name": "test-pipeline-3", "annotations": {}},
+                "spec": {"pipelineRef": {"name": "test-pipeline"}},
+                "status": {
+                    "conditions": [
+                        {"type": "Succeeded", "status": "Unknown", "reason": "Running"}
+                    ]
+                },
+            },
+        ],
+    }
+    assert await capacity_manager._get_running_tekton_pipelines_count() == 1

--- a/tests/webhook_dispatcher/test_config.py
+++ b/tests/webhook_dispatcher/test_config.py
@@ -23,6 +23,9 @@ def test_load_config(mock_open: MagicMock, mock_yaml_load: MagicMock) -> None:
                         "type": "ocp_tekton",
                         "pipeline_name": "test",
                         "namespace": "test",
+                        "annotation_selector": {
+                            "operator-pipelines.redhat.com/repository": "test/test"
+                        },
                     },
                     "filter": {
                         "cel_expression": "body.action == 'push'",
@@ -40,6 +43,9 @@ def test_load_config(mock_open: MagicMock, mock_yaml_load: MagicMock) -> None:
     assert config.dispatcher.items[0].name == "test"
     assert config.dispatcher.items[0].events == ["push"]
     assert config.dispatcher.items[0].full_repository_name == "test/test"
+    assert config.dispatcher.items[0].capacity.annotation_selector == {
+        "operator-pipelines.redhat.com/repository": "test/test"
+    }
 
 
 def test_cel_expression_compilation() -> None:

--- a/tests/webhook_dispatcher/test_pipeline_event.py
+++ b/tests/webhook_dispatcher/test_pipeline_event.py
@@ -56,6 +56,19 @@ def test_capacity_manager(pipeline_event: PipelineEvent) -> None:
         pipeline_event.capacity_manager
 
 
+def test_capacity_manager_passes_annotation_selector(
+    pipeline_event: PipelineEvent,
+) -> None:
+    pipeline_event._config_item.capacity.annotation_selector = {  # type: ignore
+        "operator-pipelines.redhat.com/repository": "test/test"
+    }
+    manager = pipeline_event.capacity_manager
+    assert isinstance(manager, OCPTektonCapacityManager)
+    assert manager.annotation_selector == {
+        "operator-pipelines.redhat.com/repository": "test/test"
+    }
+
+
 @pytest.mark.asyncio
 @patch(
     "operatorcert.webhook_dispatcher.pipeline_event.OCPTektonCapacityManager.is_capacity_available"


### PR DESCRIPTION
The dispatcher capacity manager previously counted all running pipelines by name only. Since ISV, marketplace, and
community operators all run under the same pipeline name, there was no way to enforce separate capacity limits per
repository.

This PR fixes that by:
1. Stamping each PipelineRun with a operator-pipelines.redhat.com/repository annotation (taken from the webhook
payload) when it's triggered
2. Teaching the capacity manager to filter by that annotation, so each repository's running pipelines are counted
independently

As a result, a burst of community PRs can no longer consume capacity reserved for certified operators.

