### PR TITLE
feat(ISV-7536): set release pipelines concurrency limit to 2

### DIFF
--- a/ansible/inventory/group_vars/operator-pipeline.yml
+++ b/ansible/inventory/group_vars/operator-pipeline.yml
@@ -78,7 +78,7 @@ operator_pipeline_dispatcher_release_pipeline_events:
   - closed
 
 operator_pipeline_dispatcher_hosted_capacity: 5
-operator_pipeline_dispatcher_release_capacity: 4
+operator_pipeline_dispatcher_release_capacity: 2
 
 operator_pipeline_callback_url: "https://operator-pipeline-{{ oc_namespace }}.{{ operator_pipeline_base_url}}"
 operator_pipeline_community_pipeline_callback_url: "https://community-operator-pipeline-{{ oc_namespace }}.{{ operator_pipeline_base_url }}"


### PR DESCRIPTION
Setting the limit to 2 for more predictability of finishing order of release pipelines that were run in a row. Also, to fix starving problem when running multiple very long pipelines. Random choice of which pipeline acquires lease next made some pipelines time out in the past. More info in Jira.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes