### PR TITLE
fix(ISV-7482): update git-init image from RHEL8 to RHEL9

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-ci-pipeline.yml
@@ -15,7 +15,7 @@ spec:
     - name: gitInitImage
       description: The image providing the git-init binary that the checkout task runs.
       type: string
-      default: "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8"
+      default: "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9@sha256:56e27c58ded3b0d8aab1a585ef55aa543f7cf78f36060086fec00d0a1c42bc18"
     - name: upstream_repo_name
       default: ""
       description: Upstream repository where the pull request will be opened (namespace/name)

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -252,7 +252,7 @@ spec:
         - name: revision
           value: $(params.git_commit)
         - name: gitInitImage
-          value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
+          value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9@sha256:56e27c58ded3b0d8aab1a585ef55aa543f7cf78f36060086fec00d0a1c42bc18
       workspaces:
         - name: output
           workspace: repository
@@ -273,7 +273,7 @@ spec:
         - name: revision
           value: "$(params.git_commit_base)"
         - name: gitInitImage
-          value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
+          value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9@sha256:56e27c58ded3b0d8aab1a585ef55aa543f7cf78f36060086fec00d0a1c42bc18
       workspaces:
         - name: output
           workspace: repository

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -164,7 +164,7 @@ spec:
         - name: revision
           value: $(params.git_commit)
         - name: gitInitImage
-          value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
+          value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9@sha256:56e27c58ded3b0d8aab1a585ef55aa543f7cf78f36060086fec00d0a1c42bc18
       workspaces:
         - name: output
           workspace: repository
@@ -185,7 +185,7 @@ spec:
         - name: revision
           value: "$(params.git_commit_base)"
         - name: gitInitImage
-          value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:bc551c776fb3d0fcc6cfd6d8dc9f0030de012cb9516fac42b1da75e6771001d9
+          value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9@sha256:56e27c58ded3b0d8aab1a585ef55aa543f7cf78f36060086fec00d0a1c42bc18
       workspaces:
         - name: output
           workspace: repository

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/commit-pinned-digest.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/commit-pinned-digest.yml
@@ -25,7 +25,7 @@ spec:
   params:
     - name: gitInitImage
       description: Git init image
-      default: "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8"
+      default: "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9@sha256:56e27c58ded3b0d8aab1a585ef55aa543f7cf78f36060086fec00d0a1c42bc18"
     - name: dirty_flag
     - name: git_branch
     - name: verbose
@@ -47,7 +47,7 @@ spec:
         Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden
         the gitInitImage param with an image containing custom user configuration.
       type: string
-      default: "/tekton/home"
+      default: "/home/git"
   results:
     - name: commit
       description: The precise commit SHA that was fetched by this Task.
@@ -59,8 +59,6 @@ spec:
       env:
         - name: CURRENT_BRANCH
           value: "$(params.git_branch)"
-        - name: HOME
-          value: "$(params.userHome)"
         - name: PARAM_VERBOSE
           value: $(params.verbose)
         - name: WORKSPACE_SSH_DIRECTORY_BOUND

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/git-clone.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/git-clone.yml
@@ -93,13 +93,13 @@ spec:
     - name: gitInitImage
       description: The image providing the git-init binary that this Task runs.
       type: string
-      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.21.0"
+      default: "registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9@sha256:56e27c58ded3b0d8aab1a585ef55aa543f7cf78f36060086fec00d0a1c42bc18"
     - name: userHome
       description: |
         Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden
         the gitInitImage param with an image containing custom user configuration.
       type: string
-      default: "/tekton/home"
+      default: "/home/git"
   results:
     - name: commit
       description: The precise commit SHA that was fetched by this Task.
@@ -109,8 +109,6 @@ spec:
     - name: clone
       image: "$(params.gitInitImage)"
       env:
-        - name: HOME
-          value: "$(params.userHome)"
         - name: PARAM_URL
           value: $(params.url)
         - name: PARAM_REVISION


### PR DESCRIPTION
The git-init image suddenly stopped working. This caused clone-repository tasks to fail with "Permission denied (publickey)".

Upon further investigation, this seems to boil down to OpenSSH version. The root cause seems to be that GitHub no longer accepts SSH auth from OpenSSH 8.0 (RHEL8) which lacks support for the publickey-hostbound-v00@openssh.com extension. This commit upgrades pipelines-git-init from RHEL8 (OpenSSH 8.0) to RHEL9 (OpenSSH 9.9) which supports the required extension. Even if that wasn't the root cause (no public GitHub announcement was found), this makes it work again.

Investigation was assisted by Claude Code (claude-opus-4-6)