### PR TITLE
fix(PSIRTSUPT-20643): harden CI workflow token permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,8 @@ on:  # yamllint disable-line rule:truthy
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
   tox:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 
@@ -14,7 +14,6 @@ jobs:
   tox:
     name: ${{ matrix.tox-env }}
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'build-and-test' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -51,7 +50,6 @@ jobs:
   pip-audit:
     name: pip-audit
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'build-and-test' || '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -91,7 +89,6 @@ jobs:
   hadolint:
     name: hadolint
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'build-and-test' || '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -119,7 +116,6 @@ jobs:
   build:
     name: Build and push image
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'build-and-test' || '' }}
 
     steps:
       - name: Set variables

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -215,7 +215,8 @@ jobs:
   release:
     name: Github release
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: write
     needs:
       - deploy-prod
     steps:


### PR DESCRIPTION
## Summary

- Revert `pull_request_target` to `pull_request` in `build-and-test.yml` to eliminate a security vulnerability where repository secrets could be exposed to untrusted PR code
- Remove fork-gated environment blocks from all jobs (no longer needed with `pull_request`)
- Add `permissions: contents: read` to `build-and-test.yml` to enforce least-privilege on the workflow token
- Narrow `permissions: write-all` to `permissions: contents: write` on the `release` job in `deploy.yml` (only scope actually required for tag/release creation)

Relates to: PSIRTSUPT-20643

## Test plan

- [ ] Verify CI jobs run without approval gate on non-fork PRs
- [ ] Verify the release job still creates tags and GitHub releases correctly after the permissions narrowing