### PR TITLE
fix(ISV-7499): remove cluster-admin from operator-pipeline-service-account

### DIFF
--- a/ansible/roles/operator-pipeline/tasks/operator-pipeline-service-account.yml
+++ b/ansible/roles/operator-pipeline/tasks/operator-pipeline-service-account.yml
@@ -23,25 +23,3 @@
       kind: ServiceAccount
       metadata:
         name: "{{ service_account_name }}"
-
-- name: Grant SA role "{{ service_account_name }}"
-  tags:
-    - service-account
-    - init
-  kubernetes.core.k8s:
-    state: present
-    namespace: "{{ oc_namespace }}"
-    definition:
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
-        name: "{{ service_account_name }}-{{ oc_namespace }}-{{ item }}"
-      roleRef:
-        kind: ClusterRole
-        name: "{{ item }}"
-      subjects:
-        - kind: ServiceAccount
-          name: "{{ service_account_name }}"
-          namespace: "{{ oc_namespace }}"
-  with_items:
-    - cluster-admin


### PR DESCRIPTION
See title. `pipelines-custom-scc` seems to handle everything that actually does
need privilege escalation in this system - everything passes tests just fine
without the CRB reported as an issue here(?!). I may need a second look
by someone with more intuition on operator-pipelines to be sure here...

### Merge Request Checklists

- [x] Development is done in feature branches
- [x] Code changes are submitted as pull request into a primary branch [Provide reason for non-primary branch submissions]
- [x] Code changes are covered with unit and integration tests.
- [ ] Code passes all automated code tests:
    - [ ] Linting
    - [ ] Code formatter - Black
    - [ ] Security scanners
    - [ ] Unit tests
    - [ ] Integration tests
- [ ] Code is reviewed by at least 1 team member
- [ ] Pull request is tagged with "risk/good-to-go" label for minor changes
