### PR TITLE
feat(ISV-7470): update error message for check_replaces_availability

### DIFF
--- a/operatorcert/static_tests/common/bundle.py
+++ b/operatorcert/static_tests/common/bundle.py
@@ -263,7 +263,11 @@ def check_replaces_availability(bundle: Bundle) -> Iterator[CheckResult]:
     if replaces_version not in ver_to_dir:
         yield Fail(
             f"{bundle} attempts to replace version '{replaces_version}' which"
-            f" does not exist. Available versions: {sorted(ver_to_dir.keys())}"
+            f" does not exist in the submitted PR branch."
+            f" Available versions: {sorted(ver_to_dir.keys())}."
+            f" If you are submitting multiple versions in sequence,"
+            f" make sure your fork is up to date with origin (rebased)"
+            f" before each submission to include all previously merged versions."
         )
         return
 

--- a/tests/static_tests/common/test_bundle.py
+++ b/tests/static_tests/common/test_bundle.py
@@ -799,7 +799,11 @@ def test_check_operator_version_directory_name(
             {
                 Fail(
                     "Bundle(hello/0.0.2) attempts to replace version '0.0.5' which"
-                    " does not exist. Available versions: ['0.0.1', '0.0.2']"
+                    " does not exist in the submitted PR branch."
+                    " Available versions: ['0.0.1', '0.0.2']."
+                    " If you are submitting multiple versions in sequence,"
+                    " make sure your fork is up to date with origin (rebased)"
+                    " before each submission to include all previously merged versions."
                 )
             },
             id="Nonexistent replaces version",


### PR DESCRIPTION
Update error message to advice user to keep their fork up to date before each submission to include all versions merged in origin repo.

I've checked the other static tests to see if their error messages could be considered unclear in the same way, resulting in similar issues being filed, but it seems to me this is the only static test falling into that exact category. 

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes