### PR TITLE
add git safe.directory config to all git tasks, now that git 2.43

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-fbc.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-fbc.yml
@@ -137,7 +137,11 @@ spec:
         fi
 
 
-        git config --global --add safe.directory $(workspaces.source.path)
+        # Inject safe.directory without mutating $HOME/.gitconfig.
+        export GIT_CONFIG_COUNT=1
+        export GIT_CONFIG_KEY_0=safe.directory
+        export GIT_CONFIG_VALUE_0="$(workspaces.source.path)"
+
         git config --global user.email "exd-guild-isv+operators@redhat.com"
         git config --global user.name "rh-operator-bundle-bot"
 

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/commit-pinned-digest.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/commit-pinned-digest.yml
@@ -81,6 +81,11 @@ spec:
           ssh-add $HOME/.ssh/id_rsa
         fi
 
+        # Inject safe.directory without mutating $HOME/.gitconfig.
+        export GIT_CONFIG_COUNT=1
+        export GIT_CONFIG_KEY_0=safe.directory
+        export GIT_CONFIG_VALUE_0="$(workspaces.source.path)"
+
         # Setting up the config for the git.
         git config --global user.email "$(params.git_user_email)"
         git config --global user.name "$(params.git_user_name)"

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/digest-pinning.yml
@@ -98,8 +98,10 @@ spec:
           exit 0
         fi
 
-        # configure git to enable operations on unowned repository
-        git config --global --add safe.directory $(workspaces.source.path)
+        # Inject safe.directory without mutating $HOME/.gitconfig.
+        export GIT_CONFIG_COUNT=1
+        export GIT_CONFIG_KEY_0=safe.directory
+        export GIT_CONFIG_VALUE_0="$(workspaces.source.path)"
 
         cat replacements.json
         REPLACEMENT_COUNT=$(jq length replacements.json)

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/git-clone.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/git-clone.yml
@@ -203,6 +203,12 @@ spec:
           -depth="${PARAM_DEPTH}" \
           -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
         cd "${CHECKOUT_DIR}"
+
+        # Inject safe.directory without mutating $HOME/.gitconfig.
+        export GIT_CONFIG_COUNT=1
+        export GIT_CONFIG_KEY_0=safe.directory
+        export GIT_CONFIG_VALUE_0="${CHECKOUT_DIR}"
+
         RESULT_SHA="$(git rev-parse HEAD)"
         EXIT_CODE="$?"
         if [ "${EXIT_CODE}" != 0 ] ; then


### PR DESCRIPTION
### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes

### Motivation
Users are now getting the below error due to the linked PR. This updates all git tasks, and uses the same style across them. Since not all tasks can use the `git config` cmd, since in some tasks the `/workspace` has been `chmod 400` which would cause a confict.
```
[commit-pinned-digest : commit-changes] fatal: detected dubious ownership in repository at '/workspace/source'
```

Tasks already using this style
https://github.com/redhat-openshift-ecosystem/operator-pipelines/blob/e410331c432f940afafc9b1e7427a049c3652146/ansible/roles/operator-pipeline/templates/openshift/tasks/merge-pr.yml#L117-L120

- Relates: #997 