### PR TITLE
feat(ISV-7431): redact potential leaks in logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,9 @@ RUN curl -LO https://github.com/operator-framework/operator-registry/releases/do
   chmod +x operator-sdk_linux_${ARCH} && \
   mv operator-sdk_linux_${ARCH} /usr/local/bin/operator-sdk
 
+# Install leaktkt
+COPY --from=quay.io/leaktk/leaktk:0.3.5@sha256:47f6120b372bc29629f00812ab363496321f1ab412b4d4a908516d50a2443617  /usr/local/bin/leaktk /usr/local/bin/
+
 # Create users
 RUN useradd -lms /bin/bash -u "${USER_UID}" user && \
   useradd -lu "${PODMAN_USER_UID}" podman; \

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/run-static-tests.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/run-static-tests.yml
@@ -136,6 +136,11 @@ spec:
         # Replace status words with corresponding symbols
         sed -ie 's/^|warning|/|:warning:|/g;s/^|error|/|:x:|/g' "$MESSAGE_FILE"
 
+        # Redact any potential leaks
+        tempfile=$(mktemp)
+        leaktk redact --kind Stdio < "$MESSAGE_FILE" > "$tempfile"
+        mv -f "$tempfile" "$MESSAGE_FILE"
+
         echo "Posting GitHub comment to issue (or PR) $(params.pull_request_url)"
 
         github-add-comment \

--- a/operatorcert/entrypoints/create_github_gist.py
+++ b/operatorcert/entrypoints/create_github_gist.py
@@ -12,6 +12,7 @@ from typing import Any, List, Iterator
 
 from github import Auth, Gist, Github, InputFileContent, IssueComment
 from operatorcert.logger import setup_logger
+from operatorcert.redact import scan_and_redact
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -85,13 +86,24 @@ def create_github_gist(github_api: Github, input_path: List[Path]) -> Gist.Gist:
         else:
             LOGGER.warning("Skipping %s, not a file or directory", input_item)
 
+    # Redact any potential leaks if needed
+    redacted_file_mapping = scan_and_redact(
+        *[file_path for file_path, _ in files_for_gist]
+    )
+
     for file_path, relative_path in files_for_gist:
-        content = file_path.read_text(encoding="utf-8")
+        # Content path is either directly the file or its redacted version
+        content_path = redacted_file_mapping.get(file_path.absolute(), file_path)
+        content = content_path.read_text(encoding="utf-8")
         if content.strip() == "":
-            LOGGER.warning("Skipping empty file %s", file_path)
+            LOGGER.warning("Skipping empty file %s", content_path)
             continue
         LOGGER.info("Adding file %s to gist", relative_path)
         gist_content[relative_path] = InputFileContent(content)
+
+    # cleanup of temporary redacted files
+    for redacted_file in redacted_file_mapping.values():
+        os.unlink(redacted_file)
 
     LOGGER.info("Creating gist from %s", gist_content.keys())
     gist = github_auth_user.create_gist(
@@ -141,6 +153,7 @@ def main() -> None:
 
     github_auth = Auth.Token(os.environ.get("GITHUB_TOKEN") or "")
     github = Github(auth=github_auth)
+
     gist = create_github_gist(github, args.input_path)
 
     if args.pull_request_url:

--- a/operatorcert/redact.py
+++ b/operatorcert/redact.py
@@ -7,9 +7,9 @@ and then redacts.
 """
 
 import logging
+import subprocess
 import tempfile
 from pathlib import Path
-from subprocess import Popen, PIPE
 import json
 
 from pydantic import BaseModel
@@ -47,16 +47,19 @@ def scan(*input_paths: Path) -> list[ResultSetModel]:
     Returns:
         Parsed scan results.
     """
-    results = []
-    for input_path in input_paths:
-        with Popen(
-            ["leaktk", "scan", "--kind", "Files", str(input_path.absolute())],
-            stdout=PIPE,
-        ) as scan_proc:
-            result_bytes = scan_proc.stdout.read()  # type: ignore[union-attr]
-        loaded_dict = json.loads(result_bytes)
-        results.append(ResultSetModel.model_validate(loaded_dict))
-    return results
+    requests = "".join(
+        json.dumps(
+            {"id": str(i), "kind": "Files", "resource": str(input_path.absolute())}
+        )
+        + "\n"
+        for i, input_path in enumerate(input_paths)
+    )
+    results_jsonl = subprocess.check_output(
+        ["leaktk", "listen"], input=requests, text=True
+    )
+    return list(
+        map(ResultSetModel.model_validate, map(json.loads, results_jsonl.splitlines()))
+    )
 
 
 def _redact(
@@ -78,20 +81,20 @@ def _redact(
             delete=False
         )
         with open(input_path, "rb") as input_file:
-            with Popen(
+            redact_proc = subprocess.run(
                 ["leaktk", "redact", "--kind", "Stdio"],
                 stdin=input_file,
                 stdout=tmp_file.file,
-                stderr=PIPE,
-            ) as redact_proc:
-                redact_proc.wait()
-                if redact_proc.returncode != 0:
-                    raise RuntimeError(
-                        f"Redact failed with return code: "
-                        f"{redact_proc.returncode}. STDERR: "
-                        f"{redact_proc.stderr.read().decode('utf-8')}"  # type: ignore[union-attr]
-                    )
-                file_mapping[input_path.absolute()] = Path(tmp_file.name).absolute()
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            if redact_proc.returncode != 0:
+                raise RuntimeError(
+                    f"Redact failed with return code: "
+                    f"{redact_proc.returncode}. STDERR: "
+                    f"{redact_proc.stderr.decode('utf-8')}"
+                )
+            file_mapping[input_path.absolute()] = Path(tmp_file.name).absolute()
         tmp_file.close()
     return file_mapping
 

--- a/operatorcert/redact.py
+++ b/operatorcert/redact.py
@@ -1,0 +1,132 @@
+"""
+Module for redacting leaked information from output.
+Uses LeakTK: https://github.com/leaktk/leaktk
+
+Parses LeakTK output, concatenates its results so no overlaps exist
+and then redacts.
+"""
+
+import logging
+import tempfile
+from pathlib import Path
+from subprocess import Popen, PIPE
+import json
+
+from pydantic import BaseModel
+
+LOGGER = logging.getLogger("operator-cert")
+
+
+class RedactLocation(BaseModel):
+    """
+    Class for tracking information about a chunk of data in files.
+    """
+
+    path: Path
+
+
+class ResultModel(BaseModel):
+    """
+    Model for parsing a single result from scanning.
+    """
+
+    location: RedactLocation
+
+
+class ResultSetModel(BaseModel):
+    """
+    Model for parsing all results from scanning.
+    """
+
+    results: list[ResultModel]
+
+
+def scan(*input_paths: Path) -> list[ResultSetModel]:
+    """
+    Scan all input paths and return a list of the results.
+    Returns:
+        Parsed scan results.
+    """
+    results = []
+    for input_path in input_paths:
+        with Popen(
+            ["leaktk", "scan", "--kind", "Files", str(input_path.absolute())],
+            stdout=PIPE,
+        ) as scan_proc:
+            result_bytes = scan_proc.stdout.read()  # type: ignore[union-attr]
+        loaded_dict = json.loads(result_bytes)
+        results.append(ResultSetModel.model_validate(loaded_dict))
+    return results
+
+
+def _redact(
+    *input_paths: Path,
+) -> dict[Path, Path]:
+    """
+    Redact the paths yielded by scanning. Creates a new
+    temporary file with the redacted contents.
+    Args:
+        *input_paths: The paths containing leaks.
+
+    Returns:
+        The input paths mapped to their redacted versions.
+        Both set to absolute paths.
+    """
+    file_mapping = {}
+    for input_path in input_paths:
+        tmp_file = tempfile.NamedTemporaryFile(  # pylint: disable=consider-using-with
+            delete=False
+        )
+        with open(input_path, "rb") as input_file:
+            with Popen(
+                ["leaktk", "redact", "--kind", "Stdio"],
+                stdin=input_file,
+                stdout=tmp_file.file,
+                stderr=PIPE,
+            ) as redact_proc:
+                redact_proc.wait()
+                if redact_proc.returncode != 0:
+                    raise RuntimeError(
+                        f"Redact failed with return code: "
+                        f"{redact_proc.returncode}. STDERR: "
+                        f"{redact_proc.stderr.read().decode('utf-8')}"  # type: ignore[union-attr]
+                    )
+                file_mapping[input_path.absolute()] = Path(tmp_file.name).absolute()
+        tmp_file.close()
+    return file_mapping
+
+
+def redact_results(*result_sets: ResultSetModel) -> dict[Path, Path]:
+    """
+    Redact all the paths contained in all the results yielded by scanning.
+    Creates a new temporary file with the redacted contents.
+    Args:
+        *result_sets: The parsed results from scanning.
+
+    Returns:
+        The redacted paths mapped to their redacted versions.
+        Both set to absolute paths.
+    """
+    file_locations = set()
+    for result_set in result_sets:
+        for result in result_set.results:
+            # pathlib does not consider relative & absolute paths the same
+            # even if they point to the same location
+            file_locations.add(Path(result.location.path).absolute())
+    if file_locations:
+        LOGGER.critical("Found leaks in these files: %s", file_locations)
+    return _redact(*file_locations)
+
+
+def scan_and_redact(*input_paths: Path) -> dict[Path, Path]:
+    """
+    Checks which files have leaked information and redacts them.
+    Creates a new temporary file with the redacted contents.
+    Args:
+        *input_paths: Any path (directory or file) to scan.
+    Returns:
+        The redacted paths mapped to their redacted versions.
+        Both set to absolute paths.
+    """
+    scan_results = scan(*input_paths)
+    return redact_results(*scan_results)

--- a/tests/entrypoints/test_create_github_gist.py
+++ b/tests/entrypoints/test_create_github_gist.py
@@ -12,6 +12,7 @@ from operatorcert.entrypoints.create_github_gist import (
 from tests.utils import create_files
 
 
+@patch("operatorcert.entrypoints.create_github_gist.scan_and_redact")
 @patch("operatorcert.entrypoints.create_github_gist.json.dump")
 @patch("operatorcert.entrypoints.create_github_gist.share_github_gist")
 @patch("operatorcert.entrypoints.create_github_gist.create_github_gist")
@@ -25,6 +26,7 @@ def test_main(
     mock_create_github_gist: MagicMock,
     mock_share_github_gist: MagicMock,
     mock_json_dump: MagicMock,
+    mock_scan_and_redact: MagicMock,
     monkeypatch: Any,
     tmp_path: Path,
 ) -> None:
@@ -35,6 +37,7 @@ def test_main(
     args.pull_request_url = "https://github.com/foo/bar/pull/123"
     args.comment_prefix = "prefix:"
     mock_setup_argparser.return_value.parse_args.return_value = args
+    mock_scan_and_redact.return_value = {}
 
     monkeypatch.setenv("GITHUB_TOKEN", "foo_api_token")
     main()
@@ -50,22 +53,32 @@ def test_main(
     )
 
 
+@patch("operatorcert.entrypoints.create_github_gist.scan_and_redact")
 @patch("operatorcert.entrypoints.create_github_gist.InputFileContent")
 def test_create_github_gist(
     mock_input_file_content: MagicMock,
+    mock_scan_and_redact: MagicMock,
     tmp_path: Path,
 ) -> None:
     create_files(
         tmp_path,
         {
             "some_file": "foo",
-            "file2": "bar",
+            "file2": "SECRET",
             "subdir/nested/file3": "baz",
             "subdir/nested/file4": "qux",
             "subdir/nested/empty": "",
+            # Would be created by the redact function,
+            # but that is mocked so the leaktk does not need
+            # to be installed in the host system
+            "redacted_file2": "bar",
+            # bar will be in the output instead of SECRET.
         },
     )
     mock_github = MagicMock()
+    mock_scan_and_redact.return_value = {
+        tmp_path / "file2": tmp_path / "redacted_file2"
+    }
 
     github_user = MagicMock()
     mock_github.get_user.return_value = github_user

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -3,7 +3,6 @@ import os
 import tempfile
 from base64 import b64encode
 from pathlib import Path
-from subprocess import PIPE
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -20,40 +19,33 @@ INPUT_CONTENT = b"curl -H 'Authorization: bearer " + JWT_TOKEN + b" example.com\
 REDACTED_CONTENT = b"curl -H 'Authorization: bearer ***[REDACTED]*** example.com\n"
 
 
-def _scan_result_bytes(path: str) -> bytes:
-    return json.dumps({"results": [{"location": {"path": path}}]}).encode()
+def _scan_result_str(path: str) -> str:
+    return json.dumps({"results": [{"location": {"path": path}}]})
 
 
-def _make_popen_side_effect(
-    scan_result: bytes,
+def _make_run_side_effect(
     redact_returncode: int = 0,
 ) -> Any:
-    def popen_side_effect(cmd: list[str], **kwargs: Any) -> MagicMock:
+    def run_side_effect(cmd: list[str], **kwargs: Any) -> MagicMock:
         proc = MagicMock()
-        proc.__enter__ = MagicMock(return_value=proc)
-        proc.__exit__ = MagicMock(return_value=False)
         proc.returncode = redact_returncode
-        if "scan" in cmd:
-            proc.stdout.read.return_value = scan_result
-        elif "redact" in cmd:
+        if "redact" in cmd:
             stdout = kwargs.get("stdout")
             if stdout:
                 stdout.write(REDACTED_CONTENT)
                 stdout.flush()
         return proc
 
-    return popen_side_effect
+    return run_side_effect
 
 
-@patch("operatorcert.redact.Popen")
-def test_scan(mock_popen: MagicMock) -> None:
+@patch("operatorcert.redact.subprocess.check_output")
+def test_scan(mock_check_output: MagicMock) -> None:
     """Mock leaktk scan call result, check that the expected result is parsed."""
     input_path = Path("/fake/path/testfile")
-    scan_result = _scan_result_bytes(str(input_path))
+    scan_result = _scan_result_str(str(input_path))
 
-    proc = MagicMock()
-    proc.stdout.read.return_value = scan_result
-    mock_popen.return_value.__enter__.return_value = proc
+    mock_check_output.return_value = scan_result
 
     results = scan(input_path)
 
@@ -61,44 +53,59 @@ def test_scan(mock_popen: MagicMock) -> None:
     assert len(results[0].results) == 1
     assert results[0].results[0].location.path == input_path
 
-    mock_popen.assert_called_once_with(
-        ["leaktk", "scan", "--kind", "Files", str(input_path.absolute())],
-        stdout=PIPE,
+    expected_input = (
+        json.dumps(
+            {
+                "id": "0",
+                "kind": "Files",
+                "resource": str(input_path.absolute()),
+            }
+        )
+        + "\n"
+    )
+    mock_check_output.assert_called_once_with(
+        ["leaktk", "listen"],
+        input=expected_input,
+        text=True,
     )
 
 
-@patch("operatorcert.redact.Popen")
-def test_scan_and_redact(mock_popen: MagicMock) -> None:
+@patch("operatorcert.redact.subprocess.run")
+@patch("operatorcert.redact.subprocess.check_output")
+def test_scan_and_redact(mock_check_output: MagicMock, mock_run: MagicMock) -> None:
     """Full scan and redaction workflow."""
     input_file = tempfile.NamedTemporaryFile("wb", delete=False)
     input_file_path = Path(input_file.name)
     input_file.write(INPUT_CONTENT)
     input_file.close()
 
-    scan_result = _scan_result_bytes(str(input_file_path))
-    mock_popen.side_effect = _make_popen_side_effect(scan_result)
+    mock_check_output.return_value = _scan_result_str(str(input_file_path))
+    mock_run.side_effect = _make_run_side_effect()
 
     result = scan_and_redact(input_file_path)
 
     assert len(result) == 1
-    assert input_file_path in result
-    redacted_path = result[input_file_path]
+    assert input_file_path.absolute() in result
+    redacted_path = result[input_file_path.absolute()]
     with open(redacted_path, "rb") as redacted_file:
         assert redacted_file.read() == REDACTED_CONTENT
     os.unlink(input_file_path)
     os.unlink(redacted_path)
 
 
-@patch("operatorcert.redact.Popen")
-def test_scan_and_redact_fail(mock_popen: MagicMock) -> None:
+@patch("operatorcert.redact.subprocess.run")
+@patch("operatorcert.redact.subprocess.check_output")
+def test_scan_and_redact_fail(
+    mock_check_output: MagicMock, mock_run: MagicMock
+) -> None:
     """Redaction raises RuntimeError on non-zero return code."""
     input_file = tempfile.NamedTemporaryFile("wb", delete=False)
     input_file_path = Path(input_file.name)
     input_file.write(INPUT_CONTENT)
     input_file.close()
 
-    scan_result = _scan_result_bytes(str(input_file_path))
-    mock_popen.side_effect = _make_popen_side_effect(scan_result, redact_returncode=1)
+    mock_check_output.return_value = _scan_result_str(str(input_file_path))
+    mock_run.side_effect = _make_run_side_effect(redact_returncode=1)
 
     with pytest.raises(RuntimeError):
         scan_and_redact(input_file_path)

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -1,0 +1,104 @@
+import json
+import os
+import tempfile
+from base64 import b64encode
+from pathlib import Path
+from subprocess import PIPE
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from operatorcert.redact import (
+    scan_and_redact,
+    scan,
+)
+
+JWT_TOKEN_ENCODED = b64encode(json.dumps({"hello": "world"}).encode("utf-8"))
+JWT_TOKEN = b".".join([JWT_TOKEN_ENCODED] * 3)
+INPUT_CONTENT = b"curl -H 'Authorization: bearer " + JWT_TOKEN + b" example.com\n"
+REDACTED_CONTENT = b"curl -H 'Authorization: bearer ***[REDACTED]*** example.com\n"
+
+
+def _scan_result_bytes(path: str) -> bytes:
+    return json.dumps({"results": [{"location": {"path": path}}]}).encode()
+
+
+def _make_popen_side_effect(
+    scan_result: bytes,
+    redact_returncode: int = 0,
+) -> Any:
+    def popen_side_effect(cmd: list[str], **kwargs: Any) -> MagicMock:
+        proc = MagicMock()
+        proc.__enter__ = MagicMock(return_value=proc)
+        proc.__exit__ = MagicMock(return_value=False)
+        proc.returncode = redact_returncode
+        if "scan" in cmd:
+            proc.stdout.read.return_value = scan_result
+        elif "redact" in cmd:
+            stdout = kwargs.get("stdout")
+            if stdout:
+                stdout.write(REDACTED_CONTENT)
+                stdout.flush()
+        return proc
+
+    return popen_side_effect
+
+
+@patch("operatorcert.redact.Popen")
+def test_scan(mock_popen: MagicMock) -> None:
+    """Mock leaktk scan call result, check that the expected result is parsed."""
+    input_path = Path("/fake/path/testfile")
+    scan_result = _scan_result_bytes(str(input_path))
+
+    proc = MagicMock()
+    proc.stdout.read.return_value = scan_result
+    mock_popen.return_value.__enter__.return_value = proc
+
+    results = scan(input_path)
+
+    assert len(results) == 1
+    assert len(results[0].results) == 1
+    assert results[0].results[0].location.path == input_path
+
+    mock_popen.assert_called_once_with(
+        ["leaktk", "scan", "--kind", "Files", str(input_path.absolute())],
+        stdout=PIPE,
+    )
+
+
+@patch("operatorcert.redact.Popen")
+def test_scan_and_redact(mock_popen: MagicMock) -> None:
+    """Full scan and redaction workflow."""
+    input_file = tempfile.NamedTemporaryFile("wb", delete=False)
+    input_file_path = Path(input_file.name)
+    input_file.write(INPUT_CONTENT)
+    input_file.close()
+
+    scan_result = _scan_result_bytes(str(input_file_path))
+    mock_popen.side_effect = _make_popen_side_effect(scan_result)
+
+    result = scan_and_redact(input_file_path)
+
+    assert len(result) == 1
+    assert input_file_path in result
+    redacted_path = result[input_file_path]
+    with open(redacted_path, "rb") as redacted_file:
+        assert redacted_file.read() == REDACTED_CONTENT
+    os.unlink(input_file_path)
+    os.unlink(redacted_path)
+
+
+@patch("operatorcert.redact.Popen")
+def test_scan_and_redact_fail(mock_popen: MagicMock) -> None:
+    """Redaction raises RuntimeError on non-zero return code."""
+    input_file = tempfile.NamedTemporaryFile("wb", delete=False)
+    input_file_path = Path(input_file.name)
+    input_file.write(INPUT_CONTENT)
+    input_file.close()
+
+    scan_result = _scan_result_bytes(str(input_file_path))
+    mock_popen.side_effect = _make_popen_side_effect(scan_result, redact_returncode=1)
+
+    with pytest.raises(RuntimeError):
+        scan_and_redact(input_file_path)

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,6 @@ commands = pylint {[vars]OPERATOR_MODULE} \
 
 [testenv:yamllint]
 allowlist_externals = yamllint
-basepython = python3.13
 files =
     .
 commands =


### PR DESCRIPTION
### Merge Request Checklists

- [x] Development is done in feature branches
- [x] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [x] Code changes are covered with unit and integration tests.
- [x] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes

# Testing of this
Deployed integration tests with dummy "leaks" from local host. Results:
* Latest version (after resolving Quodo comments: https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/3821), check the [published gist with log file](https://gist.github.com/rh-operator-bundle-bot/64568e9115d0fc2a602bfff8f1a42361#file-operator-hosted-pipeline-runx69tr-log-L5).
* Testing of dummy leak in static test results: https://github.com/redhat-openshift-ecosystem/operator-pipelines-test/pull/3820#issuecomment-5055850921

No actual secret was leaked, the "token" is 3 consecutive `{"hello": "world"}` encoded JSONs joined with dots.

## Shortcomings
As you can see, the redaction string is shifted by 1 byte. I have [reported this issue to upstrem](https://github.com/leaktk/leaktk/issues/280).

I also have an almost-finished version of my own redaction wrapper based on the report from `leaktk scan`, which I can update to handle this one-byte shift if necessary (but the whole wrapper is around 400 LoC and 500 lines of test code). I have this code because the `leaktk redact` command didn't exist when I started working on this PR.

The data uploaded to Pyxis is not modified in any way.