### PR TITLE
feat(ISV-7155): Use IIB overwrite feature in pipelines

### DIFF
--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-index.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/add-bundle-to-index.yml
@@ -121,29 +121,3 @@ spec:
         echo -n "success" | tee "$(results.status.path)"
         echo
         cat index-image-paths.txt
-        echo
-
-        # WORKAROUND: Manually overwriting index images using skopeo (TODO: remove when overwrite token is fixed)
-        if [[ "$(workspaces.iib-credentials.bound)" == "true" ]]; then
-          TEMP_IMAGES=$(cat index-image-paths.txt | tr "," " ")
-          for i in $TEMP_IMAGES
-          do
-            SRC_IMAGE=$(echo $i | awk -F '+' '{print $2}')
-            DEST_IMAGE=$(echo $i | awk -F '+' '{print $1}')
-            echo "1. Version tag: copying $SRC_IMAGE to $DEST_IMAGE"
-            skopeo copy --retry-times 5 --format v2s2 --all --src-no-creds \
-              --dest-creds $IIB_QUAY_USER:$IIB_QUAY_TOKEN \
-              docker://$SRC_IMAGE \
-              docker://$DEST_IMAGE
-
-            # Also copy with permanent tag if build_tags_suffix is set
-            if [[ "$(params.build_tags_suffix)" != "" ]]; then
-              DEST_IMAGE_PERMANENT="${DEST_IMAGE}-$(params.build_tags_suffix)"
-              echo "2. Permanent tag: copying $SRC_IMAGE to $DEST_IMAGE_PERMANENT"
-              skopeo copy --retry-times 5 --format v2s2 --all --src-no-creds \
-                --dest-creds $IIB_QUAY_USER:$IIB_QUAY_TOKEN \
-                docker://$SRC_IMAGE \
-                docker://$DEST_IMAGE_PERMANENT
-            fi
-          done
-        fi

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/build-fbc-index-images.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/build-fbc-index-images.yml
@@ -112,32 +112,6 @@ spec:
           $EXTRA_ARGS
 
         cat index-image-paths.txt
-        echo
-
-        # WORKAROUND: Manually overwrite index images using skopeo (TODO: remove when IIB fixed)
-        if [[ "$(workspaces.iib-credentials.bound)" == "true" ]]; then
-          TEMP_IMAGES=$(cat index-image-paths.txt | tr "," " ")
-          for i in $TEMP_IMAGES
-          do
-            SRC_IMAGE=$(echo $i | awk -F '+' '{print $2}')
-            DEST_IMAGE=$(echo $i | awk -F '+' '{print $1}')
-            echo "1. Version tag: copying $SRC_IMAGE to $DEST_IMAGE"
-            skopeo copy --retry-times 5 --format v2s2 --all --src-no-creds \
-              --dest-creds $IIB_QUAY_USER:$IIB_QUAY_TOKEN \
-              docker://$SRC_IMAGE \
-              docker://$DEST_IMAGE
-
-            # Also copy with permanent tag if build_tags_suffix is set
-            if [[ "$(params.build_tags_suffix)" != "" ]]; then
-              DEST_IMAGE_PERMANENT="${DEST_IMAGE}-$(params.build_tags_suffix)"
-              echo "2. Permanent tag: copying $SRC_IMAGE to $DEST_IMAGE_PERMANENT"
-              skopeo copy --retry-times 5 --format v2s2 --all --src-no-creds \
-                --dest-creds $IIB_QUAY_USER:$IIB_QUAY_TOKEN \
-                docker://$SRC_IMAGE \
-                docker://$DEST_IMAGE_PERMANENT
-            fi
-          done
-        fi
 
     - name: rm-operator-from-index
       image: "$(params.pipeline_image)"
@@ -185,29 +159,3 @@ spec:
           $EXTRA_ARGS
 
         cat index-image-paths.txt
-        echo
-
-        # WORKAROUND: Manually overwrite index images using skopeo (TODO: remove when IIB fixed)
-        if [[ "$(workspaces.iib-credentials.bound)" == "true" ]]; then
-          TEMP_IMAGES=$(cat index-image-paths.txt | tr "," " ")
-          for i in $TEMP_IMAGES
-          do
-            SRC_IMAGE=$(echo $i | awk -F '+' '{print $2}')
-            DEST_IMAGE=$(echo $i | awk -F '+' '{print $1}')
-            echo "1. Version tag: copying $SRC_IMAGE to $DEST_IMAGE"
-            skopeo copy --retry-times 5 --format v2s2 --all --src-no-creds \
-              --dest-creds $IIB_QUAY_USER:$IIB_QUAY_TOKEN \
-              docker://$SRC_IMAGE \
-              docker://$DEST_IMAGE
-
-            # Also copy with permanent tag if build_tags_suffix is set
-            if [[ "$(params.build_tags_suffix)" != "" ]]; then
-              DEST_IMAGE_PERMANENT="${DEST_IMAGE}-$(params.build_tags_suffix)"
-              echo "2. Permanent tag: copying $SRC_IMAGE to $DEST_IMAGE_PERMANENT"
-              skopeo copy --retry-times 5 --format v2s2 --all --src-no-creds \
-                --dest-creds $IIB_QUAY_USER:$IIB_QUAY_TOKEN \
-                docker://$SRC_IMAGE \
-                docker://$DEST_IMAGE_PERMANENT
-            fi
-          done
-        fi

--- a/operatorcert/entrypoints/add_fbc_fragments_to_index.py
+++ b/operatorcert/entrypoints/add_fbc_fragments_to_index.py
@@ -199,10 +199,6 @@ def add_fbc_fragment_to_index(
             "fbc_fragment": fragment,
         }
 
-        if build_tags_suffix:
-            version = index.split(":")[-1]
-            payload["build_tags"] = [version, f"{version}-{build_tags_suffix}"]
-
         if overwrite_token:
             payload["overwrite_from_index"] = True
             payload["overwrite_from_index_token"] = overwrite_token
@@ -216,6 +212,9 @@ def add_fbc_fragment_to_index(
         response.get("state") == "complete" for response in responses
     ):
         raise RuntimeError("IIB build failed")
+
+    if build_tags_suffix:
+        utils.copy_permanent_tags(responses, build_tags_suffix)
 
     output_index_image_paths(image_output, responses)
 

--- a/operatorcert/entrypoints/add_fbc_fragments_to_index.py
+++ b/operatorcert/entrypoints/add_fbc_fragments_to_index.py
@@ -204,11 +204,8 @@ def add_fbc_fragment_to_index(
             payload["build_tags"] = [version, f"{version}-{build_tags_suffix}"]
 
         if overwrite_token:
-            # WORKAROUND: Manually overwriting index images using skopeo
-            # TODO: uncomment when overwrite token is fixed, delete pass
-            # payload["overwrite_from_index"] = True
-            # payload["overwrite_from_index_token"] = overwrite_token
-            pass
+            payload["overwrite_from_index"] = True
+            payload["overwrite_from_index_token"] = overwrite_token
 
         resp = iib.add_fbc_build(iib_url, payload)
         request_ids.append(resp["id"])

--- a/operatorcert/entrypoints/index.py
+++ b/operatorcert/entrypoints/index.py
@@ -108,10 +108,6 @@ def add_bundle_to_index(  # pylint: disable=too-many-arguments,too-many-position
         if mode:
             build_request["graph_update_mode"] = mode
 
-        if build_tags_suffix:
-            version = index.split(":")[-1]
-            build_request["build_tags"] = [version, f"{version}-{build_tags_suffix}"]
-
         if overwrite_token:
             build_request["overwrite_from_index"] = True
             build_request["overwrite_from_index_token"] = overwrite_token
@@ -126,6 +122,9 @@ def add_bundle_to_index(  # pylint: disable=too-many-arguments,too-many-position
         build.get("state") == "complete" for build in response["items"]
     ):
         raise RuntimeError("IIB build failed")
+
+    if build_tags_suffix:
+        utils.copy_permanent_tags(response["items"], build_tags_suffix)
 
     output_index_image_paths(image_output, response)
 

--- a/operatorcert/entrypoints/index.py
+++ b/operatorcert/entrypoints/index.py
@@ -113,11 +113,8 @@ def add_bundle_to_index(  # pylint: disable=too-many-arguments,too-many-position
             build_request["build_tags"] = [version, f"{version}-{build_tags_suffix}"]
 
         if overwrite_token:
-            # WORKAROUND: Manually overwriting index images using skopeo
-            # TODO: uncomment when overwrite token is fixed, delete pass
-            # build_request["overwrite_from_index"] = True
-            # build_request["overwrite_from_index_token"] = overwrite_token
-            pass
+            build_request["overwrite_from_index"] = True
+            build_request["overwrite_from_index_token"] = overwrite_token
 
         payload["build_requests"].append(build_request)
 

--- a/operatorcert/entrypoints/rm_operator_from_index.py
+++ b/operatorcert/entrypoints/rm_operator_from_index.py
@@ -144,11 +144,8 @@ def rm_operator_from_index(
             ]
 
         if overwrite_token:
-            # WORKAROUND: Manually overwriting index images using skopeo
-            # TODO: uncomment when overwrite token is fixed, delete pass
-            # build_request["overwrite_from_index"] = True
-            # build_request["overwrite_from_index_token"] = overwrite_token
-            pass
+            build_request["overwrite_from_index"] = True
+            build_request["overwrite_from_index_token"] = overwrite_token
 
         payload["build_requests"].append(build_request)
 

--- a/operatorcert/entrypoints/rm_operator_from_index.py
+++ b/operatorcert/entrypoints/rm_operator_from_index.py
@@ -137,12 +137,6 @@ def rm_operator_from_index(
             "operators": index_image.operators_to_remove,
         }
 
-        if build_tags_suffix:
-            build_request["build_tags"] = [
-                index_image.version,
-                f"{index_image.version}-{build_tags_suffix}",
-            ]
-
         if overwrite_token:
             build_request["overwrite_from_index"] = True
             build_request["overwrite_from_index_token"] = overwrite_token
@@ -157,6 +151,9 @@ def rm_operator_from_index(
         build.get("state") == "complete" for build in response["items"]
     ):
         raise RuntimeError("IIB build failed")
+
+    if build_tags_suffix:
+        utils.copy_permanent_tags(response["items"], build_tags_suffix)
 
     return response
 

--- a/operatorcert/utils.py
+++ b/operatorcert/utils.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import re
 import subprocess
+import tempfile
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
@@ -15,6 +16,8 @@ from packaging.version import Version
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
+
+from operatorcert.integration.external_tools import RegistryAuthMixin
 
 LOGGER = logging.getLogger("operator-cert")
 
@@ -235,8 +238,6 @@ def copy_images_to_destination(
         cmd = [
             "skopeo",
             "copy",
-            "--retry-times",
-            "5",
             f"docker://{response.get('index_image_resolved')}",
             f"docker://{destination}:{version}{tag_suffix}",
         ]
@@ -246,6 +247,55 @@ def copy_images_to_destination(
         LOGGER.info("Copying image to destination: %s", cmd)
 
         run_command(cmd, retries=5)
+
+
+def copy_permanent_tags(
+    iib_responses: Any,
+    build_tags_suffix: str,
+) -> None:
+    """
+    Copy IIB-built index images to permanent tags in the pending repository.
+
+    IIB pushes the version tag (e.g. :v4.12) via overwrite, but does not
+    push the permanent tag (e.g. :v4.12-1711883400). This function creates
+    the permanent tag by copying from the IIB-built image directly.
+
+    Args:
+        iib_responses: IIB build response items
+        build_tags_suffix: Timestamp suffix for the permanent tag
+    """
+    overwrite_token = os.environ.get("IIB_OVERWRITE_TOKEN")
+    auth_file_path = None
+
+    if overwrite_token:
+        user, password = overwrite_token.split(":", 1)
+        auth = RegistryAuthMixin({"quay.io": (user, password)})
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as auth_file:
+            auth.save_auth(auth_file)
+            auth_file_path = auth_file.name
+
+    try:
+        for response in iib_responses:
+            from_index = response.get("from_index", "")
+            src_image = response.get("index_image_resolved", "")
+            dest_image = f"{from_index}-{build_tags_suffix}"
+
+            cmd = [
+                "skopeo",
+                "copy",
+                "--all",
+            ]
+            if auth_file_path:
+                cmd.extend(["--authfile", auth_file_path])
+            cmd.extend([f"docker://{src_image}", f"docker://{dest_image}"])
+
+            LOGGER.info("Copying permanent tag: %s", cmd)
+            run_command(cmd, retries=5)
+    finally:
+        if auth_file_path:
+            os.remove(auth_file_path)
 
 
 def sort_versions(version_list: list[Any]) -> list[Any]:

--- a/tests/entrypoints/test_add_fbc_fragments_to_index.py
+++ b/tests/entrypoints/test_add_fbc_fragments_to_index.py
@@ -216,24 +216,30 @@ def test_add_fbc_fragment_to_index(
     mock_results.return_value = [
         {"state": "complete", "id": 3},
     ]
-    index.add_fbc_fragment_to_index(
-        "https://iib.engineering.redhat.com",
-        [
-            (
-                "registry/index:v4.15",
-                "registry.foo/repo/foo:v4.15-fragment-sha256:1234",
-            ),
-        ],
-        "test-image-path.txt",
-        "user:token123",
-        "1711883400",
-    )
+    with patch(
+        "operatorcert.entrypoints.add_fbc_fragments_to_index.utils.copy_permanent_tags"
+    ) as mock_copy:
+        index.add_fbc_fragment_to_index(
+            "https://iib.engineering.redhat.com",
+            [
+                (
+                    "registry/index:v4.15",
+                    "registry.foo/repo/foo:v4.15-fragment-sha256:1234",
+                ),
+            ],
+            "test-image-path.txt",
+            "user:token123",
+            "1711883400",
+        )
+        mock_copy.assert_called_once_with(
+            [{"state": "complete", "id": 3}],
+            "1711883400",
+        )
     mock_iib_build.assert_called_once_with(
         "https://iib.engineering.redhat.com",
         {
             "from_index": "registry/index:v4.15",
             "fbc_fragment": "registry.foo/repo/foo:v4.15-fragment-sha256:1234",
-            "build_tags": ["v4.15", "v4.15-1711883400"],
             "overwrite_from_index": True,
             "overwrite_from_index_token": "user:token123",
         },

--- a/tests/entrypoints/test_add_fbc_fragments_to_index.py
+++ b/tests/entrypoints/test_add_fbc_fragments_to_index.py
@@ -234,10 +234,8 @@ def test_add_fbc_fragment_to_index(
             "from_index": "registry/index:v4.15",
             "fbc_fragment": "registry.foo/repo/foo:v4.15-fragment-sha256:1234",
             "build_tags": ["v4.15", "v4.15-1711883400"],
-            # WORKAROUND: Manually overwriting index images using skopeo
-            # TODO: uncomment when overwrite token is fixed
-            # "overwrite_from_index": True,
-            # "overwrite_from_index_token": "user:token123",
+            "overwrite_from_index": True,
+            "overwrite_from_index_token": "user:token123",
         },
     )
 

--- a/tests/entrypoints/test_index.py
+++ b/tests/entrypoints/test_index.py
@@ -69,10 +69,8 @@ def test_add_bundle_to_index(
                     "add_arches": ["amd64", "s390x", "ppc64le"],
                     "graph_update_mode": "replaces",
                     "build_tags": ["v4.9", "v4.9-1711883400"],
-                    # WORKAROUND: Manually overwriting index images using skopeo
-                    # TODO: uncomment when overwrite token is fixed
-                    # "overwrite_from_index": True,
-                    # "overwrite_from_index_token": "user:token123",
+                    "overwrite_from_index": True,
+                    "overwrite_from_index_token": "user:token123",
                 }
             ]
         },

--- a/tests/entrypoints/test_index.py
+++ b/tests/entrypoints/test_index.py
@@ -50,15 +50,20 @@ def test_add_bundle_to_index(
     mock_results.reset_mock()
     mock_iib_builds.return_value = [{"state": "complete", "batch": "batch2"}]
     mock_results.return_value = {"items": [{"state": "complete", "batch": "batch2"}]}
-    index.add_bundle_to_index(
-        "redhat-isv/some-pullspec",
-        "https://iib.engineering.redhat.com",
-        ["registry/index:v4.9"],
-        "test-image-path.txt",
-        "replaces",
-        "user:token123",
-        "1711883400",
-    )
+    with patch("operatorcert.entrypoints.index.utils.copy_permanent_tags") as mock_copy:
+        index.add_bundle_to_index(
+            "redhat-isv/some-pullspec",
+            "https://iib.engineering.redhat.com",
+            ["registry/index:v4.9"],
+            "test-image-path.txt",
+            "replaces",
+            "user:token123",
+            "1711883400",
+        )
+        mock_copy.assert_called_once_with(
+            [{"state": "complete", "batch": "batch2"}],
+            "1711883400",
+        )
     mock_iib_builds.assert_called_once_with(
         "https://iib.engineering.redhat.com",
         {
@@ -68,7 +73,6 @@ def test_add_bundle_to_index(
                     "bundles": ["redhat-isv/some-pullspec"],
                     "add_arches": ["amd64", "s390x", "ppc64le"],
                     "graph_update_mode": "replaces",
-                    "build_tags": ["v4.9", "v4.9-1711883400"],
                     "overwrite_from_index": True,
                     "overwrite_from_index_token": "user:token123",
                 }

--- a/tests/entrypoints/test_rm_operator_from_index.py
+++ b/tests/entrypoints/test_rm_operator_from_index.py
@@ -62,12 +62,19 @@ def test_rm_operator_from_index(
     index_images_with_token[0].operators_to_remove = ["op1"]
     mock_iib_add_builds.return_value = [{"batch": "batch2"}]
     mock_wait.return_value = {"items": [{"state": "complete"}]}
-    rm_operator_from_index.rm_operator_from_index(
-        index_images_with_token,
-        "https://iib.foo.redhat.com",
-        "user:token123",
-        "1711883400",
-    )
+    with patch(
+        "operatorcert.entrypoints.rm_operator_from_index.utils.copy_permanent_tags"
+    ) as mock_copy:
+        rm_operator_from_index.rm_operator_from_index(
+            index_images_with_token,
+            "https://iib.foo.redhat.com",
+            "user:token123",
+            "1711883400",
+        )
+        mock_copy.assert_called_once_with(
+            [{"state": "complete"}],
+            "1711883400",
+        )
 
     mock_iib_add_builds.assert_called_once_with(
         "https://iib.foo.redhat.com",
@@ -76,7 +83,6 @@ def test_rm_operator_from_index(
                 {
                     "from_index": "iib-pullspec",
                     "operators": ["op1"],
-                    "build_tags": ["v4.15", "v4.15-1711883400"],
                     "overwrite_from_index": True,
                     "overwrite_from_index_token": "user:token123",
                 }

--- a/tests/entrypoints/test_rm_operator_from_index.py
+++ b/tests/entrypoints/test_rm_operator_from_index.py
@@ -77,10 +77,8 @@ def test_rm_operator_from_index(
                     "from_index": "iib-pullspec",
                     "operators": ["op1"],
                     "build_tags": ["v4.15", "v4.15-1711883400"],
-                    # WORKAROUND: Manually overwriting index images using skopeo
-                    # TODO: uncomment when overwrite token is fixed
-                    # "overwrite_from_index": True,
-                    # "overwrite_from_index_token": "user:token123",
+                    "overwrite_from_index": True,
+                    "overwrite_from_index_token": "user:token123",
                 }
             ]
         },

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -215,8 +215,6 @@ def test_copy_images_to_destination(mock_run_command: MagicMock) -> None:
         [
             "skopeo",
             "copy",
-            "--retry-times",
-            "5",
             "docker://quay.io/qwe/asd@sha256:1234",
             "docker://quay.io/foo/bar:v4.12-foo",
             "--authfile",
@@ -224,6 +222,53 @@ def test_copy_images_to_destination(mock_run_command: MagicMock) -> None:
         ],
         retries=5,
     )
+
+
+@patch("operatorcert.utils.run_command")
+def test_copy_permanent_tags(mock_run_command: MagicMock) -> None:
+    iib_responses = [
+        {
+            "from_index": "quay.io/foo/operator-index-pending:v4.12",
+            "index_image_resolved": "quay.io/foo/operator-index-pending@sha256:aaa",
+        },
+        {
+            "from_index": "quay.io/foo/operator-index-pending:v4.13",
+            "index_image_resolved": "quay.io/foo/operator-index-pending@sha256:bbb",
+        },
+    ]
+
+    with patch.dict(os.environ, {"IIB_OVERWRITE_TOKEN": "user:token123"}):
+        utils.copy_permanent_tags(iib_responses, "1711883400")
+
+    assert mock_run_command.call_count == 2
+
+    expected_pairs = [
+        (
+            "docker://quay.io/foo/operator-index-pending@sha256:aaa",
+            "docker://quay.io/foo/operator-index-pending:v4.12-1711883400",
+        ),
+        (
+            "docker://quay.io/foo/operator-index-pending@sha256:bbb",
+            "docker://quay.io/foo/operator-index-pending:v4.13-1711883400",
+        ),
+    ]
+    for call_args, (expected_src, expected_dest) in zip(
+        mock_run_command.call_args_list, expected_pairs
+    ):
+        cmd = call_args[0][0]
+        assert "--dest-creds" not in cmd
+        assert "user:token123" not in cmd
+        auth_file_path = cmd[cmd.index("--authfile") + 1]
+        assert auth_file_path.endswith(".json")
+        assert cmd == [
+            "skopeo",
+            "copy",
+            "--all",
+            "--authfile",
+            auth_file_path,
+            expected_src,
+            expected_dest,
+        ]
 
 
 def test_is_catalog_v4_17_plus() -> None:


### PR DESCRIPTION
Draft: Can't be merged before IIB fixes the overwrite token in prod. Can be reviewed and tested via integration tests as the overwrite token fix is in IIB stage which is used by integration tests.

Changes:
- Reverted commit d87bc949b14a71c5dec7dd3adc67059a9dc5e872 that adds a workaround for passing overwrite token to IIB.
- Removed IIB call parameter build_tags as it's confirmed to exist for internal purposes only and doesn't create given tags for us.
- The normal tag (e.g. v4.23) is already created because of overwrite_from_index=True and using from_index version.
- The permanent tag (e.g. v4.23-17123456) is now created on our side, similarly to how it was done in the workaround before, but I switched to using authfile just as a safeguard from leaking the token in logs or exceptions propagation in python.

### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes