### PR TITLE
add sparse checkout to hosted and release pipelines to reduce clone size

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/community-hosted-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-hosted-pipeline-trigger.yml
@@ -145,7 +145,7 @@
                             - ReadWriteOnce
                           resources:
                             requests:
-                              storage: 10Gi
+                              storage: 5Gi
                     - name: results
                       volumeClaimTemplate:
                         spec:

--- a/ansible/roles/operator-pipeline/tasks/community-release-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/community-release-pipeline-trigger.yml
@@ -135,7 +135,7 @@
                             - ReadWriteOnce
                           resources:
                             requests:
-                              storage: 10Gi
+                              storage: 5Gi
                     - name: results
                       volumeClaimTemplate:
                         spec:

--- a/ansible/roles/operator-pipeline/tasks/operator-hosted-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-hosted-pipeline-trigger.yml
@@ -134,7 +134,7 @@
                             - ReadWriteOnce
                           resources:
                             requests:
-                              storage: 8Gi
+                              storage: 5Gi
                     - name: results
                       volumeClaimTemplate:
                         spec:

--- a/ansible/roles/operator-pipeline/tasks/operator-release-pipeline-trigger.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-release-pipeline-trigger.yml
@@ -121,7 +121,7 @@
                             - ReadWriteOnce
                           resources:
                             requests:
-                              storage: 8Gi
+                              storage: 5Gi
                     - name: results
                       volumeClaimTemplate:
                         spec:

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-hosted-pipeline.yml
@@ -239,10 +239,27 @@ spec:
         - name: access_type
           value: "internal"
 
+    # Resolve sparse checkout directories from PR changed files
+    - name: resolve-sparse-dirs
+      runAfter:
+        - set-env
+      taskRef:
+        name: resolve-sparse-checkout-dirs
+        kind: Task
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: git_pr_url
+          value: "$(params.git_pr_url)"
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
+
     # Git clone
     - name: clone-repository
       runAfter:
-        - set-env
+        - resolve-sparse-dirs
       taskRef:
         name: git-clone
         kind: Task
@@ -251,6 +268,8 @@ spec:
           value: $(params.git_fork_url)
         - name: revision
           value: $(params.git_commit)
+        - name: sparseCheckoutDirectories
+          value: "$(tasks.resolve-sparse-dirs.results.sparse_dirs)"
         - name: gitInitImage
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9@sha256:56e27c58ded3b0d8aab1a585ef55aa543f7cf78f36060086fec00d0a1c42bc18
       workspaces:
@@ -266,12 +285,14 @@ spec:
         name: git-clone
         kind: Task
       runAfter:
-        - set-env
+        - resolve-sparse-dirs
       params:
         - name: url
           value: "$(params.git_repo_url)"
         - name: revision
           value: "$(params.git_commit_base)"
+        - name: sparseCheckoutDirectories
+          value: "$(tasks.resolve-sparse-dirs.results.sparse_dirs)"
         - name: gitInitImage
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9@sha256:56e27c58ded3b0d8aab1a585ef55aa543f7cf78f36060086fec00d0a1c42bc18
       workspaces:

--- a/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/pipelines/operator-release-pipeline.yml
@@ -151,10 +151,27 @@ spec:
         - name: access_type
           value: "internal"
 
+    # Resolve sparse checkout directories from PR changed files
+    - name: resolve-sparse-dirs
+      runAfter:
+        - set-env
+      taskRef:
+        name: resolve-sparse-checkout-dirs
+        kind: Task
+      params:
+        - name: pipeline_image
+          value: "$(params.pipeline_image)"
+        - name: git_pr_url
+          value: "$(params.git_pr_url)"
+        - name: github_token_secret_name
+          value: "$(params.github_token_secret_name)"
+        - name: github_token_secret_key
+          value: "$(params.github_token_secret_key)"
+
     # Git clone
     - name: clone-repository
       runAfter:
-        - set-env
+        - resolve-sparse-dirs
       taskRef:
         name: git-clone
         kind: Task
@@ -163,6 +180,8 @@ spec:
           value: $(params.git_repo_url)
         - name: revision
           value: $(params.git_commit)
+        - name: sparseCheckoutDirectories
+          value: "$(tasks.resolve-sparse-dirs.results.sparse_dirs)"
         - name: gitInitImage
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9@sha256:56e27c58ded3b0d8aab1a585ef55aa543f7cf78f36060086fec00d0a1c42bc18
       workspaces:
@@ -178,12 +197,14 @@ spec:
         name: git-clone
         kind: Task
       runAfter:
-        - set-env
+        - resolve-sparse-dirs
       params:
         - name: url
           value: "$(params.git_repo_url)"
         - name: revision
           value: "$(params.git_commit_base)"
+        - name: sparseCheckoutDirectories
+          value: "$(tasks.resolve-sparse-dirs.results.sparse_dirs)"
         - name: gitInitImage
           value: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel9@sha256:56e27c58ded3b0d8aab1a585ef55aa543f7cf78f36060086fec00d0a1c42bc18
       workspaces:

--- a/ansible/roles/operator-pipeline/templates/openshift/tasks/resolve-sparse-checkout-dirs.yml
+++ b/ansible/roles/operator-pipeline/templates/openshift/tasks/resolve-sparse-checkout-dirs.yml
@@ -1,0 +1,67 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: resolve-sparse-checkout-dirs
+spec:
+  description: >-
+    Queries the GitHub pull request for changed files and computes the
+    minimal set of directories needed for a sparse checkout. This allows
+    the pipeline to clone only the affected operator and catalog
+    directories plus shared resources (config.yaml) instead of the
+    entire repository.
+  params:
+    - name: pipeline_image
+      description: The common pipeline image.
+
+    - name: git_pr_url
+      description: URL of the GitHub pull request
+      type: string
+
+    - name: github_token_secret_name
+      description: The name of the Kubernetes Secret that contains the GitHub token.
+      default: github-bot-token
+
+    - name: github_token_secret_key
+      description: The key within the Kubernetes Secret that contains the GitHub token.
+      default: github_bot_token
+
+  results:
+    - name: sparse_dirs
+      description: >-
+        Comma-separated list of directories for sparse checkout.
+        Always includes config.yaml; dynamically adds
+        operators/<name> for each affected operator and
+        catalogs/<version> for each affected catalog.
+
+  steps:
+    - name: resolve-dirs
+      image: "$(params.pipeline_image)"
+      env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.github_token_secret_name)
+              key: $(params.github_token_secret_key)
+      script: |
+        #! /usr/bin/env bash
+        set -e -o pipefail
+
+        echo "Fetching changed files for $(params.git_pr_url)"
+
+        ALL_FILES=$(gh pr diff "$(params.git_pr_url)" --name-only)
+
+        declare -A DIRS
+        DIRS["config.yaml"]=1
+
+        while IFS= read -r filepath; do
+          dir=$(echo "$filepath" | cut -d'/' -f1,2)
+          if [[ "$filepath" == operators/* || "$filepath" == catalogs/* ]]; then
+            DIRS["$dir"]=1
+          fi
+        done <<< "$ALL_FILES"
+
+        RESULT=$(printf '%s\n' "${!DIRS[@]}" | sort | paste -sd ',' -)
+
+        echo "Sparse checkout directories: $RESULT"
+        echo -n "$RESULT" > "$(results.sparse_dirs.path)"


### PR DESCRIPTION
### Merge Request Checklists

- [ ] Development is done in feature branches
- [ ] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [ ] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes

## Motivation
We really need to get away from the checkout(s) using all of the storage, and thus killing all the pipelines and we have to take manual intervention.

## Changes
- Resets the PVC value back to it's original `5gb` (which is probably overkill, but we'd never have to look at it again)
- Determines what files are in the PR
- Sends those files to the `clone` steps tasks

## Notes
If this direction looks fine, and the maintainers want to take on this change. I'll raise a PR to `upstream` so it can be better tested. If not I will create Jira for the maintainers to take up. (Note: this is probably my last PR to tasks outside of `preflight` tasks)

## Examples
Below is how this would look based on some recently merged `certified` PRs.

```
❯ ./scratch.sh
Fetching changed files for https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3848)
Sparse checkout directories: config.yaml

❯ ./scratch.sh
Fetching changed files for https://github.com/redhat-openshift-ecosystem/certified-operators/pull/9281
Sparse checkout directories: catalogs/v4.17,catalogs/v4.18,catalogs/v4.19,catalogs/v4.20,catalogs/v4.21,config.yaml,operators/f5-ai-security-operator

❯ ./scratch.sh
Fetching changed files for https://github.com/redhat-openshift-ecosystem/certified-operators/pull/9279
Sparse checkout directories: config.yaml,operators/f5-ai-security-operator

# additional logs have been added below for clarity

❯ ./scratch.sh
Fetching changed files for https://github.com/redhat-openshift-ecosystem/certified-operators/pull/9279
All Files: operators/f5-ai-security-operator/0.11.4/manifests/ai.security.f5.com_securityoperators.yaml
operators/f5-ai-security-operator/0.11.4/manifests/controller-manager-metrics-service_v1_service.yaml
operators/f5-ai-security-operator/0.11.4/manifests/f5-ai-security-operator.clusterserviceversion.yaml
operators/f5-ai-security-operator/0.11.4/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
operators/f5-ai-security-operator/0.11.4/metadata/annotations.yaml
operators/f5-ai-security-operator/0.11.4/release-config.yaml
Sparse checkout directories: config.yaml,operators/f5-ai-security-operator

❯ ./scratch.sh
Fetching changed files for https://github.com/redhat-openshift-ecosystem/certified-operators/pull/9268
All Files: operators/uma-team-operator/2026.8.1-23/manifests/ca.broadcom.com1_universalmonitoringagentsteams.yaml
operators/uma-team-operator/2026.8.1-23/manifests/uma-team-operator.clusterserviceversion.yaml
operators/uma-team-operator/2026.8.1-23/metadata/annotations.yaml
Sparse checkout directories: config.yaml,operators/uma-team-operator
```