### PR TITLE
fix(PSIRTSUPT-20643): revert pull_request_target to pull_request

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,8 @@ on:  # yamllint disable-line rule:truthy
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
   tox:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
@@ -14,7 +14,6 @@ jobs:
   tox:
     name: ${{ matrix.tox-env }}
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'build-and-test' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +50,6 @@ jobs:
   pip-audit:
     name: pip-audit
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'build-and-test' || '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -91,7 +89,6 @@ jobs:
   hadolint:
     name: hadolint
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'build-and-test' || '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -119,7 +116,6 @@ jobs:
   build:
     name: Build and push image
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'build-and-test' || '' }}
 
     steps:
       - name: Set variables

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -215,7 +215,8 @@ jobs:
   release:
     name: Github release
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: write
     needs:
       - deploy-prod
     steps:


### PR DESCRIPTION
The pull_request_target trigger introduced a security vulnerability. Reverting to the safer pull_request trigger which does not expose repository secrets to fork pull requests.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes