### PR TITLE
enable self-service /approve for certified catalog promotion PRs

### DIFF
--- a/operatorcert/entrypoints/check_permissions.py
+++ b/operatorcert/entrypoints/check_permissions.py
@@ -378,6 +378,9 @@ class OperatorReview:
         container = project.get("container") or {}
         usernames = container.get("github_usernames") or []
         if is_catalog_promotion_pr:
+            if "approved" in self.pr_labels:
+                LOGGER.info("Catalog promotion PR is approved by a reviewer")
+                return True
             LOGGER.info(
                 "Pull request is a catalog promotion PR. Asking for review from partners.."
             )
@@ -478,8 +481,20 @@ class OperatorReview:
 
     def request_review_from_partners(self, reviewers: list[str]) -> None:
         """
-        Request review from the partner by adding a comment to the PR.
+        Request review from the partner by adding them as PR reviewers
+        and posting a comment to the PR.
         """
+        run_command(
+            [
+                "gh",
+                "pr",
+                "edit",
+                self.pull_request_url,
+                "--add-reviewer",
+                ",".join(reviewers),
+            ]
+        )
+
         reviewers_with_at = ", ".join(map(lambda x: f"@{x}", reviewers))
         comment_text = (
             "The author of the PR is not listed as one of the reviewers in certification project.\n"

--- a/tests/entrypoints/test_check_permissions.py
+++ b/tests/entrypoints/test_check_permissions.py
@@ -340,14 +340,17 @@ def test_OperatorReview_pr_owner_can_write(
 
 
 @pytest.mark.parametrize(
-    ["project", "catalog_promotion_pr", "approved", "valid"],
+    ["project", "catalog_promotion_pr", "labels", "approved", "valid"],
     [
-        pytest.param(None, False, False, False, id="no project"),
-        pytest.param({}, False, False, False, id="no container"),
-        pytest.param({"container": {}}, False, False, False, id="no github_usernames"),
+        pytest.param(None, False, set(), False, False, id="no project"),
+        pytest.param({}, False, set(), False, False, id="no container"),
+        pytest.param(
+            {"container": {}}, False, set(), False, False, id="no github_usernames"
+        ),
         pytest.param(
             {"container": {"github_usernames": None}},
             False,
+            set(),
             False,
             False,
             id="no github_usernames",
@@ -355,6 +358,7 @@ def test_OperatorReview_pr_owner_can_write(
         pytest.param(
             {"container": {"github_usernames": ["user123"]}},
             False,
+            set(),
             False,
             False,
             id="user not in github_usernames",
@@ -362,6 +366,7 @@ def test_OperatorReview_pr_owner_can_write(
         pytest.param(
             {"container": {"github_usernames": ["owner"]}},
             False,
+            set(),
             True,
             True,
             id="user in github_usernames",
@@ -369,11 +374,24 @@ def test_OperatorReview_pr_owner_can_write(
         pytest.param(
             {"container": {"github_usernames": ["owner"]}},
             True,
+            set(),
             False,
             True,
-            id="user in github_usernames",
+            id="catalog promotion not approved",
+        ),
+        pytest.param(
+            {"container": {"github_usernames": ["owner"]}},
+            True,
+            {"approved"},
+            True,
+            True,
+            id="catalog promotion approved",
         ),
     ],
+)
+@patch(
+    "operatorcert.entrypoints.check_permissions.OperatorReview.pr_labels",
+    new_callable=mock.PropertyMock,
 )
 @patch(
     "operatorcert.entrypoints.check_permissions.OperatorReview.request_review_from_partners"
@@ -382,20 +400,25 @@ def test_OperatorReview_pr_owner_can_write(
 def test_OperatorReview_check_permission_for_partner(
     mock_pyxis_project: MagicMock,
     mock_request_review_from_partners: MagicMock,
+    mock_pr_labels: MagicMock,
     review_partner: check_permissions.OperatorReview,
     project: dict[str, Any],
     catalog_promotion_pr: bool,
+    labels: set[str],
     approved: bool,
     valid: bool,
 ) -> None:
     mock_pyxis_project.return_value = project
+    mock_pr_labels.return_value = labels
     if valid:
         assert (
             review_partner.check_permission_for_partner(catalog_promotion_pr)
             == approved
         )
-        if catalog_promotion_pr:
+        if catalog_promotion_pr and not approved:
             mock_request_review_from_partners.assert_called_once()
+        elif catalog_promotion_pr and approved:
+            mock_request_review_from_partners.assert_not_called()
     else:
         with pytest.raises(check_permissions.NoPermissionError):
             review_partner.check_permission_for_partner(catalog_promotion_pr)
@@ -497,19 +520,33 @@ def test_OperatorReview_request_review_from_partners(
     review_community: check_permissions.OperatorReview,
 ) -> None:
     review_community.request_review_from_partners(["user1", "user2"])
-    mock_command.assert_called_once_with(
+    mock_command.assert_has_calls(
         [
-            "gh",
-            "pr",
-            "comment",
-            review_community.pull_request_url,
-            "--body",
-            "The author of the PR is not listed as one of the reviewers in certification project.\n"
-            f"@user1, @user2: please review the PR and approve it with an "
-            "`/approve` comment.\n\n"
-            "Consider adding the author of the PR to the list of reviewers in "
-            "the certification project if you want automated merge without explicit "
-            "approval.",
+            call(
+                [
+                    "gh",
+                    "pr",
+                    "edit",
+                    review_community.pull_request_url,
+                    "--add-reviewer",
+                    "user1,user2",
+                ]
+            ),
+            call(
+                [
+                    "gh",
+                    "pr",
+                    "comment",
+                    review_community.pull_request_url,
+                    "--body",
+                    "The author of the PR is not listed as one of the reviewers in certification project.\n"
+                    "@user1, @user2: please review the PR and approve it with an "
+                    "`/approve` comment.\n\n"
+                    "Consider adding the author of the PR to the list of reviewers in "
+                    "the certification project if you want automated merge without explicit "
+                    "approval.",
+                ]
+            ),
         ]
     )
 


### PR DESCRIPTION
### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes

## Motivation
The community/certified work differently for the auto generated PR's and the direct pings from partners to force a maintainer to trigger the `/approve` and `/trigger-hosted` labels does not scale. This the below is just _one_ of many approaches that seems to be possible. If the maintainers reject this approach, that is fine I'm happy to file a JIRA instead.

- Relates:  redhat-openshift-ecosystem/certified-operators#9113

## Changes
Add requested reviewer support and approved label check for catalog promotion PRs.

Catalog promotion PRs are auto-generated by a bot, so the PR author is never in the Pyxis github_usernames list. Previously, check_permission_for_partner unconditionally returned False for these PRs, and on pipeline re-run it would post a duplicate comment and still not merge. 

- Add Pyxis users as GitHub PR requested reviewers via `gh pr edit --add-reviewer`,
    giving the /approve GH Action an authoritative list to validate against
- Check for the approved label before returning False on catalog promotion PRs,
    allowing the pipeline to merge on re-run after partner approval

## Depends on
- redhat-openshift-ecosystem/github-workflows#3