### PR TITLE
chore: fix github release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -217,6 +217,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Required when the tagged commit modifies files under .github/workflows/.
+      actions: write
     needs:
       - deploy-prod
     steps:


### PR DESCRIPTION
Behavior documented [here](https://github.blog/changelog/2023-11-02-github-actions-enforcing-workflow-scope-when-creating-a-release/).